### PR TITLE
Replace some instances of `CoreDB` to `Tembo`

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -118,4 +118,4 @@ jobs:
           pgmq_ver=$(stoml Cargo.toml package.version)
           pgmq_descr=$(stoml Cargo.toml package.description)
           pgmq_repo=$(stoml Cargo.toml package.repository)
-          trunk publish pgmq --version ${pgmq_ver} --file .trunk/pgmq-${pgmq_ver}.tar.gz --description "Message Queue for postgres" --homepage "https://github.com/CoreDB-io/coredb/pgmq" --repository "https://github.com/CoreDB-io/coredb/pgmq" --license "Apache-2.0"
+          trunk publish pgmq --version ${pgmq_ver} --file .trunk/pgmq-${pgmq_ver}.tar.gz --description "Message Queue for postgres" --homepage "https://github.com/tembo-io/pgmq" --repository "https://github.com/tembo-io/pgmq" --license "Apache-2.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ cargo pgrx init
 Then, clone this repo and change into this directory.
 
 ```bash
-git clone git@github.com:CoreDB-io/coredb.git
+git clone git@https://github.com/tembo-io/pgmq.git
 cd coredb/extensions/pgmq/
 ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 name = "pgmq"
 version = "0.10.0"
 edition = "2021"
-authors = ["CoreDB.io"]
+authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"
-homepage = "https://www.coredb.io"
+homepage = "https://www.tembo.io"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/CoreDB-io/coredb"
+repository = "https://github.com/tembo-io/pgmq/"
 publish = false
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io
 ## Client Libraries
 
 
-- [Rust](https://github.com/CoreDB-io/coredb/tree/main/pgmq/core)
-- [Python](https://github.com/CoreDB-io/coredb/tree/main/pgmq/coredb-pgmq-python)
+- [Rust](https://github.com/tembo-io/pgmq/tree/main/core)
+- [Python](https://github.com/tembo-io/pgmq/tree/main/tembo-pgmq-python)
 
 ## SQL Examples
 

--- a/core/LICENSE
+++ b/core/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 CoreDB, Inc.
+   Copyright 2023 Tembo, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/README.md
+++ b/core/README.md
@@ -9,11 +9,11 @@ Message queues allow you to decouple and connect microservices.
 Send, store, and receive messages between components scalably, without dropping messages or
 needing other services to be available.
 
-PGMQ was created by CoreDB. Our goal is to make the full Postgres ecosystem accessible to everyone.
+PGMQ was created by [Tembo](https://tembo.io/). Our goal is to make the full Postgres ecosystem accessible to everyone.
 We're building a radically simplified Postgres platform designed to be developer-first and easily extensible.
 PGMQ is a part of that project.
 
-Not building in Rust? Try the [CoreDB pgmq Postgres extension](https://github.com/CoreDB-io/coredb/tree/main/extensions/pgmq).
+Not building in Rust? Try the [Tembo pgmq Postgres extension](https://pgt.dev/extensions/pgmq).
 
 ## Features
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,11 +9,11 @@
 //! Send, store, and receive messages between components scalably, without dropping messages or
 //! needing other services to be available.
 //!
-//! PGMQ was created by CoreDB. Our goal is to make the full Postgres ecosystem accessible to everyone.
+//! PGMQ was created by Tembo. Our goal is to make the full Postgres ecosystem accessible to everyone.
 //! We're building a radically simplified Postgres platform designed to be developer-first and easily extensible.
 //! PGMQ is a part of that project.
 //!
-//! Not building in Rust? Try the [CoreDB pgmq Postgres extension](https://github.com/CoreDB-io/coredb/tree/main/extensions/pgmq).
+//! Not building in Rust? Try the [CoreDB pgmq Postgres extension](https://pgt.dev/extensions/pgmq).
 //!
 //! ## Features
 //!


### PR DESCRIPTION
Replace some left-over "CoreDB" mentions

I didn't change quay.io links since I'm not sure what are the correct new links