### PR TITLE
Image refs

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -118,4 +118,4 @@ jobs:
           pgmq_ver=$(stoml Cargo.toml package.version)
           pgmq_descr=$(stoml Cargo.toml package.description)
           pgmq_repo=$(stoml Cargo.toml package.repository)
-          trunk publish pgmq --version ${pgmq_ver} --file .trunk/pgmq-${pgmq_ver}.tar.gz --description "Message Queue for postgres" --homepage "https://github.com/tembo-io/pgmq" --repository "https://github.com/tembo-io/pgmq" --license "Apache-2.0" --category featured --category orchestration
+          trunk publish pgmq --version ${pgmq_ver} --file .trunk/pgmq-${pgmq_ver}.tar.gz --description "A lightweight distributed message queue. Like AWS SQS and RSMQ, on Postgres." --homepage "https://github.com/tembo-io/pgmq" --repository "https://github.com/tembo-io/pgmq" --license "PostgreSQL" --category featured --category orchestration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Then, clone this repo and change into this directory.
 
 ```bash
 git clone git@https://github.com/tembo-io/pgmq.git
-cd coredb/extensions/pgmq/
+cd pgmq
 ```
 
 ### Setup dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,10 +1210,10 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
- "pgmq 0.13.0",
+ "pgmq 0.13.1",
  "pgrx",
  "pgrx-tests",
  "rand",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ format:
 	cargo +nightly clippy
 
 run.postgres:
-	docker run -d --name pgmq-pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io/coredb/pgmq-pg:latest
+	docker run -d --name pgmq-pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io/tembo/pgmq-pg:latest

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Partitions behavior is configured at the time queues are created, via `pgmq_crea
 
 In order for automatic partition maintenance to take place, several settings must be added to the `postgresql.conf` file, which is typically located in the postgres `DATADIR`.
  `pg_partman_bgw.interval` 
-in `postgresql.conf`. Below are the default configuration values set in CoreDB docker images.
+in `postgresql.conf`. Below are the default configuration values set in Tembo docker images.
 
 Add the following to `postgresql.conf`. Note, changing `shared_preload_libraries` requires a restart of Postgres.
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,14 +2,14 @@
 name = "pgmq"
 version = "0.13.0"
 edition = "2021"
-authors = ["CoreDB.io"]
+authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."
 documentation = "https://docs.rs/pgmq"
-homepage = "https://github.com/CoreDB-io/coredb"
+homepage = "https://github.com/tembo-io/pgmq"
 keywords = ["messaging", "queues", "postgres"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/CoreDB-io/coredb/tree/main/pgmq/core"
+repository = "https://github.com/tembo-io/pgmq"
 
 [dependencies]
 chrono = { version = "0.4.23", features = [ "serde" ] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/tembo-io/pgmq"
 chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }
-sqlx = { version = "0.6", features = [ "offline", "runtime-tokio-native-tls" , "postgres", "chrono", "json" ] }
+sqlx = { version = "0.6.3", features = [ "offline", "runtime-tokio-native-tls" , "postgres", "chrono", "json" ] }
 thiserror = "1.0.38"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.17"

--- a/core/Makefile
+++ b/core/Makefile
@@ -12,7 +12,7 @@ update.readme:
 		> README.md
 
 run.postgres:
-	docker run --rm -d --name pgmq-pg -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -p 5432:5432 quay.io/coredb/pgmq-pg:latest
+	docker run --rm -d --name pgmq-pg -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -p 5432:5432 quay.io/tembo/pgmq-pg:latest
 
 test: run.postgres
 	sleep 2;

--- a/core/sqlx-data.json
+++ b/core/sqlx-data.json
@@ -466,5 +466,25 @@
       }
     },
     "query": "SELECT pgmq_send as msg_id from pgmq_send($1::text, $2::jsonb);"
+  },
+  "ed8b7aacd0d94fe647899b6d2fe61a29372cd7d6dbc28bf59ac6bb3118e3fe6c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "pgmq_create_partitioned",
+          "ordinal": 0,
+          "type_info": "Void"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "SELECT * from pgmq_create_partitioned($1::text);"
   }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,7 +13,7 @@
 //! We're building a radically simplified Postgres platform designed to be developer-first and easily extensible.
 //! PGMQ is a part of that project.
 //!
-//! Not building in Rust? Try the [CoreDB pgmq Postgres extension](https://pgt.dev/extensions/pgmq).
+//! Not building in Rust? Try the [Tembo pgmq Postgres extension](https://pgt.dev/extensions/pgmq).
 //!
 //! ## Features
 //!

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -803,20 +803,20 @@ async fn test_pgmq_init() {
         .await
         .expect("failed to connect to postgres");
     let init = queue.init().await.expect("failed to create extension");
-    assert!(init);
+    assert!(init, "failed to create extension");
 
-    // error mode on queue create but already exists
+    // error mode on queue partitioned create but already exists
     let qname = format!("test_dup_{}", rand::thread_rng().gen_range(0..100));
     println!("db_url: {}, qname: {:?}", db_url, qname);
     let created = queue
-        .create(&qname)
+        .create_partitioned(&qname)
         .await
         .expect("failed attempting to create queue");
     assert!(created, "did not create queue");
     // create again
     let created = queue
-        .create(&qname)
+        .create_partitioned(&qname)
         .await
         .expect("failed attempting to create the duplicate queue");
-    assert!(!created)
+    assert!(!created, "failed to detect duplicate queue");
 }

--- a/examples/ruby.rb
+++ b/examples/ruby.rb
@@ -18,7 +18,7 @@ QUEUE_NAME = "myqueue"
 LOCK_TIMEOUT = 1
 NUM_MSGS = 1
 
-# Connect to the CoreDB postgres (update port number to match how you are running it locally)
+# Connect to the Tembo postgres (update port number to match how you are running it locally)
 conn = PG.connect(host: "localhost", port: 5434, user: "postgres", password: "postgres")
 
 # Output versions to stdout (for debugging)

--- a/tembo-pgmq-python/Makefile
+++ b/tembo-pgmq-python/Makefile
@@ -14,7 +14,7 @@ clear-postgres:
 	docker rm -f pgmq-postgres || true
 
 run-pgmq-postgres:
-	docker run -d --name pgmq-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io/coredb/pgmq-pg:latest || true
+	docker run -d --name pgmq-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io/tembo/pgmq-pg:latest || true
 
 test: run-pgmq-postgres
 	poetry run pytest

--- a/tembo-pgmq-python/pyproject.toml
+++ b/tembo-pgmq-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tembo-pgmq-python"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python client for the PGMQ Postgres extension."
 authors = ["Adam Hendel <adam@tembo.io>"]
 license = "Apache 2.0"


### PR DESCRIPTION
- update some more refs from coredb -> tembo
- use the images published in https://github.com/tembo-io/pgmq/pull/13
- bump minor versions of python lib, crate, and extension to update docs for all
- fixes a bug in the rust client sdk. the default create() in the extension was changed to a non-partitioned queue, so moved that action to its own function in the rust sdk as well. this will probably change in a future 1.0 release.