### PR TITLE
bring your own pg pool

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -201,6 +201,15 @@ impl PGMQueue {
         })
     }
 
+    /// BYOP  - bring your own pool
+    /// initialize a PGMQ connection with your own SQLx Postgres connection pool
+    pub async fn new_with_pool(pool: Pool<Postgres>) -> Result<PGMQueue, errors::PgmqError> {
+        Ok(PGMQueue {
+            url: "".to_owned(),
+            connection: pool,
+        })
+    }
+
     /// Create a queue. This sets up the queue's tables, indexes, and metadata.
     /// It is idempotent, but does not check if the queue already exists.
     /// Amounts to `IF NOT EXISTS` statements in Postgres.

--- a/core/src/pg_ext.rs
+++ b/core/src/pg_ext.rs
@@ -27,6 +27,15 @@ impl PGMQueueExt {
         })
     }
 
+    /// BYOP  - bring your own pool
+    /// initialize a PGMQ connection with your own SQLx Postgres connection pool
+    pub async fn new_with_pool(pool: Pool<Postgres>) -> Result<PGMQueueExt, PgmqError> {
+        Ok(PGMQueueExt {
+            url: "".to_owned(),
+            connection: pool,
+        })
+    }
+
     pub async fn init(&self) -> Result<bool, PgmqError> {
         sqlx::query!("CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;")
             .execute(&self.connection)


### PR DESCRIPTION
Allow user to bring their own Pool<Postgres> to the PGMQueue and PGMQExt APIs.

This allows users to setup a unix connection or more fine tuned connection configuration, for example.