### PR TITLE
fully qualify insert path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,10 +1240,10 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
- "pgmq 0.13.1",
+ "pgmq 0.14.0",
  "pgrx",
  "pgrx-tests",
  "rand",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,9 @@ pub mod metrics;
 pub mod partition;
 
 use pgmq_crate::errors::PgmqError;
-use pgmq_crate::query::{archive, check_input, delete, init_queue, pop, read, TABLE_PREFIX, PGMQ_SCHEMA};
+use pgmq_crate::query::{
+    archive, check_input, delete, init_queue, pop, read, PGMQ_SCHEMA, TABLE_PREFIX,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod metrics;
 pub mod partition;
 
 use pgmq_crate::errors::PgmqError;
-use pgmq_crate::query::{archive, check_input, delete, init_queue, pop, read, TABLE_PREFIX};
+use pgmq_crate::query::{archive, check_input, delete, init_queue, pop, read, TABLE_PREFIX, PGMQ_SCHEMA};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -82,7 +82,7 @@ fn enqueue_str(name: &str) -> Result<String, PgmqError> {
     check_input(name)?;
     Ok(format!(
         "
-        INSERT INTO {TABLE_PREFIX}_{name} (vt, message)
+        INSERT INTO {PGMQ_SCHEMA}.{TABLE_PREFIX}_{name} (vt, message)
         VALUES (now() at time zone 'utc', $1)
         RETURNING msg_id;
         "


### PR DESCRIPTION
Problems arise when pgmq is installed a different schema than 'public' and first schema on the user's search path is not 'public'.

I think long-term, likely specifying `schema = pgmq` in the control file.