### PR TITLE
update CI

### DIFF
--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -1,0 +1,83 @@
+name: Cargo publish or validate
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/[0-9]+.[0-9]+"
+  push:
+    branches:
+      - 'main'
+      - 'release/[0-9]+.[0-9]+'
+
+jobs:
+  find_directories:
+    name: Find crates that changed
+    runs-on: ubuntu-20.04
+    outputs:
+      changed_crates: ${{ steps.find_directories.outputs.build_matrix }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Find directories including Cargo.toml that changed
+        id: find_directories
+        uses: ./.github/actions/find-changed-directories
+        with:
+          contains_the_file: Cargo.toml
+          # If the branch does not exist, then it will not
+          # filter any directories containing the file.
+          # This allows for filtering out unchanged directories
+          # in a pull request, and using all directories on the release
+          # or main branches.
+          changed_relative_to_ref: origin/${{ github.base_ref || 'not-a-branch' }}
+
+
+  cargo_publish:
+    # On a pull request, this is validating that the version
+    # is not already published to crates.io, and on a push to
+    # main or release branches, it is publishing if the version
+    # does not exist, ignoring if the version is already
+    # published.
+    name: Cargo publish or validate
+    runs-on: ubuntu-20.04
+    needs:
+      - find_directories
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_directories.outputs.changed_crates) }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Determine which flags to use on cargo publish
+        id: cargo_flags
+        run: |
+          set -x
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          if [ "${BRANCH_NAME}" == "main" ]; then
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+            echo "fail_if_version_published=false" >> $GITHUB_OUTPUT
+          elif [[ "${BRANCH_NAME}" == release/* ]]; then
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+            echo "fail_if_version_published=false" >> $GITHUB_OUTPUT
+          else
+            echo "dry_run=true" >> $GITHUB_OUTPUT
+            echo "fail_if_version_published=true" >> $GITHUB_OUTPUT
+          fi
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ matrix.name }}
+          workspaces: |
+            ${{ matrix.path }}
+          # Additional directories to cache
+          cache-directories: |
+            /home/runner/.pgrx
+      - uses: ./.github/actions/pgx-init
+        with:
+          working-directory: ${{ matrix.path }}
+      - name: Publish or validate
+        uses: ./.github/actions/publish-crate
+        with:
+          working-directory: ${{ matrix.path }}
+          dry-run: ${{ steps.cargo_flags.outputs.dry_run }}
+          fail-if-version-published: ${{ steps.cargo_flags.outputs.fail_if_version_published }}
+          cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/crate_ci.yml
+++ b/.github/workflows/crate_ci.yml
@@ -10,7 +10,7 @@ on:
     branches:
      - main
     paths:
-      - '.github/workflows/pgmq.yml'
+      - '.github/workflows/crate_ci.yml'
       - 'core/**'
   push:
     branches:

--- a/.github/workflows/crate_ci.yml
+++ b/.github/workflows/crate_ci.yml
@@ -56,21 +56,3 @@ jobs:
         run: cargo sqlx prepare --check
       - name: teardown
         run: make test.cleanup
-
-  publish:
-    # only run off head main
-    if: github.ref == 'refs/heads/main'
-    name: Publish Crate & Extension
-    runs-on: ubuntu-22.04
-    needs: [lint, tests]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-      - name: publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -76,8 +76,9 @@ jobs:
           cargo pgrx test ${pg_version}
 
   publish:
-    # only publish off main branch
-    if: github.ref == 'refs/heads/main'
+    # only publish on tagged release events
+    # if: github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/')
     name: trunk publish
     runs-on: ubuntu-22.04
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,7 @@ Run this script to package into a `.deb` file, which can be installed on Ubuntu.
 ```
 /bin/bash build-extension.sh
 ```
+
+# Releases
+
+PGMQ Postgres Extension releases are automated through a [Github workflow](https://github.com/tembo-io/pgmq/blob/main/.github/workflows/extension_ci.yml). The compiled binaries are publish to and hosted at [pgt.dev](https://pgt.dev). To create a release, create a new tag follow a valid [semver](https://semver.org/), then create a release with the same name. Auto-generate the release notes and/or add more relevant details as needed. See subdirectories for the [Rust](https://github.com/tembo-io/pgmq/tree/main/core) and [Python](https://github.com/tembo-io/pgmq/tree/main/tembo-pgmq-python) SDK release processes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ name = "pgmq"
 version = "0.10.1"
 dependencies = [
  "chrono",
- "pgmq 0.13.1",
+ "pgmq 0.14.0",
  "pgrx",
  "pgrx-tests",
  "rand",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ name = "pgmq"
 version = "0.10.2"
 dependencies = [
  "chrono",
- "pgmq 0.14.0",
+ "pgmq 0.14.1",
  "pgrx",
  "pgrx-tests",
  "rand",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chrono",
  "log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/core/Makefile
+++ b/core/Makefile
@@ -15,7 +15,7 @@ run.postgres:
 	docker run --rm -d --name pgmq-pg -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -p 5432:5432 quay.io/tembo/pgmq-pg:latest
 
 test: run.postgres
-	sleep 2;
+	sleep 4;
 	echo "Running all tests..."
 	sqlx migrate run
 	DATABASE_URL=postgres://postgres:postgres@0.0.0.0:5432 cargo test


### PR DESCRIPTION
partially resolves https://github.com/tembo-io/pgmq/issues/20

- only publish new extensions on tag release events
- separate the Rust crate publish from tests. cargo publish will only run when there is increase to the crate version in Cargo.toml