### PR TITLE
Add pgmq_read_with_poll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,10 +1243,10 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "chrono",
- "pgmq 0.15.2",
+ "pgmq 0.16.0",
  "pgrx",
  "pgrx-tests",
  "rand",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/core/sqlx-data.json
+++ b/core/sqlx-data.json
@@ -14,12 +14,12 @@
           "type_info": "Int4"
         },
         {
-          "name": "vt",
+          "name": "enqueued_at",
           "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "name": "enqueued_at",
+          "name": "vt",
           "ordinal": 3,
           "type_info": "Timestamptz"
         },
@@ -220,12 +220,12 @@
           "type_info": "Int4"
         },
         {
-          "name": "vt",
+          "name": "enqueued_at",
           "ordinal": 2,
           "type_info": "Timestamptz"
         },
         {
-          "name": "enqueued_at",
+          "name": "vt",
           "ordinal": 3,
           "type_info": "Timestamptz"
         },
@@ -272,6 +272,54 @@
       }
     },
     "query": "SELECT pgmq_send as msg_id from pgmq_send($1::text, $2::jsonb);"
+  },
+  "e4c38347b44aed05aa890d3351a362d3b6f81387e98fc564ec922cefa1e96f71": {
+    "describe": {
+      "columns": [
+        {
+          "name": "msg_id",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "read_ct",
+          "ordinal": 1,
+          "type_info": "Int4"
+        },
+        {
+          "name": "enqueued_at",
+          "ordinal": 2,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "vt",
+          "ordinal": 3,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "message",
+          "ordinal": 4,
+          "type_info": "Jsonb"
+        }
+      ],
+      "nullable": [
+        null,
+        null,
+        null,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Int4",
+          "Int4",
+          "Int4",
+          "Int4"
+        ]
+      }
+    },
+    "query": "SELECT * from pgmq_read_with_poll($1::text, $2, $3, $4, $5)"
   },
   "ed8b7aacd0d94fe647899b6d2fe61a29372cd7d6dbc28bf59ac6bb3118e3fe6c": {
     "describe": {

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -804,6 +804,16 @@ async fn test_extension_api() {
         .expect("error reading message");
     assert!(read_message.is_none());
 
+    // read with poll, blocks until message visible
+    let read_messages = queue
+        .read_batch_with_poll::<MyMessage>(&test_queue, 5, 1, Some(std::time::Duration::from_secs(6)), None)
+        .await
+        .expect("error reading message")
+        .expect("no message");
+
+    assert_eq!(read_messages.len(), 1);
+    assert_eq!(read_messages[0].msg_id, msg_id);
+
     // change the VT to now
     let _vt_set = queue
         .set_vt::<MyMessage>(&test_queue, msg_id, 0)

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -292,10 +292,9 @@ async fn test_read_batch_with_poll() {
             None,
         )
         .await
-        .unwrap()
         .unwrap();
 
-    assert_eq!(read_message_3.len(), 0);
+    assert!(read_message_3.is_none());
 }
 
 #[tokio::test]

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -806,7 +806,13 @@ async fn test_extension_api() {
 
     // read with poll, blocks until message visible
     let read_messages = queue
-        .read_batch_with_poll::<MyMessage>(&test_queue, 5, 1, Some(std::time::Duration::from_secs(6)), None)
+        .read_batch_with_poll::<MyMessage>(
+            &test_queue,
+            5,
+            1,
+            Some(std::time::Duration::from_secs(6)),
+            None,
+        )
         .await
         .expect("error reading message")
         .expect("no message");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,6 @@ fn pgmq_read_with_poll(
     spi::Error,
 > {
     let start_time = std::time::Instant::now();
-    dbg!(start_time);
     loop {
         let results = readit(queue_name, vt, limit)?;
         if results.len() == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ use pgmq_crate::query::{
 };
 use thiserror::Error;
 
+use std::time::Duration;
+
 #[derive(Error, Debug)]
 pub enum PgmqExtError {
     #[error("")]
@@ -153,9 +155,7 @@ fn pgmq_read_with_poll(
             if start_time.elapsed().as_millis() > (poll_timeout_s * 1000) as u128 {
                 break Ok(TableIterator::new(results));
             } else {
-                std::thread::sleep(std::time::Duration::from_millis(
-                    poll_interval_ms.try_into().unwrap(),
-                ));
+                std::thread::sleep(Duration::from_millis(poll_interval_ms.try_into().unwrap()));
                 continue;
             }
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use pgmq_crate::query::{
 };
 use thiserror::Error;
 
-const POLL_READ_INTERVAL_MS: u64 = 250;
+const POLL_READ_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
 
 #[derive(Error, Debug)]
 pub enum PgmqExtError {
@@ -148,7 +148,6 @@ fn pgmq_read_with_poll(
     spi::Error,
 > {
     let start_time = std::time::Instant::now();
-    let poll_read_interval = std::time::Duration::from_millis(POLL_READ_INTERVAL_MS);
     dbg!(start_time);
     loop {
         let results = readit(queue_name, vt, limit)?;
@@ -156,7 +155,7 @@ fn pgmq_read_with_poll(
             if start_time.elapsed().as_millis() > poll_timeout_ms.try_into().unwrap() {
                 break Ok(TableIterator::new(results));
             } else {
-                std::thread::sleep(poll_read_interval);
+                std::thread::sleep(POLL_READ_INTERVAL);
                 continue;
             }
         } else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -82,8 +82,7 @@ async fn test_lifecycle() {
     assert!(message.is_none());
 
     // read again, now using poll to block until message is ready
-    let query =
-        &format!("SELECT * from pgmq_read_with_poll('{test_default_queue}', 10, 1, 10000);");
+    let query = &format!("SELECT * from pgmq_read_with_poll('{test_default_queue}', 10, 1, 10);");
     let message = fetch_one_message::<serde_json::Value>(query, &conn)
         .await
         .expect("failed reading message")


### PR DESCRIPTION
For feature parity with SQS. The implementation is a bit naive: it simply will retry querying for messages on a small interval until the timeout is reached.

To be discussed: 
- should we make the interval configurable? maybe it should be a parameter to the function?
- should we receive the timeout in seconds instead of ms, for consistency, considering vt is defined in seconds?

To be done:
- add tests, i only tested manually
- add in rust client without the extension (there we could use async instead of thread::sleep)
- document