### PR TITLE
Patch assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,10 +1243,10 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.14.0"
+version = "0.14.2"
 dependencies = [
  "chrono",
- "pgmq 0.16.0",
+ "pgmq 0.16.1",
  "pgrx",
  "pgrx-tests",
  "rand",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -364,12 +364,9 @@ pub fn assign(table_name: &str) -> String {
             WHERE refobjid = (SELECT oid FROM pg_extension WHERE extname = 'pgmq')
             AND objid = (SELECT oid FROM pg_class WHERE relname = '{TABLE_PREFIX}_{table_name}')
         ) THEN
-
             EXECUTE 'ALTER EXTENSION pgmq ADD TABLE {PGMQ_SCHEMA}.{TABLE_PREFIX}_{table_name}';
-
         END IF;
-
-        END $$;
+    END $$;
     "
     )
 }

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -336,7 +336,7 @@ pub fn assign_queue(name: CheckedName<'_>) -> Result<String, PgmqError> {
 }
 
 pub fn assign_archive(name: CheckedName<'_>) -> Result<String, PgmqError> {
-    Ok(assign(&format!("{name}_archive; ")))
+    Ok(assign(&format!("{name}_archive")))
 }
 
 pub fn unassign_queue(name: CheckedName<'_>) -> Result<String, PgmqError> {
@@ -362,7 +362,11 @@ pub fn assign(table_name: &str) -> String {
             SELECT 1
             FROM pg_depend
             WHERE refobjid = (SELECT oid FROM pg_extension WHERE extname = 'pgmq')
-            AND objid = (SELECT oid FROM pg_class WHERE relname = '{TABLE_PREFIX}_{table_name}')
+            AND objid = (
+                SELECT oid
+                FROM pg_class
+                WHERE relname = '{TABLE_PREFIX}_{table_name}'
+            )
         ) THEN
             EXECUTE 'ALTER EXTENSION pgmq ADD TABLE {PGMQ_SCHEMA}.{TABLE_PREFIX}_{table_name}';
         END IF;
@@ -401,6 +405,12 @@ pub fn check_input(input: &str) -> Result<(), PgmqError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_assign() {
+        let query = assign("my_queue_archive");
+        assert!(query.contains("WHERE relname = 'pgmq_my_queue_archive'"));
+    }
 
     #[test]
     fn test_create() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -44,6 +44,13 @@ async fn test_lifecycle() {
         .await
         .expect("failed to create queue");
 
+    // creating a queue must be idempotent
+    // create with same name again, must be no  error
+    let _ = sqlx::query(&format!("SELECT pgmq_create('{test_default_queue}');"))
+        .execute(&conn)
+        .await
+        .expect("failed to create queue");
+
     let msg_id = sqlx::query(&format!(
         "SELECT * from pgmq_send('{test_default_queue}', '{{\"hello\": \"world\"}}');"
     ))


### PR DESCRIPTION
assignment of the archive table to pgmq extension was adding an extra semi-colon. this made `pgmq_create()` no longer idempotent. it would fail if the queue already existed.

Also added some extra test cases.