### PR TITLE
grant usage on queue sequence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "pgmq 0.16.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ name = "pgmq"
 version = "0.15.1"
 dependencies = [
  "chrono",
- "pgmq 0.16.2",
+ "pgmq 0.16.3",
  "pgrx",
  "pgrx-tests",
  "rand",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -107,7 +107,7 @@ BEGIN
     WHERE has_table_privilege('pg_monitor', '{table}', 'SELECT')
   ) THEN
     EXECUTE 'GRANT SELECT ON {table} TO pg_monitor';
-    EXECUTE 'GRANT USAGE ON SEQUENCE {table}_msg_id_seq TO pg_monitor';
+    EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';
   END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -408,7 +408,7 @@ BEGIN
     WHERE has_table_privilege('pg_monitor', 'my_table', 'SELECT')
   ) THEN
     EXECUTE 'GRANT SELECT ON my_table TO pg_monitor';
-    EXECUTE 'GRANT USAGE ON SEQUENCE my_table_msg_id_seq TO pg_monitor';
+    EXECUTE 'GRANT SELECT ON SEQUENCE my_table_msg_id_seq TO pg_monitor';
   END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -98,9 +98,9 @@ pub fn create_meta() -> String {
 }
 
 fn grant_stmt(table: &str) -> String {
-    let grant_seq = match table {
-        "pgmq_meta" => "".to_string(),
-        _ => format!("EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';"),
+    let grant_seq = match &table.contains("pgmq_meta") {
+        true => "".to_string(),
+        false => format!("EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';"),
     };
     format!(
         "

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -98,6 +98,10 @@ pub fn create_meta() -> String {
 }
 
 fn grant_stmt(table: &str) -> String {
+    let grant_seq = match table {
+        "pgmq_meta" => "".to_string(),
+        _ => format!("EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';")
+    };
     format!(
         "
 DO $$
@@ -107,7 +111,7 @@ BEGIN
     WHERE has_table_privilege('pg_monitor', '{table}', 'SELECT')
   ) THEN
     EXECUTE 'GRANT SELECT ON {table} TO pg_monitor';
-    EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';
+    {grant_seq}
   END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -413,7 +417,24 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 ";
+        assert_eq!(q, expected);
+
+        let q = grant_stmt("pgmq_meta");
+        let expected = "
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    WHERE has_table_privilege('pg_monitor', 'pgmq_meta', 'SELECT')
+  ) THEN
+    EXECUTE 'GRANT SELECT ON pgmq_meta TO pg_monitor';
+    
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+";
         assert_eq!(q, expected)
+
     }
 
     #[test]

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -100,7 +100,7 @@ pub fn create_meta() -> String {
 fn grant_stmt(table: &str) -> String {
     let grant_seq = match table {
         "pgmq_meta" => "".to_string(),
-        _ => format!("EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';")
+        _ => format!("EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';"),
     };
     format!(
         "
@@ -434,7 +434,6 @@ END;
 $$ LANGUAGE plpgsql;
 ";
         assert_eq!(q, expected)
-
     }
 
     #[test]


### PR DESCRIPTION
`pg_monitor` needs to be able to select `last_value` from the queue's message ID sequence. 

https://github.com/tembo-io/pgmq/blob/c4716c7d1a6bf2454475ce0583cc399a6bec4dc1/src/metrics.rs#L111-L113