### PR TITLE
Add archive_batch function to ext api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,10 +1243,10 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "chrono",
- "pgmq 0.17.0",
+ "pgmq 0.18.0",
  "pgrx",
  "pgrx-tests",
  "rand",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/core/sqlx-data.json
+++ b/core/sqlx-data.json
@@ -109,17 +109,7 @@
     },
     "query": "SELECT * from pgmq_create($1::text);"
   },
-  "3a3440841fba7d0f8744f5873cdb93a64b6e2f6481c3b14af701c5189f5e73f0": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": []
-      }
-    },
-    "query": "CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;"
-  },
-  "595dd830c53f4560378cfadcf8a1cc6f566307e3d76fea4c84e35e70649a7f17": {
+  "36b2ecea83484248d99c8d091f8d9b7fa6ce368d7db8fe14e3ab491eb52c723c": {
     "describe": {
       "columns": [
         {
@@ -134,11 +124,21 @@
       "parameters": {
         "Left": [
           "Text",
-          "Int8"
+          "Int8Array"
         ]
       }
     },
-    "query": "SELECT * from pgmq_archive($1::text, $2)"
+    "query": "SELECT * from pgmq_archive($1::text, $2::bigint[])"
+  },
+  "3a3440841fba7d0f8744f5873cdb93a64b6e2f6481c3b14af701c5189f5e73f0": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;"
   },
   "8e4f6635dc4cfb5ed42ddb87930b985793e81243b8a5609dec4ab566aaab4e9c": {
     "describe": {
@@ -272,6 +272,27 @@
       }
     },
     "query": "SELECT * from pgmq_read($1::text, $2, $3)"
+  },
+  "cb7072cc0f81a187953b6210a40d799b0ff301b73ad873f767c29fd383724a32": {
+    "describe": {
+      "columns": [
+        {
+          "name": "pgmq_archive",
+          "ordinal": 0,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Int8"
+        ]
+      }
+    },
+    "query": "SELECT * from pgmq_archive($1::text, $2::bigint)"
   },
   "cd7b28f6bd348038e7c26d89292f2445841e7c13143b453277a010390699d1fc": {
     "describe": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ pub mod partition;
 
 use pgmq_crate::errors::PgmqError;
 use pgmq_crate::query::{
-    archive, check_input, delete, delete_batch, init_queue, pop, read, PGMQ_SCHEMA, TABLE_PREFIX,
+    archive, archive_batch, check_input, delete, delete_batch, init_queue, pop, read, PGMQ_SCHEMA,
+    TABLE_PREFIX,
 };
 
 use errors::PgmqExtError;
@@ -217,18 +218,16 @@ fn pgmq_delete(queue_name: &str, msg_id: i64) -> Result<Option<bool>, PgmqExtErr
 
 #[pg_extern(name = "pgmq_delete")]
 fn pgmq_delete_batch(queue_name: &str, msg_ids: Vec<i64>) -> Result<Option<bool>, PgmqExtError> {
-    let mut num_deleted = 0;
     let query = delete_batch(queue_name, &msg_ids)?;
     Spi::connect(|mut client| {
         let tup_table = client.update(&query, None, None);
         match tup_table {
-            Ok(tup_table) => num_deleted = tup_table.len(),
+            Ok(_) => Ok(Some(true)),
             Err(e) => {
                 error!("error deleting message: {}", e);
             }
         }
-    });
-    Ok(Some(true))
+    })
 }
 
 /// archive a message forever instead of deleting it
@@ -255,6 +254,20 @@ fn pgmq_archive(queue_name: &str, msg_id: i64) -> Result<Option<bool>, PgmqExtEr
             error!("multiple messages found with msg_id: {}", msg_id);
         }
     }
+}
+
+#[pg_extern(name = "pgmq_archive")]
+fn pgmq_archive_batch(queue_name: &str, msg_ids: Vec<i64>) -> Result<Option<bool>, PgmqExtError> {
+    let query = archive_batch(queue_name, &msg_ids)?;
+    Spi::connect(|mut client| {
+        let tup_table = client.update(&query, None, None);
+        match tup_table {
+            Ok(_) => Ok(Some(true)),
+            Err(e) => {
+                error!("error deleting message: {}", e);
+            }
+        }
+    })
 }
 
 // reads and deletes at same time


### PR DESCRIPTION
- Adds variant of `pgmq_archive` that takes `bigint[]`
- Adds `archive_batch` to QueueExt