### PR TITLE
no token flag on dry-run

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -72,8 +72,9 @@ runs:
 
         # Set --dry-run flag, if configured
         DRY_RUN=""
-        if [ "${{ inputs.dry-run }}" == "true" ]; then
-          DRY_RUN="--dry-run"
+        if [ "${{ inputs.dry-run }}" == "true" ];
+        then
+          cargo publish --dry-run
+        else
+          cargo publish --token ${{ inputs.cargo-registry-token }}
         fi
-
-        cargo publish ${DRY_RUN} --token ${{ inputs.cargo-registry-token }}


### PR DESCRIPTION
Not completely sure why the token is not getting passed in. Instead of interpolating the DRY_RUN flag, maybe execute statements separately? Here's an example of it the token not making it into the action. 

https://github.com/tembo-io/pgmq/actions/runs/6018252013/job/16329118585#step:18:159

<img width="522" alt="image" src="https://github.com/tembo-io/pgmq/assets/15756360/a9afd136-b26a-4472-aacb-c09ae082407f">


