### PR TITLE
Fix small typo from #97

### DIFF
--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -154,7 +154,7 @@ pub fn insert_meta(name: CheckedName<'_>, is_partitioned: bool) -> Result<String
     Ok(format!(
         "
         INSERT INTO {PGMQ_SCHEMA}.{TABLE_PREFIX}_meta (queue_name, is_partitioned)
-        VALUES ('{name}', '{is_partitioned}')
+        VALUES ('{name}', {is_partitioned})
         ON CONFLICT
         DO NOTHING;
         ",


### PR DESCRIPTION
Sorry, small typo crept in from an earlier version when working with a text column.