### PR TITLE
update pgmq-rs for latest core

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -9,9 +9,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'pgmq-rs/**'
   push:
     branches:
       - main
+    paths-ignore:
+      - 'pgmq-rs/**'
   release:
     types: 
       - created

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/tembo-io/pgmq"
 
 [dependencies]
-pgmq_core = { package = "pgmq-core", version = "0.3.0" }
+pgmq_core = { package = "pgmq-core", version = "0.4.0" }
 chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }

--- a/pgmq-rs/Makefile
+++ b/pgmq-rs/Makefile
@@ -1,7 +1,8 @@
 POSTGRES_PASSWORD:=postgres
+DATABASE_URL:=postgres://postgres:postgres@0.0.0.0:5432/postgres
 
 format:
-	cargo sqlx prepare
+	cargo sqlx prepare --database-url ${DATABASE_URL}
 	cargo +nightly fmt --all
 	cargo clippy
 
@@ -17,8 +18,8 @@ run.postgres:
 test: run.postgres
 	sleep 4;
 	echo "Running all tests..."
-	sqlx migrate run
-	DATABASE_URL=postgres://postgres:postgres@0.0.0.0:5432 cargo test
+	sqlx migrate run --database-url ${DATABASE_URL}
+	cargo test
 
 test.cleanup:
 	docker stop pgmq-pg

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -688,8 +688,11 @@ impl PGMQueue {
     ///     Ok(())
     /// }
     pub async fn delete(&self, queue_name: &str, msg_id: i64) -> Result<u64, PgmqError> {
-        let query = &core_query::delete(queue_name, msg_id)?;
-        let row = sqlx::query(query).execute(&self.connection).await?;
+        let query = &core_query::delete_batch(queue_name)?;
+        let row = sqlx::query(query)
+            .bind(vec![msg_id])
+            .execute(&self.connection)
+            .await?;
         let num_deleted = row.rows_affected();
         Ok(num_deleted)
     }
@@ -737,8 +740,11 @@ impl PGMQueue {
     ///     Ok(())
     /// }
     pub async fn delete_batch(&self, queue_name: &str, msg_ids: &[i64]) -> Result<u64, PgmqError> {
-        let query = &core_query::delete_batch(queue_name, msg_ids)?;
-        let row = sqlx::query(query).execute(&self.connection).await?;
+        let query = &core_query::delete_batch(queue_name)?;
+        let row = sqlx::query(query)
+            .bind(msg_ids)
+            .execute(&self.connection)
+            .await?;
         let num_deleted = row.rows_affected();
         Ok(num_deleted)
     }
@@ -787,8 +793,11 @@ impl PGMQueue {
     ///     Ok(())
     /// }
     pub async fn archive(&self, queue_name: &str, msg_id: i64) -> Result<u64, PgmqError> {
-        let query = core_query::archive(queue_name, msg_id)?;
-        let row = sqlx::query(&query).execute(&self.connection).await?;
+        let query = core_query::archive_batch(queue_name)?;
+        let row = sqlx::query(&query)
+            .bind(vec![msg_id])
+            .execute(&self.connection)
+            .await?;
         let num_deleted = row.rows_affected();
         Ok(num_deleted)
     }

--- a/pgmq-rs/src/query.rs
+++ b/pgmq-rs/src/query.rs
@@ -10,7 +10,7 @@ pub fn init_queue_client_only(name: &str) -> Result<Vec<String>, errors::PgmqErr
         query::create_index(name)?,
         query::create_archive(name)?,
         query::create_archive_index(name)?,
-        query::insert_meta(name)?,
+        query::insert_meta(name, false)?,
         query::grant_pgmon_meta(),
         query::grant_pgmon_queue(name)?,
     ])


### PR DESCRIPTION
- Updating pgmq-rs internals for compatibility with the refactors to `pgmq-core`.

- Moves `PGMQueueExt` API tests to their own database to avoid collisions with `PGMQueue` tests.