### PR TITLE
Rewrite some core APIs in PL/pgSQL

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -79,7 +79,7 @@ jobs:
           rm -rf ./target/pgrx-test-data-* || true
           pg_version=$(stoml Cargo.toml features.default)
           cargo pgrx run ${pg_version} --pgcli || true
-          cargo test -- --test-threads=1
+          make test
 
   publish:
     # only publish release events

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -79,7 +79,7 @@ jobs:
           rm -rf ./target/pgrx-test-data-* || true
           pg_version=$(stoml Cargo.toml features.default)
           cargo pgrx run ${pg_version} --pgcli || true
-          cargo pgrx test ${pg_version}
+          cargo test ${pg_version} -- --test-threads=1
 
   publish:
     # only publish release events

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -79,7 +79,7 @@ jobs:
           rm -rf ./target/pgrx-test-data-* || true
           pg_version=$(stoml Cargo.toml features.default)
           cargo pgrx run ${pg_version} --pgcli || true
-          cargo test ${pg_version} -- --test-threads=1
+          cargo test -- --test-threads=1
 
   publish:
     # only publish release events

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -64,4 +64,4 @@ jobs:
           SQLX_OFFLINE=true cargo pgrx run ${pg_version} --pgcli || true
           psql $DATABASE_URL -c "ALTER EXTENSION pgmq UPDATE;"
           # Run extension tests
-          SQLX_OFFLINE=true cargo pgrx test ${pg_version}
+          SQLX_OFFLINE=true cargo test -- --test-threads=1

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -66,4 +66,5 @@ jobs:
           SQLX_OFFLINE=true cargo pgrx run ${pg_version} --pgcli || true
           psql $DATABASE_URL -c "ALTER EXTENSION pgmq UPDATE;"
           # Run extension tests
-          SQLX_OFFLINE=true cargo test -- --test-threads=1
+          cargo pgrx test
+          SQLX_OFFLINE=true make test

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -55,6 +55,8 @@ jobs:
           git fetch --tags
           git checkout tags/v0.14.2
           SQLX_OFFLINE=true cargo pgrx run ${pg_version} --pgcli || true
+          psql $DATABASE_URL -c "DROP EXTENSION IF EXISTS pgmq;"
+          psql $DATABASE_URL -c "DROP EXTENSION IF EXISTS pg_partman;"
           psql $DATABASE_URL -c "CREATE EXTENSION pg_partman;"
           psql $DATABASE_URL -c "CREATE EXTENSION pgmq;"
           psql $DATABASE_URL -c "select * from pgmq_create('test_queue_1')"

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -55,8 +55,8 @@ jobs:
           git fetch --tags
           git checkout tags/v0.14.2
           SQLX_OFFLINE=true cargo pgrx run ${pg_version} --pgcli || true
-          psql $DATABASE_URL -c "DROP EXTENSION IF EXISTS pgmq;"
-          psql $DATABASE_URL -c "DROP EXTENSION IF EXISTS pg_partman;"
+          psql $DATABASE_URL -c "DROP EXTENSION IF EXISTS pgmq CASCADE;"
+          psql $DATABASE_URL -c "DROP EXTENSION IF EXISTS pg_partman CASCADE;"
           psql $DATABASE_URL -c "CREATE EXTENSION pg_partman;"
           psql $DATABASE_URL -c "CREATE EXTENSION pgmq;"
           psql $DATABASE_URL -c "select * from pgmq_create('test_queue_1')"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "chrono",
  "pgmq-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+test:
+	cargo pgrx test
+	cargo test -- --test-threads=1 --ignored
+
 format:
 	cargo +nightly fmt --all
 	cargo +nightly clippy

--- a/sql/pgmq--0.25.0--0.26.0.sql
+++ b/sql/pgmq--0.25.0--0.26.0.sql
@@ -41,7 +41,7 @@ BEGIN
             read_ct = read_ct + 1
         FROM cte
         WHERE m.msg_id = cte.msg_id
-        RETURNING *;
+        RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
         $QUERY$,
         queue_name, queue_name
     );
@@ -85,7 +85,7 @@ BEGIN
               read_ct = read_ct + 1
           FROM cte
           WHERE t.msg_id=cte.msg_id
-          RETURNING *;
+          RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
           $QUERY$,
           queue_name, queue_name
       );

--- a/sql/pgmq--0.25.0--0.26.0.sql
+++ b/sql/pgmq--0.25.0--0.26.0.sql
@@ -1,6 +1,8 @@
 -- Dropping rust impls
 DROP FUNCTION pgmq.read(text, integer, integer);
 DROP FUNCTION pgmq.read_with_poll(text, integer, integer, integer, integer);
+DROP FUNCTION pgmq.archive(text, bigint);
+DROP FUNCTION pgmq.archive(text, bigint[]);
 
 -- Adding message record type, required for the functions
 CREATE TYPE pgmq.message_record AS (

--- a/sql/pgmq--0.25.0--0.26.0.sql
+++ b/sql/pgmq--0.25.0--0.26.0.sql
@@ -3,6 +3,8 @@ DROP FUNCTION pgmq.read(text, integer, integer);
 DROP FUNCTION pgmq.read_with_poll(text, integer, integer, integer, integer);
 DROP FUNCTION pgmq.archive(text, bigint);
 DROP FUNCTION pgmq.archive(text, bigint[]);
+DROP FUNCTION pgmq.delete(text, bigint);
+DROP FUNCTION pgmq.delete(text, bigint[]);
 
 -- Adding message record type, required for the functions
 CREATE TYPE pgmq.message_record AS (

--- a/sql/pgmq--0.25.0--0.26.0.sql
+++ b/sql/pgmq--0.25.0--0.26.0.sql
@@ -1,18 +1,8 @@
-------------------------------------------------------------
--- Schema, tables, records, privileges, indexes, etc
-------------------------------------------------------------
--- We don't need to create the `pgmq` schema because it is automatically
--- created by postgres due to being declared in extension control file
+-- Dropping rust impls
+DROP FUNCTION pgmq.read(text, integer, integer);
+DROP FUNCTION pgmq.read_with_poll(text, integer, integer, integer, integer);
 
--- Table where queues and metadata about them is stored
-CREATE TABLE pgmq.meta (
-    queue_name VARCHAR UNIQUE NOT NULL,
-    is_partitioned BOOLEAN NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL
-);
-
--- This type has the shape of a message in a queue, and is often returned by
--- pgmq functions that return messages
+-- Adding message record type, required for the functions
 CREATE TYPE pgmq.message_record AS (
     msg_id BIGINT,
     read_ct INTEGER,
@@ -21,23 +11,8 @@ CREATE TYPE pgmq.message_record AS (
     message JSONB
 );
 
--- pg_monitor should have select access to everything in pgmq schema
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1
-    WHERE has_table_privilege('pg_monitor', 'pgmq.meta', 'SELECT')
-  ) THEN
-    EXECUTE 'GRANT SELECT ON pgmq.meta TO pg_monitor';
-  END IF;
-END;
-$$ LANGUAGE plpgsql;
-
-------------------------------------------------------------
--- Functions
-------------------------------------------------------------
--- read
--- reads a number of messages from a queue, setting a visibility timeout on them
+-- Adding PL/pgSQL impls
+-- Copy-pasted from pgrx schema
 CREATE FUNCTION pgmq.read(
     queue_name TEXT,
     vt INTEGER,
@@ -52,13 +27,13 @@ BEGIN
         WITH cte AS
         (
             SELECT msg_id
-            FROM pgmq.q_%s
+            FROM pgmq.queue_%s
             WHERE vt <= clock_timestamp()
             ORDER BY msg_id ASC
             LIMIT $1
             FOR UPDATE SKIP LOCKED
         )
-        UPDATE pgmq.q_%s
+        UPDATE pgmq.queue_%s
         SET
             vt = clock_timestamp() + interval '$2 seconds',
             read_ct = read_ct + 1
@@ -97,13 +72,13 @@ BEGIN
           WITH cte AS
           (
               SELECT msg_id
-              FROM pgmq.q_%s
+              FROM pgmq.queue_%s
               WHERE vt <= clock_timestamp()
               ORDER BY msg_id ASC
               LIMIT $1
               FOR UPDATE SKIP LOCKED
           )
-          UPDATE pgmq.q_%s
+          UPDATE pgmq.queue_%s
           SET
               vt = clock_timestamp() + interval '$2 seconds',
               read_ct = read_ct + 1
@@ -126,3 +101,4 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE plpgsql;
+

--- a/sql/pgmq--0.25.0--0.26.0.sql
+++ b/sql/pgmq--0.25.0--0.26.0.sql
@@ -37,15 +37,15 @@ BEGIN
         )
         UPDATE pgmq.q_%s m
         SET
-            vt = clock_timestamp() + interval '$2 seconds',
+            vt = clock_timestamp() + interval '%s seconds',
             read_ct = read_ct + 1
         FROM cte
         WHERE m.msg_id = cte.msg_id
         RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
         $QUERY$,
-        queue_name, queue_name
+        queue_name, queue_name, vt
     );
-    RETURN QUERY EXECUTE sql USING qty, vt;
+    RETURN QUERY EXECUTE sql USING qty;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -81,17 +81,17 @@ BEGIN
           )
           UPDATE pgmq.q_%s t
           SET
-              vt = clock_timestamp() + interval '$2 seconds',
+              vt = clock_timestamp() + interval '%s seconds',
               read_ct = read_ct + 1
           FROM cte
           WHERE t.msg_id=cte.msg_id
           RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
           $QUERY$,
-          queue_name, queue_name
+          queue_name, queue_name, vt
       );
 
       FOR r IN
-        EXECUTE sql USING qty, vt
+        EXECUTE sql USING qty
       LOOP
         RETURN NEXT r;
       END LOOP;
@@ -153,6 +153,52 @@ BEGIN
         RETURNING msg_id;
         $QUERY$,
         queue_name, queue_name
+    );
+    RETURN QUERY EXECUTE sql USING msg_id;
+END;
+$$ LANGUAGE plpgsql;
+
+---- delete
+---- deletes a message id from the queue permanently
+CREATE FUNCTION pgmq.delete(
+    queue_name TEXT,
+    msg_id BIGINT
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+    sql TEXT;
+    result BIGINT;
+BEGIN
+    sql := FORMAT(
+        $QUERY$
+        DELETE FROM pgmq.q_%s
+        WHERE msg_id = $1
+        RETURNING msg_id
+        $QUERY$,
+        queue_name
+    );
+    EXECUTE sql USING msg_id INTO result;
+    RETURN NOT (result IS NULL);
+END;
+$$ LANGUAGE plpgsql;
+
+---- delete
+---- deletes an array of message ids from the queue permanently
+CREATE FUNCTION pgmq.delete(
+    queue_name TEXT,
+    msg_id BIGINT[]
+)
+RETURNS SETOF BIGINT AS $$
+DECLARE
+    sql TEXT;
+BEGIN
+    sql := FORMAT(
+        $QUERY$
+        DELETE FROM pgmq.q_%s
+        WHERE msg_id = ANY($1)
+        RETURNING msg_id
+        $QUERY$,
+        queue_name
     );
     RETURN QUERY EXECUTE sql USING msg_id;
 END;

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,8 +14,6 @@ use pgmq_core::{
     util::check_input,
 };
 
-use std::time::Duration;
-
 #[pg_extern(name = "drop_queue")]
 fn pgmq_drop_queue(
     queue_name: String,
@@ -383,7 +381,6 @@ fn pgmq_set_vt(
 #[pg_schema]
 mod tests {
     use super::*;
-    use pgmq_core::types::ARCHIVE_PREFIX;
 
     #[pg_test]
     fn test_create_non_partitioned() {
@@ -472,97 +469,6 @@ mod tests {
         .expect("SQL select failed");
         assert_eq!(init_count.unwrap(), 0);
     }
-
-    //#[pg_test]
-    //fn test_archive() {
-    //    let qname = r#"test_archive"#;
-    //    let _ = pgmq_create_non_partitioned(&qname).unwrap();
-    //    // no messages in the queue
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 0);
-    //    // no messages in queue archive
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{ARCHIVE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 0);
-    //    // put a message on the queue
-    //    let msg_id = pgmq_send(&qname, pgrx::JsonB(serde_json::json!({"x":"y"})), 0).unwrap();
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 1);
-
-    //    // archive the message
-    //    let archived = pgmq_archive(&qname, msg_id.unwrap()).unwrap().unwrap();
-    //    assert!(archived);
-    //    // should be no messages left on the queue table
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 0);
-    //    // but one on the archive table
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{ARCHIVE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 1);
-    //}
-
-    //#[pg_test]
-    //fn test_archive_batch() {
-    //    let qname = r#"test_archive_batch"#;
-    //    let _ = pgmq_create_non_partitioned(&qname).unwrap();
-    //    // no messages in the queue
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 0);
-    //    // no messages in queue archive
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{ARCHIVE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 0);
-    //    // put messages on the queue
-    //    let msg_id1 = pgmq_send(&qname, pgrx::JsonB(serde_json::json!({"x":1})), 0)
-    //        .unwrap()
-    //        .unwrap();
-    //    let msg_id2 = pgmq_send(&qname, pgrx::JsonB(serde_json::json!({"x":2})), 0)
-    //        .unwrap()
-    //        .unwrap();
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 2);
-
-    //    // archive the message. The first two exist so should return true, the
-    //    // last one doesn't so should return false.
-    //    let mut archived = pgmq_archive_batch(&qname, vec![msg_id1, msg_id2, -1]).unwrap();
-    //    assert!(archived.next().unwrap().0);
-    //    assert!(archived.next().unwrap().0);
-    //    assert!(!archived.next().unwrap().0);
-
-    //    // should be no messages left on the queue table
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 0);
-    //    // but two on the archive table
-    //    let retval = Spi::get_one::<i64>(&format!(
-    //        "SELECT count(*) FROM {PGMQ_SCHEMA}.{ARCHIVE_PREFIX}_{qname}"
-    //    ))
-    //    .expect("SQL select failed");
-    //    assert_eq!(retval.unwrap(), 2);
-    //}
 
     #[pg_test]
     fn test_validate_same_type() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ pub mod api;
 pub mod errors;
 pub mod metrics;
 pub mod partition;
-pub mod util;
 pub mod removed_functions;
+pub mod util;
 
 use crate::errors::PgmqExtError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod errors;
 pub mod metrics;
 pub mod partition;
 pub mod util;
+pub mod removed_functions;
 
 use crate::errors::PgmqExtError;
 

--- a/src/removed_functions.rs
+++ b/src/removed_functions.rs
@@ -1,8 +1,21 @@
 use pgrx::prelude::*;
 
 // We need to keep exposing linkable wrappers for old, removed functions. This
-// is required so that transitional version upgrades work as expected
-#[pg_extern(sql="")]
-pub  fn pgmq_read() {}
-#[pg_extern(sql="")]
+// is required so that transitory version upgrades work as expected.
+//
+// For example, assume the following update chain:
+// 0.22 -> 0.23 -> 0.24 -> 0.25 -> 0.26
+// In the version 0.23, `pgmq_archive` was added. But if the user has the dynamic
+// library from version 0.26, the transitory update from 0.22 to 0.23 won't work
+// as postgres can see that `pgmq_archive` isn't available in the dynamic library.
+// For this reason, we need to keep `pgmq_archive` in the dynamic library forever
+// to keep update compatibility.
+//
+#[pg_extern(sql = "")]
+pub fn pgmq_read() {}
+#[pg_extern(sql = "")]
 pub fn pgmq_read_with_poll() {}
+#[pg_extern(sql = "")]
+pub fn pgmq_archive() {}
+#[pg_extern(sql = "")]
+pub fn pgmq_archive_batch() {}

--- a/src/removed_functions.rs
+++ b/src/removed_functions.rs
@@ -1,0 +1,8 @@
+use pgrx::prelude::*;
+
+// We need to keep exposing linkable wrappers for old, removed functions. This
+// is required so that transitional version upgrades work as expected
+#[pg_extern(sql="")]
+pub  fn pgmq_read() {}
+#[pg_extern(sql="")]
+pub fn pgmq_read_with_poll() {}

--- a/src/removed_functions.rs
+++ b/src/removed_functions.rs
@@ -19,3 +19,7 @@ pub fn pgmq_read_with_poll() {}
 pub fn pgmq_archive() {}
 #[pg_extern(sql = "")]
 pub fn pgmq_archive_batch() {}
+#[pg_extern(sql = "")]
+pub fn pgmq_delete() {}
+#[pg_extern(sql = "")]
+pub fn pgmq_delete_batch() {}

--- a/src/sql_src.sql
+++ b/src/sql_src.sql
@@ -58,11 +58,12 @@ BEGIN
             LIMIT $1
             FOR UPDATE SKIP LOCKED
         )
-        UPDATE pgmq.q_%s
+        UPDATE pgmq.q_%s m
         SET
             vt = clock_timestamp() + interval '$2 seconds',
             read_ct = read_ct + 1
-        WHERE msg_id in (select msg_id from cte)
+        FROM cte
+        WHERE m.msg_id = cte.msg_id
         RETURNING *;
         $QUERY$,
         queue_name, queue_name

--- a/src/sql_src.sql
+++ b/src/sql_src.sql
@@ -64,7 +64,7 @@ BEGIN
             read_ct = read_ct + 1
         FROM cte
         WHERE m.msg_id = cte.msg_id
-        RETURNING *;
+        RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
         $QUERY$,
         queue_name, queue_name
     );
@@ -110,7 +110,7 @@ BEGIN
               read_ct = read_ct + 1
           FROM cte
           WHERE m.msg_id = cte.msg_id
-          RETURNING *;
+          RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
           $QUERY$,
           queue_name, queue_name
       );

--- a/src/sql_src.sql
+++ b/src/sql_src.sql
@@ -103,11 +103,12 @@ BEGIN
               LIMIT $1
               FOR UPDATE SKIP LOCKED
           )
-          UPDATE pgmq.q_%s
+          UPDATE pgmq.q_%s m
           SET
               vt = clock_timestamp() + interval '$2 seconds',
               read_ct = read_ct + 1
-          WHERE msg_id in (select msg_id from cte)
+          FROM cte
+          WHERE m.msg_id = cte.msg_id
           RETURNING *;
           $QUERY$,
           queue_name, queue_name

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -16,7 +16,7 @@ struct MetricsRow {
 }
 
 #[allow(dead_code)]
-#[derive(FromRow,Debug)]
+#[derive(FromRow, Debug)]
 struct QueueMeta {
     queue_name: String,
 }
@@ -329,9 +329,9 @@ async fn test_read_read_with_poll() {
     let queue_name = format!("test_read_{test_num}");
 
     // Creating queue
-    sqlx::query(
-        &format!("select * from {PGMQ_SCHEMA}.create('{queue_name}')")
-    )
+    sqlx::query(&format!(
+        "select * from {PGMQ_SCHEMA}.create('{queue_name}')"
+    ))
     .execute(&conn)
     .await
     .unwrap();
@@ -380,7 +380,6 @@ async fn test_read_read_with_poll() {
     assert_eq!(read_batch3[0].get::<i64, usize>(0), msg_id1);
 }
 
-
 #[tokio::test]
 async fn test_partitioned_delete() {
     let conn = init_database().await;
@@ -398,16 +397,16 @@ async fn test_partitioned_delete() {
         .await
         .unwrap();
 
-    let create_result = sqlx::query(
-            &format!("select *
+    let create_result = sqlx::query(&format!(
+        "select *
                      from {PGMQ_SCHEMA}.create_partitioned(
                          '{queue_name}',
                          '{partition_interval}',
                          '{retention_interval}'
-                     )")
-        )
-        .execute(&conn)
-        .await;
+                     )"
+    ))
+    .execute(&conn)
+    .await;
 
     assert!(create_result.is_err());
 
@@ -417,16 +416,16 @@ async fn test_partitioned_delete() {
         .await
         .unwrap();
 
-    let create_result = sqlx::query(
-            &format!("select *
+    let create_result = sqlx::query(&format!(
+        "select *
                      from {PGMQ_SCHEMA}.create_partitioned(
                          '{queue_name}',
                          '{partition_interval}',
                          '{retention_interval}'
-                     )")
-        )
-        .execute(&conn)
-        .await;
+                     )"
+    ))
+    .execute(&conn)
+    .await;
 
     assert!(create_result.is_ok());
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -438,16 +438,19 @@ async fn test_partitioned_delete() {
     assert!(create_result.is_ok());
 
     // queue shows up in list queues
-    // TODO: fix
-    //let queue_meta = sqlx::query_as::<_, QueueMeta>(&format!(
-    //    "select queue_name from {PGMQ_SCHEMA}.list_queues();"
-    //))
-    //.fetch_all(&conn)
-    //.await
-    //.expect("failed to list queues")
-    //.iter()
-    //.find(|m| m.queue_name == queue_name);
-    //assert!(queue_meta.is_some());
+    let list_queues_result = sqlx::query_as::<_, QueueMeta>(&format!(
+        "select queue_name from {PGMQ_SCHEMA}.list_queues();"
+    ))
+    .fetch_all(&conn)
+    .await;
+
+    match list_queues_result {
+        Ok(qm) => {
+            let q = qm.iter().find(|m| m.queue_name == queue_name);
+            assert!(q.is_some());
+        }
+        Err(err) => panic!("{}", err),
+    }
 
     // Sending 3 messages to the queue
     let msg_id1 = send_sample_message(&queue_name, &conn).await;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,4 @@
+use pgmq_core::types::{ARCHIVE_PREFIX, PGMQ_SCHEMA, QUEUE_PREFIX};
 use pgmq_core::util::{conn_options, fetch_one_message};
 use rand::Rng;
 use sqlx::postgres::PgPoolOptions;
@@ -14,8 +15,7 @@ async fn connect(url: &str) -> Pool<Postgres> {
         .expect("failed to connect to pg")
 }
 
-#[tokio::test]
-async fn test_lifecycle() {
+async fn init_database() -> Pool<Postgres> {
     let username = whoami::username();
 
     let conn00 = connect(&format!(
@@ -32,38 +32,55 @@ async fn test_lifecycle() {
         "postgres://{username}:postgres@localhost:28815/pgmq_test"
     ))
     .await;
-    let mut rng = rand::thread_rng();
-    let test_num = rng.gen_range(0..100000);
 
     // DROP EXTENSION
     // requires pg_partman to already be installed in the instance
-    let _ = sqlx::query("DROP EXTENSION IF EXISTS pgmq")
+    let _ = sqlx::query("DROP EXTENSION IF EXISTS pgmq CASCADE")
         .execute(&conn)
         .await
         .expect("failed to drop extension");
 
     // CREATE EXTENSION
-    let _ = sqlx::query("CREATE EXTENSION pgmq cascade")
+    let _ = sqlx::query("CREATE EXTENSION pgmq")
         .execute(&conn)
         .await
         .expect("failed to create extension");
 
-    // CREATE with default retention and partition strategy
-    let test_default_queue = format!("test_default_{test_num}");
-    let _ = sqlx::query(&format!("SELECT pgmq.create('{test_default_queue}');"))
+    // CREATE EXTENSION
+    let _ = sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_partman")
         .execute(&conn)
         .await
-        .expect("failed to create queue");
+        .expect("failed to create extension");
+
+    conn
+}
+
+#[tokio::test]
+async fn test_lifecycle() {
+    let conn = init_database().await;
+    let mut rng = rand::thread_rng();
+    let test_num = rng.gen_range(0..100000);
+
+    // CREATE with default retention and partition strategy
+    let test_default_queue = format!("test_default_{test_num}");
+    let _ = sqlx::query(&format!(
+        "SELECT {PGMQ_SCHEMA}.create('{test_default_queue}');"
+    ))
+    .execute(&conn)
+    .await
+    .expect("failed to create queue");
 
     // creating a queue must be idempotent
     // create with same name again, must be no  error
-    let _ = sqlx::query(&format!("SELECT pgmq.create('{test_default_queue}');"))
-        .execute(&conn)
-        .await
-        .expect("failed to create queue");
+    let _ = sqlx::query(&format!(
+        "SELECT {PGMQ_SCHEMA}.create('{test_default_queue}');"
+    ))
+    .execute(&conn)
+    .await
+    .expect("failed to create queue");
 
     let msg_id = sqlx::query(&format!(
-        "SELECT * from pgmq.send('{test_default_queue}', '{{\"hello\": \"world\"}}');"
+        "SELECT * from {PGMQ_SCHEMA}.send('{test_default_queue}', '{{\"hello\": \"world\"}}');"
     ))
     .fetch_one(&conn)
     .await
@@ -73,7 +90,7 @@ async fn test_lifecycle() {
 
     // read message
     // vt=2, limit=1
-    let query = &format!("SELECT * from pgmq.read('{test_default_queue}', 2, 1);");
+    let query = &format!("SELECT * from {PGMQ_SCHEMA}.read('{test_default_queue}', 2, 1);");
 
     let message = fetch_one_message::<serde_json::Value>(query, &conn)
         .await
@@ -82,7 +99,8 @@ async fn test_lifecycle() {
     assert_eq!(message.msg_id, 1);
 
     // set VT to in 10 seconds
-    let query = &format!("SELECT * from pgmq.set_vt('{test_default_queue}', {msg_id}, 5);");
+    let query =
+        &format!("SELECT * from {PGMQ_SCHEMA}.set_vt('{test_default_queue}', {msg_id}, 5);");
     let message = fetch_one_message::<serde_json::Value>(query, &conn)
         .await
         .expect("failed reading message")
@@ -93,14 +111,15 @@ async fn test_lifecycle() {
     assert!(message.vt > now + chrono::Duration::seconds(4));
 
     // read again, assert no messages because we just set VT to the future
-    let query = &format!("SELECT * from pgmq.read('{test_default_queue}', 2, 1);");
+    let query = &format!("SELECT * from {PGMQ_SCHEMA}.read('{test_default_queue}', 2, 1);");
     let message = fetch_one_message::<serde_json::Value>(query, &conn)
         .await
         .expect("failed reading message");
     assert!(message.is_none());
 
     // read again, now using poll to block until message is ready
-    let query = &format!("SELECT * from pgmq.read_with_poll('{test_default_queue}', 10, 1, 10);");
+    let query =
+        &format!("SELECT * from {PGMQ_SCHEMA}.read_with_poll('{test_default_queue}', 10, 1, 10);");
     let message = fetch_one_message::<serde_json::Value>(query, &conn)
         .await
         .expect("failed reading message")
@@ -108,7 +127,8 @@ async fn test_lifecycle() {
     assert_eq!(message.msg_id, 1);
 
     // after reading it, set VT to now
-    let query = &format!("SELECT * from pgmq.set_vt('{test_default_queue}', {msg_id}, 0);");
+    let query =
+        &format!("SELECT * from {PGMQ_SCHEMA}.set_vt('{test_default_queue}', {msg_id}, 0);");
     let message = fetch_one_message::<serde_json::Value>(query, &conn)
         .await
         .expect("failed reading message")
@@ -116,7 +136,7 @@ async fn test_lifecycle() {
     assert_eq!(message.msg_id, 1);
 
     // read again, should have msg_id 1 again
-    let query = &format!("SELECT * from pgmq.read('{test_default_queue}', 2, 1);");
+    let query = &format!("SELECT * from {PGMQ_SCHEMA}.read('{test_default_queue}', 2, 1);");
     let message = fetch_one_message::<serde_json::Value>(query, &conn)
         .await
         .expect("failed reading message")
@@ -125,22 +145,18 @@ async fn test_lifecycle() {
 
     // send a batch of 2 messages
     let batch_queue = format!("test_batch_{test_num}");
-    let _ = sqlx::query(&format!("SELECT pgmq.create('{batch_queue}');"))
+    let _ = sqlx::query(&format!("SELECT {PGMQ_SCHEMA}.create('{batch_queue}');"))
         .execute(&conn)
         .await
         .expect("failed to create queue");
     let msg_ids = sqlx::query(
-        &format!("select pgmq.send_batch('{batch_queue}', ARRAY['{{\"hello\": \"world_0\"}}'::jsonb, '{{\"hello\": \"world_1\"}}'::jsonb])")
+        &format!("select {PGMQ_SCHEMA}.send_batch('{batch_queue}', ARRAY['{{\"hello\": \"world_0\"}}'::jsonb, '{{\"hello\": \"world_1\"}}'::jsonb])")
     )
     .fetch_all(&conn).await.expect("failed to send batch");
     assert_eq!(msg_ids.len(), 2);
     assert_eq!(msg_ids[0].get::<i64, usize>(0), 1);
     assert_eq!(msg_ids[1].get::<i64, usize>(0), 2);
-    let rowcount: i64 = sqlx::query_scalar(&format!("SELECT count(*) from pgmq.q_{batch_queue}"))
-        .fetch_one(&conn)
-        .await
-        .expect("failed to get rowcount");
-    assert_eq!(rowcount, 2);
+    assert_eq!(get_queue_size(&batch_queue, &conn).await, 2);
 
     let _ = sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_partman")
         .execute(&conn)
@@ -149,7 +165,7 @@ async fn test_lifecycle() {
 
     // CREATE with 5 seconds per partition, 10 seconds retention
     let test_duration_queue = format!("test_duration_{test_num}");
-    let q = format!("SELECT pgmq.create_partitioned('{test_duration_queue}'::text, '5 seconds'::text, '10 seconds'::text);");
+    let q = format!("SELECT {PGMQ_SCHEMA}.create_partitioned('{test_duration_queue}'::text, '5 seconds'::text, '10 seconds'::text);");
     let _ = sqlx::query(&q)
         .execute(&conn)
         .await
@@ -158,7 +174,7 @@ async fn test_lifecycle() {
     // CREATE with 10 messages per partition, 20 messages retention
     let test_numeric_queue = format!("test_numeric_{test_num}");
     let _ = sqlx::query(&format!(
-        "SELECT pgmq.create_partitioned('{test_numeric_queue}'::text, '10'::text, '20'::text);"
+        "SELECT {PGMQ_SCHEMA}.create_partitioned('{test_numeric_queue}'::text, '10'::text, '20'::text);"
     ))
     .execute(&conn)
     .await
@@ -177,7 +193,7 @@ async fn test_lifecycle() {
 
     // get metrics
     let rows = sqlx::query_as::<_, MetricsRow>(&format!(
-        "SELECT * from pgmq.metrics('{test_duration_queue}'::text);"
+        "SELECT * from {PGMQ_SCHEMA}.metrics('{test_duration_queue}'::text);"
     ))
     .fetch_all(&conn)
     .await
@@ -185,10 +201,11 @@ async fn test_lifecycle() {
     assert_eq!(rows.len(), 1);
 
     // get metrics all
-    let rows = sqlx::query_as::<_, MetricsRow>(&format!("SELECT * from pgmq.metrics_all();"))
-        .fetch_all(&conn)
-        .await
-        .expect("failed creating numeric interval queue");
+    let rows =
+        sqlx::query_as::<_, MetricsRow>(&format!("SELECT * from {PGMQ_SCHEMA}.metrics_all();"))
+            .fetch_all(&conn)
+            .await
+            .expect("failed creating numeric interval queue");
     assert!(rows.len() > 1);
 
     // delete all the queues
@@ -200,30 +217,37 @@ async fn test_lifecycle() {
 
     // delete partitioned queues
     for queue in [test_duration_queue, test_numeric_queue].iter() {
-        sqlx::query(&format!("select pgmq.drop_queue('{}', true);", &queue))
-            .execute(&conn)
-            .await
-            .expect("failed to drop partitioned queues");
+        sqlx::query(&format!(
+            "select {PGMQ_SCHEMA}.drop_queue('{}', true);",
+            &queue
+        ))
+        .execute(&conn)
+        .await
+        .expect("failed to drop partitioned queues");
     }
 
-    let queues = sqlx::query_as::<_, QueueMeta>("select queue_name from pgmq.list_queues();")
-        .fetch_all(&conn)
-        .await
-        .expect("failed to list queues");
+    let queues = sqlx::query_as::<_, QueueMeta>(&format!(
+        "select queue_name from {PGMQ_SCHEMA}.list_queues();"
+    ))
+    .fetch_all(&conn)
+    .await
+    .expect("failed to list queues");
 
     // drop the rest of the queues
     for queue in queues {
         let q = queue.queue_name;
-        sqlx::query(&format!("select pgmq.drop_queue('{}');", &q))
+        sqlx::query(&format!("select {PGMQ_SCHEMA}.drop_queue('{}');", &q))
             .execute(&conn)
             .await
             .expect("failed to drop standard queues");
     }
 
-    let queues = sqlx::query_as::<_, QueueMeta>("select queue_name from pgmq.list_queues();")
-        .fetch_all(&conn)
-        .await
-        .expect("failed to list queues");
+    let queues = sqlx::query_as::<_, QueueMeta>(&format!(
+        "select queue_name from {PGMQ_SCHEMA}.list_queues();"
+    ))
+    .fetch_all(&conn)
+    .await
+    .expect("failed to list queues");
     assert!(queues.is_empty());
 
     #[allow(dead_code)]
@@ -237,4 +261,106 @@ async fn test_lifecycle() {
             .await
             .expect("failed to query partman config");
     assert_eq!(partmans.num_partmans, 0);
+}
+
+#[tokio::test]
+async fn test_archive() {
+    let conn = init_database().await;
+    let mut rng = rand::thread_rng();
+    let test_num = rng.gen_range(0..100000);
+
+    let queue_name = format!("test_archive_{test_num}");
+
+    let _ = sqlx::query(&format!("SELECT {PGMQ_SCHEMA}.create('{queue_name}');"))
+        .execute(&conn)
+        .await
+        .expect("failed to create queue");
+
+    // no messages in the queue
+    assert_eq!(get_queue_size(&queue_name, &conn).await, 0);
+
+    // no messages in queue archive
+    assert_eq!(get_archive_size(&queue_name, &conn).await, 0);
+
+    // put messages on the queue
+    let msg_id1 = sqlx::query(&format!(
+        "SELECT * FROM {PGMQ_SCHEMA}.send('{queue_name}', '1')"
+    ))
+    .fetch_one(&conn)
+    .await
+    .expect("failed to push message")
+    .get::<i64, usize>(0);
+
+    let msg_id2 = sqlx::query(&format!(
+        "SELECT * FROM {PGMQ_SCHEMA}.send('{queue_name}', '2')"
+    ))
+    .fetch_one(&conn)
+    .await
+    .expect("failed to push message")
+    .get::<i64, usize>(0);
+
+    // two messages in the queue
+    assert_eq!(get_queue_size(&queue_name, &conn).await, 2);
+
+    // archive the message. The first two exist so the id should be returned, the
+    // last one doesn't
+    let archived = sqlx::query(&format!(
+        "SELECT * FROM {PGMQ_SCHEMA}.archive('{queue_name}', ARRAY[{msg_id1}, {msg_id2}])"
+    ))
+    .fetch_all(&conn)
+    .await
+    .expect("failed to archive");
+
+    assert_eq!(archived.len(), 2);
+    assert_eq!(archived[0].get::<i64, usize>(0), 1);
+    assert_eq!(archived[1].get::<i64, usize>(0), 2);
+
+    // should be no messages left on the queue table
+    assert_eq!(get_queue_size(&queue_name, &conn).await, 0);
+
+    // should be two messages in archive
+    assert_eq!(get_archive_size(&queue_name, &conn).await, 2);
+
+    let msg_id3 = sqlx::query(&format!(
+        "SELECT * FROM {PGMQ_SCHEMA}.send('{queue_name}', '2')"
+    ))
+    .fetch_one(&conn)
+    .await
+    .expect("failed to push message")
+    .get::<i64, usize>(0);
+
+    assert_eq!(get_queue_size(&queue_name, &conn).await, 1);
+
+    let archived_single = sqlx::query(&format!(
+        "SELECT * FROM {PGMQ_SCHEMA}.archive('{queue_name}', {msg_id3})"
+    ))
+    .fetch_one(&conn)
+    .await
+    .expect("failed to archive")
+    .get::<bool, usize>(0);
+
+    assert_eq!(archived_single, true);
+
+    assert_eq!(get_queue_size(&queue_name, &conn).await, 0);
+    assert_eq!(get_archive_size(&queue_name, &conn).await, 3);
+}
+
+async fn get_queue_size(queue_name: &String, conn: &Pool<Postgres>) -> i64 {
+    sqlx::query(&format!(
+        "SELECT count(*) FROM {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{queue_name}"
+    ))
+    .fetch_one(conn)
+    .await
+    .expect("failed get queue size")
+    .get::<i64, usize>(0)
+}
+
+async fn get_archive_size(queue_name: &String, conn: &Pool<Postgres>) -> i64 {
+    sqlx::query(&format!(
+        "SELECT count(*) FROM {PGMQ_SCHEMA}.{ARCHIVE_PREFIX}_{queue_name}"
+    ))
+    .fetch_one(conn)
+    .await
+    .expect("failed get queue size")
+    .get::<i64, usize>(0)
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -78,6 +78,8 @@ async fn init_database() -> Pool<Postgres> {
     conn
 }
 
+// Integration tests are ignored by default
+#[ignore]
 #[tokio::test]
 async fn test_lifecycle() {
     let conn = init_database().await;
@@ -257,6 +259,8 @@ async fn test_lifecycle() {
     assert!(queues.is_empty());
 }
 
+// Integration tests are ignored by default
+#[ignore]
 #[tokio::test]
 async fn test_archive() {
     let conn = init_database().await;
@@ -320,6 +324,8 @@ async fn test_archive() {
     assert_eq!(get_archive_size(&queue_name, &conn).await, 3);
 }
 
+// Integration tests are ignored by default
+#[ignore]
 #[tokio::test]
 async fn test_read_read_with_poll() {
     let conn = init_database().await;
@@ -380,6 +386,8 @@ async fn test_read_read_with_poll() {
     assert_eq!(read_batch3[0].get::<i64, usize>(0), msg_id1);
 }
 
+// Integration tests are ignored by default
+#[ignore]
 #[tokio::test]
 async fn test_partitioned_delete() {
     let conn = init_database().await;


### PR DESCRIPTION
Rewrites:
- read
- read_with_poll
- archive_batch
- archive
- delete_batch
- delete

Breaking change: instead of returning a SETOF boolean, archive_batch and delete_batch now return SETOF bigint of the message ids they deleted.