### PR TITLE
Faster query with a simpler plan by joining with the CTE instead of making IN query

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Core functionality shared between the PGMQ Rust SDK and Postgres Extension"

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -219,11 +219,12 @@ pub fn read(name: &str, vt: i32, limit: i32) -> Result<String, PgmqError> {
             LIMIT {limit}
             FOR UPDATE SKIP LOCKED
         )
-    UPDATE {PGMQ_SCHEMA}.{TABLE_PREFIX}_{name}
+    UPDATE {PGMQ_SCHEMA}.{TABLE_PREFIX}_{name} t
     SET
         vt = clock_timestamp() + interval '{vt} seconds',
         read_ct = read_ct + 1
-    WHERE msg_id in (select msg_id from cte)
+    FROM cte
+    WHERE t.msg_id=cte.msg_id
     RETURNING *;
     "
     ))


### PR DESCRIPTION
I set a benchmark doing 200+ updates/second on the queue (using the current behaviour), and ran both queries 1 after the other in a separate session to get their plans. My change removes the `HashAggregate`. The same plan was with LIMIT 10.

Using `PostgreSQL 15.4 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit`.


[limit_1_before.sql.txt](https://github.com/tembo-io/pgmq/files/12565920/limit_1_before.sql.txt)
[limit_1_after.sql.txt](https://github.com/tembo-io/pgmq/files/12565921/limit_1_after.sql.txt)

The limit 10 was done with a bigger queue doing 40 read/s of batch_size=100.

[limit_10.sql.txt](https://github.com/tembo-io/pgmq/files/12565914/limit_10.sql.txt)
