### PR TITLE
ci: lock pg_partman version

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -73,6 +73,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
           git clone https://github.com/pgpartman/pg_partman.git && \
           cd pg_partman && \
+          git checkout v4.7.4 && \
           sudo make install && cd ../
           cp /usr/share/postgresql/14/extension/pg_partman* ~/.pgrx/15.4/pgrx-install/share/postgresql/extension/
           cp /usr/lib/postgresql/14/lib/pg_partman_bgw.so ~/.pgrx/15.4/pgrx-install/lib/postgresql/

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -42,6 +42,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y postgresql-server-dev-14
           git clone https://github.com/pgpartman/pg_partman.git && \
           cd pg_partman && \
+          git checkout v4.7.4 && \
           sudo make install && cd ../
           cp /usr/share/postgresql/14/extension/pg_partman* ~/.pgrx/15.4/pgrx-install/share/postgresql/extension/
           cp /usr/lib/postgresql/14/lib/pg_partman_bgw.so ~/.pgrx/15.4/pgrx-install/lib/postgresql/


### PR DESCRIPTION
pg_partman 5.0.0 was released and it has breaking changes. CI is picking up HEAD.