### PR TITLE
fix: desimplify pgmon permissions for extensionless client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "log",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq-core"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Core functionality shared between the PGMQ Rust SDK and Postgres Extension"

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -308,17 +308,84 @@ pub fn assign(table_name: &str) -> String {
     )
 }
 
-pub fn pg_mon_grant_schema_tables_permission() -> String {
-    format!("GRANT SELECT ON ALL TABLES IN SCHEMA {PGMQ_SCHEMA} TO pg_monitor;")
+fn grant_stmt(table: &str) -> String {
+    let grant_seq = match &table.contains("meta") {
+        true => "".to_string(),
+        false => {
+            format!("    EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';")
+        }
+    };
+    format!(
+        "
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    WHERE has_table_privilege('pg_monitor', '{table}', 'SELECT')
+  ) THEN
+    EXECUTE 'GRANT SELECT ON {table} TO pg_monitor';
+{grant_seq}
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+"
+    )
 }
 
-pub fn pg_mon_grant_schema_seqs_permission() -> String {
-    format!("GRANT SELECT ON ALL SEQUENCES IN SCHEMA {PGMQ_SCHEMA} TO pg_monitor;")
+// pg_monitor needs to query queue metadata
+pub fn grant_pgmon_meta() -> String {
+    let table = format!("{PGMQ_SCHEMA}.meta");
+    grant_stmt(&table)
+}
+
+// pg_monitor needs to query queue tables
+pub fn grant_pgmon_queue(name: CheckedName<'_>) -> Result<String, PgmqError> {
+    let table = format!("{PGMQ_SCHEMA}.{QUEUE_PREFIX}_{name}");
+    Ok(grant_stmt(&table))
+}
+
+pub fn grant_pgmon_queue_seq(name: CheckedName<'_>) -> Result<String, PgmqError> {
+    let table = format!("{PGMQ_SCHEMA}.{QUEUE_PREFIX}_{name}_msg_id_seq");
+    Ok(grant_stmt(&table))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_grant() {
+        let q = grant_stmt("my_table");
+        let expected = "
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    WHERE has_table_privilege('pg_monitor', 'my_table', 'SELECT')
+  ) THEN
+    EXECUTE 'GRANT SELECT ON my_table TO pg_monitor';
+    EXECUTE 'GRANT SELECT ON SEQUENCE my_table_msg_id_seq TO pg_monitor';
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+";
+        assert_eq!(q, expected);
+
+        let q = grant_stmt("meta");
+        let expected = "
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    WHERE has_table_privilege('pg_monitor', 'meta', 'SELECT')
+  ) THEN
+    EXECUTE 'GRANT SELECT ON meta TO pg_monitor';
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+";
+        assert_eq!(q, expected)
+    }
 
     #[test]
     fn test_assign() {

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -312,7 +312,7 @@ fn grant_stmt(table: &str) -> String {
     let grant_seq = match &table.contains("meta") {
         true => "".to_string(),
         false => {
-            format!("    EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';")
+            format!("\n    EXECUTE 'GRANT SELECT ON SEQUENCE {table}_msg_id_seq TO pg_monitor';")
         }
     };
     format!(
@@ -323,8 +323,7 @@ BEGIN
     SELECT 1
     WHERE has_table_privilege('pg_monitor', '{table}', 'SELECT')
   ) THEN
-    EXECUTE 'GRANT SELECT ON {table} TO pg_monitor';
-{grant_seq}
+    EXECUTE 'GRANT SELECT ON {table} TO pg_monitor';{grant_seq}
   END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/tembo-io/pgmq"
 
 [dependencies]
-pgmq_core = { package = "pgmq-core", version = "0.7.0" }
+pgmq_core = { package = "pgmq-core", path = "../core" }
 chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -5,8 +5,7 @@ use pgmq_core::{
     errors::PgmqError,
     query::{
         assign_archive, assign_queue, create_archive, create_archive_index, create_index,
-        create_meta, insert_meta, pg_mon_grant_schema_seqs_permission,
-        pg_mon_grant_schema_tables_permission,
+        create_meta, grant_pgmon_meta, grant_pgmon_queue, grant_pgmon_queue_seq, insert_meta,
     },
     types::{PGMQ_SCHEMA, QUEUE_PREFIX},
     util::CheckedName,
@@ -47,6 +46,7 @@ pub fn init_partitioned_queue_client_only(
     let partition_col = map_partition_col(partition_interval);
     Ok(vec![
         create_meta(),
+        grant_pgmon_meta(),
         create_partitioned_queue(name, partition_col)?,
         assign_queue(name)?,
         create_partitioned_index(name, partition_col)?,
@@ -57,8 +57,8 @@ pub fn init_partitioned_queue_client_only(
         create_partitioned_table(name, partition_col, partition_interval)?,
         insert_meta(name, true, false)?,
         set_retention_config(name, retention_interval)?,
-        pg_mon_grant_schema_tables_permission(),
-        pg_mon_grant_schema_seqs_permission(),
+        grant_pgmon_queue(name)?,
+        grant_pgmon_queue_seq(name)?,
     ])
 }
 


### PR DESCRIPTION
My last PR (#138) would cause issues in the extension-less client, as postgres can error with concurrent `GRANT` statements and my PR increased the likelihood of those happening.