### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ SELECT pgmq.archive('my_queue', 2);
 
 Archive tables have the prefix `a_`:
 ```sql
-SELECT pgmq.a_my_queue;
+SELECT * FROM pgmq.a_my_queue;
 ```
 
 ```text


### PR DESCRIPTION
Update archive view statement to include FROM-clause. The code below shows the error I encountered and subsequent fix.

```
postgres=# SELECT pgmq.a_my_queue;
ERROR:  missing FROM-clause entry for table "pgmq"
LINE 1: SELECT pgmq.a_my_queue;
               ^

postgres=# SELECT * FROM pgmq.a_my_queue;
 msg_id | read_ct |          enqueued_at          |          archived_at          |              vt               |     message
--------+---------+-------------------------------+-------------------------------+-------------------------------+-----------------
      2 |       1 | 2023-10-18 12:10:43.302729+00 | 2023-10-18 12:11:19.739058+00 | 2023-10-18 12:11:21.635924+00 | {"foo": "bar2"}
(1 row)
```