### PR TITLE
Fix timezone error in metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.32.1"
+version = "0.32.2"
 dependencies = [
  "chrono",
  "pgmq-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.32.1"
+version = "0.32.2"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -101,8 +101,12 @@ fn build_summary_query(queue_name: &str) -> String {
         "SELECT * FROM
             (SELECT
                 count(*) as queue_length,
-                (EXTRACT(epoch FROM (SELECT (NOW() at time zone 'utc' -  max(enqueued_at)))))::int as newest_msg_age_sec,
-                (EXTRACT(epoch FROM (SELECT (NOW() at time zone 'utc' -  min(enqueued_at)))))::int as oldest_msg_age_sec,
+                (EXTRACT(epoch FROM (
+                    SELECT (NOW() at time zone 'utc' -  (max(enqueued_at) at time zone 'utc'))
+                )))::int as newest_msg_age_sec,
+                (EXTRACT(epoch FROM (
+                    SELECT (NOW() at time zone 'utc' -  (min(enqueued_at) at time zone 'utc'))
+                )))::int as oldest_msg_age_sec,
                 (NOW() at time zone 'utc')::timestamp at time zone 'utc' as scrape_time
             FROM {fq_table}) as q_summary
         CROSS JOIN


### PR DESCRIPTION
The interval was being calculated from 2 timestamps in different timezones. By shifting them both to UTC, the calculation yields the correct result.

Closes https://github.com/tembo-io/pgmq/issues/147