### PR TITLE
define and run sequential benchmarks

### DIFF
--- a/tembo-pgmq-python/benches/bench.py
+++ b/tembo-pgmq-python/benches/bench.py
@@ -103,6 +103,7 @@ def bench(
         "connection_info": connection_info,
         "duration_seconds": duration_seconds,
         "batch_size": write_batch_size,
+        "message_size_bytes": message_size_bytes,
     }
     for i in range(write_concurrency):
         producer = f"producer_{i}"

--- a/tembo-pgmq-python/benches/log.py
+++ b/tembo-pgmq-python/benches/log.py
@@ -14,7 +14,6 @@ def setup_bench_results(eng, bench_name: str):
             CREATE TABLE "bench_results_{bench_name}"(
                 operation text NULL,
                 duration_sec float8 NULL,
-                msg_ids jsonb NULL,
                 batch_size int8 NULL,
                 epoch float8 NULL
             )
@@ -67,7 +66,6 @@ def setup_bench_results(eng, bench_name: str):
             CREATE TABLE IF NOT EXISTS "event_log_{bench_name}" (
                 operation text NOT NULL,
                 duration_sec numeric NULL,
-                msg_ids jsonb NULL,
                 batch_size numeric NULL,
                 epoch numeric NOT NULL,
                 queue_length numeric NULL

--- a/tembo-pgmq-python/benches/ops.py
+++ b/tembo-pgmq-python/benches/ops.py
@@ -2,10 +2,8 @@ import json
 import logging
 import multiprocessing
 import os
-import subprocess
 import time
 
-import pandas as pd
 import psycopg
 
 logging.basicConfig(level=logging.INFO)
@@ -27,76 +25,72 @@ def produce(
     port = connection_info["port"]
     database = connection_info["database"]
     url = f"postgresql://{username}:{password}@{host}:{port}/{database}"
-    conn = psycopg.connect(url)
-    conn.autocommit = True
-    cur = conn.cursor()
+    with psycopg.connect(url, autocommit=True) as conn:
+        cur = conn.cursor()
 
-    all_results = []
+        all_results = []
 
-    start_time = time.time()
+        start_time = time.time()
 
-    num_msg = 0
-    running_duration = 0
-    last_print_time = time.time()
+        num_msg = 0
+        running_duration = 0
+        last_print_time = time.time()
 
-    payloads = {22: "22B.json", 1000: "1KB.json", 10000: "10KB.json"}
+        payloads = {22: "22B.json", 1000: "1KB.json", 10000: "10KB.json"}
 
-    # get specified message payload by size
-    # just fail hard if its invalid value
-    message_file = payloads[message_size_bytes]
+        # get specified message payload by size
+        # just fail hard if its invalid value
+        message_file = payloads[message_size_bytes]
 
-    with open(f"benches/payloads/{message_file}", "r") as f:
-        message = json.dumps(json.load(f))
+        with open(f"benches/payloads/{message_file}", "r") as f:
+            message = json.dumps(json.load(f))
 
-    if batch_size > 1:
-        # create array of messages when in batch mode
-        msg = [message for _ in range(batch_size)]
-        message = msg
-
-    while running_duration < duration_seconds:
-        send_start = time.perf_counter()
         if batch_size > 1:
-            cur.execute(
-                "select * from pgmq.send_batch(%s, %s::jsonb[])",
-                (
-                    queue_name,
-                    message,
-                ),
+            # create array of messages when in batch mode
+            msg = [message for _ in range(batch_size)]
+            message = msg
+
+        while running_duration < duration_seconds:
+            send_start = time.perf_counter()
+            if batch_size > 1:
+                cur.execute(
+                    "select * from pgmq.send_batch(%s, %s::jsonb[])",
+                    (
+                        queue_name,
+                        message,
+                    ),
+                )
+
+            else:
+                cur.execute(
+                    "select * from pgmq.send(%s, %s::jsonb)",
+                    (
+                        queue_name,
+                        message,
+                    ),
+                )
+            send_duration = time.perf_counter() - send_start
+            all_results.append(
+                # {
+                #     "operation": "write",
+                #     "duration": send_duration,
+                #     "batch_size": batch_size,
+                #     "epoch": time.time(),
+                # }
+                ("write", send_duration, batch_size, time.time())
             )
+            num_msg += 1
+            running_duration = int(time.time() - start_time)
+            # log every 5 seconds
+            if time.time() - last_print_time >= 5:
+                last_print_time = time.time()
+                logging.debug(f"pid: {pid}, total_sent: {num_msg}, {running_duration} / {duration_seconds} seconds")
 
-        else:
-            cur.execute(
-                "select * from pgmq.send(%s, %s::jsonb)",
-                (
-                    queue_name,
-                    message,
-                ),
-            )
-        msg_id = [x[0] for x in cur.fetchall()]
-        send_duration = time.perf_counter() - send_start
-        all_results.append(
-            {
-                "operation": "write",
-                "duration": send_duration,
-                "batch_size": batch_size,
-                "epoch": time.time(),
-            }
-        )
-        num_msg += 1
-        running_duration = int(time.time() - start_time)
-        # log every 5 seconds
-        if time.time() - last_print_time >= 5:
-            last_print_time = time.time()
-            logging.debug(f"pid: {pid}, total_sent: {num_msg}, {running_duration} / {duration_seconds} seconds")
+        logging.debug(f"pid: {pid}, total_sent: {num_msg}, {running_duration} / {duration_seconds} seconds")
 
-    logging.debug(f"pid: {pid}, total_sent: {num_msg}, {running_duration} / {duration_seconds} seconds")
-
-    with cur.copy(f"COPY bench_results_{queue_name} FROM STDIN") as copy:
-        for record in all_results:
-            copy.write_row(tuple(record.values()))
-
-    cur.close()
-    conn.close()
+        with cur.copy(f"COPY bench_results_{queue_name} FROM STDIN") as copy:
+            for record in all_results:
+                copy.write_row(record)
     logging.info(f"producer complete, pid: {pid}")
 
 
@@ -112,74 +106,69 @@ def consume(queue_name: str, connection_info: dict, pattern: str = "delete", bat
     port = connection_info["port"]
     database = connection_info["database"]
     url = f"postgresql://{username}:{password}@{host}:{port}/{database}"
-    conn = psycopg.connect(url)
-    cur = conn.cursor()
+    with psycopg.connect(url, autocommit=True) as conn:
+        cur = conn.cursor()
 
-    conn.autocommit = True
+        results = []
+        no_message_timeout = 0
+        while no_message_timeout < 20:
+            # stmt = f"select * from pgmq.read('{queue_name}', 1, 1)"
+            read_start = time.perf_counter()
+            cur.execute("select * from pgmq.read(%s, 1, %s)", (queue_name, batch_size))
+            read_duration = time.perf_counter() - read_start
+            message = cur.fetchall()
 
-    cur = conn.cursor()
-    results = []
-    no_message_timeout = 0
-    while no_message_timeout < 20:
-        # stmt = f"select * from pgmq.read('{queue_name}', 1, 1)"
-        read_start = time.perf_counter()
-        cur.execute("select * from pgmq.read(%s, 1, %s)", (queue_name, batch_size))
-        read_duration = time.perf_counter() - read_start
-        message = cur.fetchall()
+            if len(message) == 0:
+                no_message_timeout += 1
+                if no_message_timeout > 2:
+                    logging.debug(f"No messages for {no_message_timeout} consecutive reads")
+                time.sleep(0.500)
+                continue
+            else:
+                no_message_timeout = 0
 
-        if len(message) == 0:
-            no_message_timeout += 1
-            if no_message_timeout > 2:
-                logging.debug(f"No messages for {no_message_timeout} consecutive reads")
-            time.sleep(0.500)
-            continue
-        else:
-            no_message_timeout = 0
+            msg_ids = [x[0] for x in message]
 
-        msg_ids = [x[0] for x in message]
+            num_consumed = int(len(msg_ids))
 
-        num_consumed = int(len(msg_ids))
+            results.append(
+                # {
+                #     "operation": "read",
+                #     "duration_sec": read_duration,
+                #     "batch_size": num_consumed,
+                #     "epoch": time.time(),
+                # }
+                ("read", read_duration, num_consumed, time.time())
+            )
 
-        results.append(
-            {
-                "operation": "read",
-                "duration_sec": read_duration,
-                "batch_size": num_consumed,
-                "epoch": time.time(),
-            }
-        )
+            archive_start = time.perf_counter()
+            if pattern == "archive":
+                cur.execute("select * from pgmq.archive(%s, %s);", [queue_name, msg_ids])
+            else:
+                cur.execute("select * from pgmq.delete(%s, %s);", [queue_name, msg_ids])
 
-        archive_start = time.perf_counter()
-        if pattern == "archive":
-            cur.execute("select * from pgmq.archive(%s, %s);", [queue_name, msg_ids])
-        else:
-            cur.execute("select * from pgmq.delete(%s, %s);", [queue_name, msg_ids])
+            cur.fetchall()
 
-        cur.fetchall()
+            archive_duration = time.perf_counter() - archive_start
+            results.append(
+                # {
+                #     "operation": pattern,
+                #     "duration_sec": archive_duration,
+                #     "batch_size": num_consumed,
+                #     "epoch": time.time(),
+                # }
+                (pattern, archive_duration, num_consumed, time.time())
+            )
 
-        archive_duration = time.perf_counter() - archive_start
-        results.append(
-            {
-                "operation": pattern,
-                "duration_sec": archive_duration,
-                "batch_size": num_consumed,
-                "epoch": time.time(),
-            }
-        )
+            if num_consumed < batch_size:
+                logging.debug(f"Consumed {num_consumed}/{batch_size} batch size")
 
-        if num_consumed < batch_size:
-            logging.debug(f"Consumed {num_consumed}/{batch_size} batch size")
-
+        with cur.copy(f"COPY bench_results_{queue_name} FROM STDIN") as copy:
+            for record in results:
+                copy.write_row(record)
     # divide by 2 because we're appending two results (read/archive) per message
     num_consumed = len(results) / 2
     logging.info(f"pid: {pid}, read {num_consumed} messages")
-
-    with cur.copy(f"COPY bench_results_{queue_name} FROM STDIN") as copy:
-        for record in results:
-            copy.write_row(tuple(record.values()))
-
-    cur.close()
-    conn.close()
 
 
 def queue_depth(queue_name: str, connection_info: dict, kill_flag: multiprocessing.Value, duration_seconds: int):
@@ -189,58 +178,57 @@ def queue_depth(queue_name: str, connection_info: dict, kill_flag: multiprocessi
     port = connection_info["port"]
     database = connection_info["database"]
     url = f"postgresql://{username}:{password}@{host}:{port}/{database}"
-    conn = psycopg.connect(url)
-    pid = os.getpid()
-    cur = conn.cursor()
-    conn.autocommit = True
-    all_metrics = []
+    with psycopg.connect(url, autocommit=True) as conn:
+        pid = os.getpid()
+        cur = conn.cursor()
+        conn.autocommit = True
+        all_metrics = []
 
-    cur.execute(
-        f"""
-        CREATE TABLE bench_results_{queue_name}_queue_depth(
-            queue_name text NULL,
-            queue_length int8 NULL,
-            total_messages int8 NULL,
-            select1 float8 NULL,
-            "time" float8 NULL
-        )"""
-    )
-
-    start = time.time()
-    while not kill_flag.value:
-        cur.execute(f"select * from pgmq.metrics('{queue_name}')")
-        metrics = cur.fetchall()[0]
-        depth = metrics[1]
-        total_messages = metrics[-2]
-
-        read_start = time.perf_counter()
-        cur.execute("select 1")
-        cur.fetchall()
-        sel_duration = time.perf_counter() - read_start
-        duration = int(time.time() - start)
-        all_metrics.append(
-            {
-                "queue_name": metrics[0],
-                "queue_length": depth,
-                "total_messages": total_messages,
-                "select1": sel_duration,
-                "time": time.time(),
-            }
+        cur.execute(
+            f"""
+            CREATE TABLE bench_results_{queue_name}_queue_depth(
+                queue_name text NULL,
+                queue_length int8 NULL,
+                total_messages int8 NULL,
+                select1 float8 NULL,
+                "time" float8 NULL
+            )"""
         )
-        log = {
-            "q_len": depth,
-            "elapsed": f"{duration}/{duration_seconds}",
-            "select1_sec": sel_duration,
-            "tot_msg": total_messages,
-        }
-        logging.info(log)
-        time.sleep(5)
 
-    with cur.copy(f"COPY bench_results_{queue_name}_queue_depth FROM STDIN") as copy:
-        for record in all_metrics:
-            copy.write_row(tuple(record.values()))
+        start = time.time()
+        while not kill_flag.value:
+            cur.execute(f"select * from pgmq.metrics('{queue_name}')")
+            metrics = cur.fetchall()[0]
+            depth = metrics[1]
+            total_messages = metrics[-2]
 
-    cur.close()
-    conn.close()
+            read_start = time.perf_counter()
+            cur.execute("select 1")
+            cur.fetchall()
+            sel_duration = time.perf_counter() - read_start
+            duration = int(time.time() - start)
+            all_metrics.append(
+                # {
+                #     "queue_name": metrics[0],
+                #     "queue_length": depth,
+                #     "total_messages": total_messages,
+                #     "select1": sel_duration,
+                #     "time": time.time(),
+                # }
+                # use a tuple to use less memory
+                (metrics[0], depth, total_messages, sel_duration, time.time())
+            )
+            log = {
+                "q_len": depth,
+                "elapsed": f"{duration}/{duration_seconds}",
+                "select1_sec": sel_duration,
+                "tot_msg": total_messages,
+            }
+            logging.info(log)
+            time.sleep(5)
+
+        with cur.copy(f"COPY bench_results_{queue_name}_queue_depth FROM STDIN") as copy:
+            for record in all_metrics:
+                copy.write_row(record)
 
     return all_metrics

--- a/tembo-pgmq-python/benches/ops.py
+++ b/tembo-pgmq-python/benches/ops.py
@@ -39,7 +39,6 @@ def produce(
     running_duration = 0
     last_print_time = time.time()
 
-    logging.info(f"Running message_size_bytes: {message_size_bytes}")
     payloads = {22: "22B.json", 1000: "1KB.json", 10000: "10KB.json"}
 
     # get specified message payload by size

--- a/tembo-pgmq-python/benches/runner.py
+++ b/tembo-pgmq-python/benches/runner.py
@@ -1,1 +1,64 @@
+from yaml import load
 
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
+import copy
+import logging
+
+import typer
+
+from benches.bench import bench
+
+
+def run_multi(infile: str):
+    """
+    run a series of benchmarks sequentially, where each bench defined in yaml.
+
+    For example:
+
+    poetry run python -m benches.runner bench.yaml
+
+    # bench.yaml
+    globals:
+    postgres_connection: 'postgresql://postgres:postgres@localhost:5432/postgres'
+    duration_seconds: 1
+    message_size_bytes: 1000
+    benches:
+    - read_concurrency: 1
+        read_batch_size: 1
+        write_concurrency: 1
+        write_batch_size: 1
+    - read_concurrency: 2
+        read_batch_size: 2
+        write_concurrency: 2
+        write_batch_size: 2
+    - read_concurrency: 3
+        read_batch_size: 3
+        write_concurrency: 3
+        write_batch_size: 3
+    """
+    with open(infile, "r") as f:
+        config = load(f, Loader=Loader)
+
+    # start with global defaults
+    benches: list[dict] = []
+    for _b in config["benches"]:
+        this_bench = copy.deepcopy(config.get("globals", {}))
+        this_bench.update(_b)
+        benches.append(this_bench)
+
+    completed_benches: list[str] = []
+    for i, b in enumerate(benches):
+        logging.info("Starting bench %s / %s", i + 1, len(benches))
+        print(b)
+        bench_name = bench(**b)
+        completed_benches.append(bench_name)
+
+    logging.info(f"All benches complete: {completed_benches}")
+
+
+if __name__ == "__main__":
+    typer.run(run_multi)

--- a/tembo-pgmq-python/benches/runner.py
+++ b/tembo-pgmq-python/benches/runner.py
@@ -23,9 +23,9 @@ def run_multi(infile: str):
 
     # bench.yaml
     globals:
-    postgres_connection: 'postgresql://postgres:postgres@localhost:5432/postgres'
-    duration_seconds: 1
-    message_size_bytes: 1000
+        postgres_connection: 'postgresql://postgres:postgres@localhost:5432/postgres'
+        duration_seconds: 60
+        message_size_bytes: 1000
     benches:
     - read_concurrency: 1
         read_batch_size: 1

--- a/tembo-pgmq-python/benches/stats.py
+++ b/tembo-pgmq-python/benches/stats.py
@@ -6,6 +6,7 @@ from matplotlib import pyplot as plt  # type: ignore
 from scipy.ndimage import gaussian_filter1d
 from sqlalchemy import create_engine, text
 
+from benches.log import write_event_log
 from tembo_pgmq_python import PGMQueue
 
 
@@ -48,8 +49,6 @@ def stack_events(
     )
 
     events_df = pd.concat([df, sel1_df, queue_depth[["operation", "queue_length", "epoch"]]])
-
-    from benches.log import write_event_log
 
     # write event log back to postgres table
     write_event_log(db_url=db_url, event_log=events_df, bench_name=bench_name)

--- a/tembo-pgmq-python/benches/stats.py
+++ b/tembo-pgmq-python/benches/stats.py
@@ -30,7 +30,7 @@ def stack_events(
     queue_depth = pd.read_sql(f'''select * from "{queue_depth_table}"''', con=con)
 
     sel1_df = queue_depth[["time", "select1"]]
-    sel1_df["operation"] = "select1"
+    sel1_df = sel1_df.assign(operation="select1")
     sel1_df.rename(
         columns={
             "select1": "duration_sec",
@@ -38,7 +38,7 @@ def stack_events(
         },
         inplace=True,
     )
-    queue_depth["operation"] = "queue_depth"
+    queue_depth = queue_depth.assign(operation="queue_depth")
     queue_depth.rename(
         columns={
             "total_messages": "msg_id",
@@ -134,14 +134,12 @@ def plot_rolling(event_log: pd.DataFrame, summary_df: pd.DataFrame, bench_name: 
 import numpy as np
 
 
-# # TODO: make return model data type
-def summarize(event_log: pd.DataFrame) -> dict:
+def summarize(event_log: pd.DataFrame) -> pd.DataFrame:
     """Compute summary stats from the bench
 
     event_log: pd.DataFrame representnation of event_log table
         operation text NOT NULL,
         duration_sec numeric NULL,
-        msg_ids jsonb NULL,
         batch_size numeric NULL,
         epoch numeric NOT NULL,
         queue_length numeric NULL

--- a/tembo-pgmq-python/pyproject.toml
+++ b/tembo-pgmq-python/pyproject.toml
@@ -14,7 +14,7 @@ packages = [{include = "tembo_pgmq_python"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-psycopg = {extras = ["binary", "pool"], version = "^3.1.12"}
+psycopg = {extras = ["binary", "pool"], version = "^3"}
 pydantic = "^1"
 orjson = "^3"
 

--- a/tembo-pgmq-python/pyproject.toml
+++ b/tembo-pgmq-python/pyproject.toml
@@ -37,6 +37,7 @@ scipy = "^1"
 typer = {extras = ["all"], version = "^0.9.0"}
 types-psycopg2 = "^2.9.21.11"
 pyyaml = "^6.0.1"
+seaborn = "^0.13.0"
 
 [tool.black]
 line-length = 120

--- a/tembo-pgmq-python/pyproject.toml
+++ b/tembo-pgmq-python/pyproject.toml
@@ -14,7 +14,7 @@ packages = [{include = "tembo_pgmq_python"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-psycopg = {extras = ["binary", "pool"], version = "^3"}
+psycopg = {extras = ["binary", "pool"], version = "^3.1.12"}
 pydantic = "^1"
 orjson = "^3"
 
@@ -36,6 +36,7 @@ psycopg2 = "^2.9.6"
 scipy = "^1"
 typer = {extras = ["all"], version = "^0.9.0"}
 types-psycopg2 = "^2.9.21.11"
+pyyaml = "^6.0.1"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
- adds a runner wrapper that lets us define benchmarks in yaml, and execute them sequentially
- replace subprocess calls to `psql COPY` with psycopg3's copy API. saves on process spawning, memory, and tmp disk writes