### PR TITLE
Fix off by one in metrics (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.32.3"
+version = "0.33.1"
 dependencies = [
  "chrono",
  "pgmq-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.33.0"
+version = "0.33.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -110,9 +110,10 @@ fn build_summary_query(queue_name: &str) -> String {
                 (NOW() at time zone 'utc')::timestamp at time zone 'utc' as scrape_time
             FROM {fq_table}) as q_summary
         CROSS JOIN
-            (SELECT
-                (last_value - 1) as total_messages
-            from {fq_table}_msg_id_seq) as q_sent_summary
+            (
+                SELECT (CASE WHEN is_called THEN last_value ELSE 0 END) as total_messages
+                FROM {fq_table}_msg_id_seq
+            ) as q_sent_summary
         "
     )
 }


### PR DESCRIPTION
The fix on commit https://github.com/tembo-io/pgmq/commit/6d5d695ccba0687839624a41f1878465e6ac7fdf was naive.

When the seq wasn't used, `last_value` is 1, and `is_called` is false.
When the seq was used once, `last_value` is 1, and `is_called` is true.
When the seq was used more than once, `last_value` is N, and `is_called`
is true.