### PR TITLE
Use generated always as identity instead of bigserial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "pgmq"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "chrono",
  "pgmq-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.33.2"
+version = "0.33.3"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Postgres extension for PGMQ"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq-core"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Core functionality shared between the PGMQ Rust SDK and Postgres Extension"

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -39,7 +39,7 @@ pub fn create_queue(name: CheckedName<'_>, is_unlogged: bool) -> Result<String, 
     Ok(format!(
         "
         CREATE {maybe_unlogged} TABLE IF NOT EXISTS {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{name} (
-            msg_id BIGSERIAL PRIMARY KEY,
+            msg_id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
             read_ct INT DEFAULT 0 NOT NULL,
             enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
             vt TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -53,7 +53,7 @@ pub fn create_archive(name: CheckedName<'_>) -> Result<String, PgmqError> {
     Ok(format!(
         "
         CREATE TABLE IF NOT EXISTS {PGMQ_SCHEMA}.{ARCHIVE_PREFIX}_{name} (
-            msg_id BIGSERIAL PRIMARY KEY,
+            msg_id BIGINT PRIMARY KEY,
             read_ct INT DEFAULT 0 NOT NULL,
             enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
             archived_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -79,7 +79,7 @@ fn create_partitioned_queue(
     Ok(format!(
         "
         CREATE TABLE IF NOT EXISTS {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{queue} (
-            msg_id BIGSERIAL NOT NULL,
+            msg_id BIGINT GENERATED ALWAYS AS IDENTITY,
             read_ct INT DEFAULT 0 NOT NULL,
             enqueued_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
             vt TIMESTAMP WITH TIME ZONE NOT NULL,


### PR DESCRIPTION
Resolves #100.

Hi @ChuckHend. I think [you are right](https://github.com/tembo-io/pgmq/issues/100#issuecomment-1806880932) in that this update just works with older queues without requiring a migration. I did some local testing and all was well. I can't say it was completely exhaustive though. Create a queue under the old version, add some messages, update the extension version, read old stuff, insert new stuff, delete, etc., and, after all, the sequence values were correct.

In the end, the same sequences exist:
```
pgmq=# \ds pgmq.*
              List of relations
 Schema |       Name       |   Type   | Owner
--------+------------------+----------+-------
 pgmq   | a_old_msg_id_seq | sequence | craig
 pgmq   | q_new_msg_id_seq | sequence | craig
 pgmq   | q_old_msg_id_seq | sequence | craig
(3 rows)
```
However, none on the new archive table as the creation of that one has been dropped in this PR.

I can describe the sequences:
```
pgmq=# \d pgmq.q_new_msg_id_seq
                       Sequence "pgmq.q_new_msg_id_seq"
  Type  | Start | Minimum |       Maximum       | Increment | Cycles? | Cache
--------+-------+---------+---------------------+-----------+---------+-------
 bigint |     1 |       1 | 9223372036854775807 |         1 | no      |     1
Sequence for identity column: pgmq.q_new.msg_id

pgmq=# \d pgmq.q_old_msg_id_seq
                       Sequence "pgmq.q_old_msg_id_seq"
  Type  | Start | Minimum |       Maximum       | Increment | Cycles? | Cache
--------+-------+---------+---------------------+-----------+---------+-------
 bigint |     1 |       1 | 9223372036854775807 |         1 | no      |     1
Owned by: pgmq.q_old.msg_id
```
Anything else that I should check?