### PR TITLE
Use sqlx without TLS feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }
-sqlx = { version = "0.7.2", features = [ "runtime-tokio-native-tls" , "postgres", "chrono", "json" ] }
+sqlx = { version = "0.7.2", features = [ "runtime-tokio" , "postgres", "chrono", "json" ] }
 thiserror = "1.0.38"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.17"

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -16,7 +16,7 @@ pgmq_core = { package = "pgmq-core", version = "0.8.2" }
 chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }
-sqlx = { version = "0.7.2", features = [ "runtime-tokio-native-tls" , "postgres", "chrono", "json" ] }
+sqlx = { version = "0.7.2", features = [ "runtime-tokio" , "postgres", "chrono", "json" ] }
 thiserror = "1.0.38"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.17"


### PR DESCRIPTION
The pgmq extension doesn't use TLS at all - the resulting so library is not linked against libcrypto, i.e. the part of the code using sqlx connect is not used here.

The TLS support adds unnecessary dependencies that increases the build time and make building on some platform difficult (due to openssl dependency or lack of rustls/ring support for these platforms).

runtime-tokio is a subset of runtime-tokio-native-tls, so if some projects that depend on pgmq-core or pgmq-rs need TLS, they can easily enable runtime-tokio-native-tls on their side.