### PR TITLE
feat: add archive_batch

### DIFF
--- a/pgmq-rs/tests/integration_test.rs
+++ b/pgmq-rs/tests/integration_test.rs
@@ -606,6 +606,29 @@ async fn test_archive() {
     assert_eq!(num_rows_archive, 1);
 }
 
+#[tokio::test]
+async fn test_archive_batch() {
+    let test_queue = "test_archive_batch_queue".to_owned();
+    let queue = init_queue(&test_queue).await;
+    let msg = MyMessage::default();
+
+    let msg_1 = queue.send(&test_queue, &msg).await.unwrap();
+    let msg_2 = queue.send(&test_queue, &msg).await.unwrap();
+    let msg_3 = queue.send(&test_queue, &msg).await.unwrap();
+
+    let num_moved = queue
+        .archive_batch(&test_queue, &[msg_1, msg_2, msg_3])
+        .await
+        .unwrap();
+    assert_eq!(num_moved, 3);
+
+    let num_rows_queue = rowcount(&test_queue, &queue.connection).await;
+    assert_eq!(num_rows_queue, 0);
+
+    let num_rows_archive = archive_rowcount(&test_queue, &queue.connection).await;
+    assert_eq!(num_rows_archive, 3);
+}
+
 /// test db operations that should produce errors
 #[tokio::test]
 async fn test_database_error_modes() {


### PR DESCRIPTION
### #179  Note I haven't tested it yet because:
1. I cannot connect to pgmq docker container(quay.io/tembo/pgmq-pg:latest) pgmq client error Failed to connect to postgres: ```error: DatabaseError(PoolTimedOut)```

2. Follow the instructions in [CONTRIBUTING](https://github.com/tembo-io/pgmq/blob/main/CONTRIBUTING.md)
   2.1 Running `cargo pgrx init --pg15=`which pg_config` will report error: ```unexpected argument 'not' found```
  2.2 cargo pgrx install --release will report an error ```couldn't get cargo metadata```
  2.3 I cannot download the 0.11 version of pgrx. The following is the error:
```
error[E0412]: cannot find type `pid_t` in crate `libc`
   --> C:\Users\l-7-l\.cargo\registry\src\index.crates.io-6f17d22bba15001f\fork-0.1.22\src\lib.rs:21:18
    |
21 | Parent(libc::pid_t),
    | ^^^^^ not found in `libc`

error[E0425]: cannot find function `fork` in crate `libc`
    --> C:\Users\l-7-l\.cargo\registry\src\index.crates.io-6f17d22bba15001f\fork-0.1.22\src\lib.rs:112:30
     |
112 | let res = unsafe { libc::fork() };
     | ^^^^ not found in `libc`

error[E0412]: cannot find type `pid_t` in crate `libc`
    --> C:\Users\l-7-l\.cargo\registry\src\index.crates.io-6f17d22bba15001f\fork-0.1.22\src\lib.rs:128:33
     |
128 | pub fn setsid() -> Result<libc::pid_t, i32> {
     | ^^^^^ not found in `libc`

error[E0425]: cannot find function `setsid` in crate `libc`
    --> C:\Users\l-7-l\.cargo\registry\src\index.crates.io-6f17d22bba15001f\fork-0.1.22\src\lib.rs:129:30
     |
129 | let res = unsafe { libc::setsid() };
     | ^^^^^^ help: a function with a similar name exists: `getpid`
     |
    ::: C:\Users\l-7-l\.cargo\registry\src\index.crates.io-6f17d22bba15001f\libc-0.2.149\src\windows\mod.rs:491:5
     |
491 | pub fn getpid() -> ::c_int;
     | -------------------------- similarly named function `getpid` defined here

error[E0412]: cannot find type `pid_t` in crate `libc`
    --> C:\Users\l-7-l\.cargo\registry\src\index.crates.io-6f17d22bba15001f\fork-0.1.22\src\lib.rs:140:34
     |
140 | pub fn getpgrp() -> Result<libc::pid_t, i32> {
     | ^^^^^ not found in `libc`

error[E0425]: cannot find function `getpgrp` in crate `libc`
    --> C:\Users\l-7-l\.cargo\registry\src\index.crates.io-6f17d22bba15001f\fork-0.1.22\src\lib.rs:141:30
     |
141 | let res = unsafe { libc::getpgrp() };
     | ^^^^^^^ not found in `libc`

Some errors have detailed explanations: E0412, E0425.
For more information about an error, try `rustc --explain E0412`.
```