### PR TITLE
pgmq-core - make the `enqueue` method return a parametrized query

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq-core"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Core functionality shared between the PGMQ Rust SDK and Postgres Extension"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq-core"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "Core functionality shared between the PGMQ Rust SDK and Postgres Extension"

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -155,15 +155,16 @@ pub fn purge_queue(name: &str) -> Result<String, PgmqError> {
 
 pub fn enqueue(
     name: &str,
-    messages: &[serde_json::Value],
+    messages_num: usize,
     delay: &u64,
 ) -> Result<String, PgmqError> {
     // construct string of comma separated messages
     check_input(name)?;
     let mut values = "".to_owned();
-    for message in messages.iter() {
-        let full_msg = format!("((now() + interval '{delay} seconds'), '{message}'::json),");
-        values.push_str(&full_msg)
+
+    for i in messages_num {
+        let full_msg = format!("((now() + interval '{delay} seconds'), ${}::json),", i + 1);
+        values.push_str(&full_msg);
     }
     // drop trailing comma from constructed string
     values.pop();

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -153,11 +153,7 @@ pub fn purge_queue(name: &str) -> Result<String, PgmqError> {
     Ok(format!("DELETE FROM {PGMQ_SCHEMA}.{QUEUE_PREFIX}_{name};"))
 }
 
-pub fn enqueue(
-    name: &str,
-    messages_num: usize,
-    delay: &u64,
-) -> Result<String, PgmqError> {
+pub fn enqueue(name: &str, messages_num: usize, delay: &u64) -> Result<String, PgmqError> {
     // construct string of comma separated messages
     check_input(name)?;
     let mut values = "".to_owned();

--- a/core/src/query.rs
+++ b/core/src/query.rs
@@ -162,7 +162,7 @@ pub fn enqueue(
     check_input(name)?;
     let mut values = "".to_owned();
 
-    for i in messages_num {
+    for i in 0..messages_num {
         let full_msg = format!("((now() + interval '{delay} seconds'), ${}::json),", i + 1);
         values.push_str(&full_msg);
     }
@@ -409,14 +409,9 @@ $$ LANGUAGE plpgsql;
 
     #[test]
     fn test_enqueue() {
-        let mut msgs: Vec<serde_json::Value> = Vec::new();
-        let msg = serde_json::json!({
-            "foo": "bar"
-        });
-        msgs.push(msg);
-        let query = enqueue("yolo", &msgs, &0).unwrap();
+        let query = enqueue("yolo", 1, &0).unwrap();
         assert!(query.contains("q_yolo"));
-        assert!(query.contains("{\"foo\":\"bar\"}"));
+        assert!(query.contains("(now() + interval '0 seconds'), $1::json)"));
     }
 
     #[test]


### PR DESCRIPTION
Part #1 of 2 for #185 - this enhnaces the core so it will generate a parametrized query allowing sqlx / pg to do the sanitization of the input