### PR TITLE
pgmq-rs - Leverage parametrized queries from core

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/tembo-io/pgmq"
 
 [dependencies]
-pgmq_core = { package = "pgmq-core", version = "0.8.2" }
+pgmq_core = { package = "pgmq-core", version = "0.8.5" }
 chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pgmq"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."
 documentation = "https://docs.rs/pgmq"
 homepage = "https://github.com/tembo-io/pgmq"
 keywords = ["messaging", "queues", "postgres"]
-license = "Apache-2.0"
+license = "Apache 2.0"
 readme = "README.md"
 repository = "https://github.com/tembo-io/pgmq"
 

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -440,7 +440,8 @@ impl PGMQueue {
         messages: &[T],
     ) -> Result<Vec<i64>, PgmqError> {
         let mut msg_ids: Vec<i64> = Vec::new();
-        let mut q = sqlx::query(&core_query::enqueue(queue_name, messages.len(), &0)?);
+        let query = core_query::enqueue(queue_name, messages.len(), &0)?;
+        let mut q = sqlx::query(&query);
         for msg in messages.iter() {
             q = q.bind(serde_json::json!(msg));
         }

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -320,8 +320,8 @@ impl PGMQueue {
         message: &T,
     ) -> Result<i64, PgmqError> {
         let msg = serde_json::json!(&message);
-        let msgs: [serde_json::Value; 1] = [msg];
-        let row: PgRow = sqlx::query(&core_query::enqueue(queue_name, &msgs, &0)?)
+        let row: PgRow = sqlx::query(&core_query::enqueue(queue_name, 1, &0)?)
+            .bind(msg)
             .fetch_one(&self.connection)
             .await?;
         let msg_id: i64 = row.get("msg_id");
@@ -385,10 +385,9 @@ impl PGMQueue {
         message: &T,
         delay: u64,
     ) -> Result<i64, PgmqError> {
-        let mut msgs: Vec<serde_json::Value> = Vec::new();
         let msg = serde_json::json!(&message);
-        msgs.push(msg);
-        let row: PgRow = sqlx::query(&core_query::enqueue(queue_name, &msgs, &delay)?)
+        let row: PgRow = sqlx::query(&core_query::enqueue(queue_name, 1, &delay)?)
+            .bind(msg)
             .fetch_one(&self.connection)
             .await?;
         let msg_id: i64 = row.get("msg_id");
@@ -440,15 +439,12 @@ impl PGMQueue {
         queue_name: &str,
         messages: &[T],
     ) -> Result<Vec<i64>, PgmqError> {
-        let mut msgs: Vec<serde_json::Value> = Vec::new();
         let mut msg_ids: Vec<i64> = Vec::new();
+        let mut q = sqlx::query(&core_query::enqueue(queue_name, messages.len(), &0)?);
         for msg in messages.iter() {
-            let binding = serde_json::json!(&msg);
-            msgs.push(binding)
+            q = q.bind(serde_json::json!(msg));
         }
-        let rows: Vec<PgRow> = sqlx::query(&core_query::enqueue(queue_name, &msgs, &0)?)
-            .fetch_all(&self.connection)
-            .await?;
+        let rows: Vec<PgRow> = q.fetch_all(&self.connection).await?;
         for row in rows.iter() {
             msg_ids.push(row.get("msg_id"));
         }


### PR DESCRIPTION
Part 2 of 2. Makes pgmq-rs leverage the parametrized methods in the new core version that will be published.

Will break UTs until the new version is published

Depends on #186 . Resolves #185 