### PR TITLE
ignore dirs in extension CI

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -11,11 +11,13 @@ on:
       - main
     paths-ignore:
       - 'pgmq-rs/**'
+      - 'tembo-pgmq-python/**'
   push:
     branches:
       - main
     paths-ignore:
       - 'pgmq-rs/**'
+      - 'tembo-pgmq-python/**'
   release:
     types:
       - created

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -9,9 +9,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'pgmq-rs/**'
   push:
     branches:
       - main
+    paths-ignore:
+      - 'pgmq-rs/**'
   release:
     types:
       - created


### PR DESCRIPTION
We don't need to re-run the extension CI workflow when there are changes to the client SDKs. Especially don't need to be rebuilding a postgres image w/ pgmq in it when there are changes to client SDK only.
