### PR TITLE
Set minimum psycopg version to 3.1.14 which includes support for gevent (for locust load testing)

### DIFF
--- a/tembo-pgmq-python/pyproject.toml
+++ b/tembo-pgmq-python/pyproject.toml
@@ -38,6 +38,7 @@ locust = "^2.16.1"
 ruff = "^0.3.1"
 pyyaml = "^6.0.1"
 seaborn = "^0.13.0"
+psycopg = {version = "^3.1.14", extras = ["binary", "pool"]}
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Support was added in 3.1.14 https://www.psycopg.org/psycopg3/docs/news.html#psycopg-3-1-14.
