### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,14 +82,6 @@ Finally, you can create the extension and get started with the example in the [R
 CREATE EXTENSION pgmq cascade;
 ```
 
-# Packaging
-
-Run this script to package into a `.deb` file, which can be installed on Ubuntu.
-
-```
-/bin/bash build-extension.sh
-```
-
 # Releases
 
 PGMQ Postgres Extension releases are automated through a [Github workflow](https://github.com/tembo-io/pgmq/blob/main/.github/workflows/extension_ci.yml). The compiled binaries are publish to and hosted at [pgt.dev](https://pgt.dev). To create a release, create a new tag follow a valid [semver](https://semver.org/), then create a release with the same name. Auto-generate the release notes and/or add more relevant details as needed. See subdirectories for the [Rust](https://github.com/tembo-io/pgmq/tree/main/core) and [Python](https://github.com/tembo-io/pgmq/tree/main/tembo-pgmq-python) SDK release processes.


### PR DESCRIPTION
Removes the Packaging from the contrib guide. `build-extension.sh` has been gone for many months. We could consider adding a more comprehensive guide somewhere other than CONTRIBUTING.md to discuss there various places where pgmq is distributed, such as pgxn, the .deb in github release, trunk, pgxman, dbdev (when we get there).

Closes https://github.com/tembo-io/pgmq/issues/208