### PR TITLE
only run pgmq-python CI on code changes

### DIFF
--- a/.github/workflows/pgmq_python.yml
+++ b/.github/workflows/pgmq_python.yml
@@ -11,13 +11,15 @@ on:
      - main
     paths:
       - '.github/workflows/pgmq-python.yml'
-      - 'tembo-pgmq-python/**'
+      - 'tembo-pgmq-python/tembo_pgmq_python/**'
+      - 'tembo-pgmq-python/tests/**'
   push:
     branches:
       - main
     paths:
       - '.github/workflows/pgmq-python.yml'
-      - 'tembo-pgmq-python/**'
+      - 'tembo-pgmq-python/tembo_pgmq_python/**'
+      - 'tembo-pgmq-python/tests/**'
 
 jobs:
   lints:


### PR DESCRIPTION
limiting the CI to the source and test directories. I noticed CI running and failing for README changes, such as https://github.com/tembo-io/pgmq/pull/214