### PR TITLE
adjust new_with_pool to return PGMQueue directly

### DIFF
--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -170,9 +170,9 @@ pub struct PGMQueue {
 }
 
 impl PGMQueue {
-    pub async fn new(url: String) -> Result<PGMQueue, PgmqError> {
+    pub async fn new(url: String) -> Result<Self, PgmqError> {
         let con = util::connect(&url, 5).await?;
-        Ok(PGMQueue {
+        Ok(Self {
             url,
             connection: con,
         })
@@ -180,11 +180,11 @@ impl PGMQueue {
 
     /// BYOP  - bring your own pool
     /// initialize a PGMQ connection with your own SQLx Postgres connection pool
-    pub async fn new_with_pool(pool: Pool<Postgres>) -> Result<PGMQueue, PgmqError> {
-        Ok(PGMQueue {
+    pub async fn new_with_pool(pool: Pool<Postgres>) -> Self {
+        Self {
             url: "".to_owned(),
             connection: pool,
-        })
+        }
     }
 
     /// Create a queue. This sets up the queue's tables, indexes, and metadata.

--- a/pgmq-rs/src/pg_ext.rs
+++ b/pgmq-rs/src/pg_ext.rs
@@ -26,8 +26,8 @@ pub struct PGMQueueMeta {
 }
 impl PGMQueueExt {
     /// Initialize a connection to PGMQ/Postgres
-    pub async fn new(url: String, max_connections: u32) -> Result<PGMQueueExt, PgmqError> {
-        Ok(PGMQueueExt {
+    pub async fn new(url: String, max_connections: u32) -> Result<Self, PgmqError> {
+        Ok(Self {
             connection: connect(&url, max_connections).await?,
             url,
         })
@@ -35,11 +35,11 @@ impl PGMQueueExt {
 
     /// BYOP  - bring your own pool
     /// initialize a PGMQ connection with your own SQLx Postgres connection pool
-    pub async fn new_with_pool(pool: Pool<Postgres>) -> Result<PGMQueueExt, PgmqError> {
-        Ok(PGMQueueExt {
+    pub async fn new_with_pool(pool: Pool<Postgres>) -> Self {
+        Self {
             url: "".to_owned(),
             connection: pool,
-        })
+        }
     }
 
     pub async fn init(&self) -> Result<bool, PgmqError> {

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -357,8 +357,7 @@ async fn test_byop() {
     let pool = _queue.connection;
 
     let queue = pgmq::PGMQueueExt::new_with_pool(pool)
-        .await
-        .expect("failed to connect to postgres");
+        .await;
 
     let init = queue.init().await.expect("failed to create extension");
     assert!(init, "failed to create extension");


### PR DESCRIPTION
I'm not sure, if this was done on purpose, but `new_with_pool(...)` can't return an error, because the pool creation and initial connection is done beforehand. I changed it to just return itself 🙂 