### PR TITLE
update sqlx cache in pgmq-rs

### DIFF
--- a/pgmq-rs/.sqlx/query-ecde748537ee27524a682a71ac5bfd9237c8b44300c6809cc5808cc1ba497d60.json
+++ b/pgmq-rs/.sqlx/query-ecde748537ee27524a682a71ac5bfd9237c8b44300c6809cc5808cc1ba497d60.json
@@ -6,22 +6,22 @@
       {
         "ordinal": 0,
         "name": "queue_name",
-        "type_info": "Text"
+        "type_info": "Varchar"
       },
       {
         "ordinal": 1,
-        "name": "created_at",
-        "type_info": "Timestamptz"
-      },
-      {
-        "ordinal": 2,
         "name": "is_partitioned",
         "type_info": "Bool"
       },
       {
-        "ordinal": 3,
+        "ordinal": 2,
         "name": "is_unlogged",
         "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
       }
     ],
     "parameters": {


### PR DESCRIPTION
v1.2.0 of the extension changed the order of the columns returned by `pgmq.list_queues()`. I like the new way better, and is only an issue for the sqlx cache for the Rust client. Quick fix in this PR.


old:

```text
 queue_name | is_partitioned | is_unlogged |          created_at           
------------+----------------+-------------+-------------------------------
 x          | f              | f           | 2024-05-21 18:53:45.589962+00
```


new:

```text
 queue_name |          created_at           | is_partitioned | is_unlogged 
------------+-------------------------------+----------------+-------------
 x          | 2024-05-21 18:56:11.791476+00 | f              | f
 ```