### PR TITLE
Fix deb builds

### DIFF
--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -6,9 +6,6 @@ defaults:
     working-directory: ./
 
 on:
-  push:
-    branches:
-      - fix-deb-build
   release:
     types:
       - created
@@ -17,7 +14,7 @@ jobs:
   build-deb:
     # source: https://github.com/supabase/pg_jsonschema/blob/29fcd5b23abe3dd6a78a490082f34113de7813a1/.github/workflows/release.yml
     name: release .deb
-    # if: github.event_name == 'release'
+    if: github.event_name == 'release'
     strategy:
       matrix:
         extension_name:
@@ -31,7 +28,7 @@ jobs:
             - 15
             - 16
         box:
-          # - { runner: large-8x8, arch: amd64 }
+          - { runner: large-8x8, arch: amd64 }
           - { runner: arm64, arch: arm64 }
     runs-on: 
       - "dind"

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -6,6 +6,9 @@ defaults:
     working-directory: ./
 
 on:
+  push:
+    branches:
+      - fix-deb-build
   release:
     types:
       - created
@@ -29,8 +32,11 @@ jobs:
             - 16
         box:
           - { runner: ubuntu-20.04, arch: amd64 }
-          - { runner: arm-runner, arch: arm64 }
-    runs-on: ${{ matrix.box.runner }}
+          - { runner: arm64, arch: arm64 }
+    runs-on: 
+      - "dind"
+      - "self-hosted"
+      - ${{ matrix.box.arch }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
@@ -98,12 +104,12 @@ jobs:
           echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${deb_version} | jq .upload_url --raw-output) >> $GITHUB_ENV
           echo ASSET_NAME=${{ matrix.extension_name }}-${deb_version}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb >> $GITHUB_ENV
 
-      - name: Upload deb to github release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./${{ env.ASSET_NAME }}
-          asset_name: ${{ env.ASSET_NAME }}
-          asset_content_type: application/vnd.debian.binary-package
+      # - name: Upload deb to github release
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ env.UPLOAD_URL }}
+      #     asset_path: ./${{ env.ASSET_NAME }}
+      #     asset_name: ${{ env.ASSET_NAME }}
+      #     asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -6,6 +6,9 @@ defaults:
     working-directory: ./
 
 on:
+  push:
+    branches:
+      - fix-deb-build
   release:
     types:
       - created
@@ -14,7 +17,7 @@ jobs:
   build-deb:
     # source: https://github.com/supabase/pg_jsonschema/blob/29fcd5b23abe3dd6a78a490082f34113de7813a1/.github/workflows/release.yml
     name: release .deb
-    if: github.event_name == 'release'
+    # if: github.event_name == 'release'
     strategy:
       matrix:
         extension_name:

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -6,6 +6,9 @@ defaults:
     working-directory: ./
 
 on:
+  push:
+    branches:
+      - fix-deb-build
   release:
     types:
       - created

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -6,9 +6,6 @@ defaults:
     working-directory: ./
 
 on:
-  push:
-    branches:
-      - fix-deb-build
   release:
     types:
       - created
@@ -17,7 +14,7 @@ jobs:
   build-deb:
     # source: https://github.com/supabase/pg_jsonschema/blob/29fcd5b23abe3dd6a78a490082f34113de7813a1/.github/workflows/release.yml
     name: release .deb
-    # if: github.event_name == 'release'
+    if: github.event_name == 'release'
     strategy:
       matrix:
         extension_name:

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -28,11 +28,11 @@ jobs:
           - 0.11.3
         postgres: 
             - 14
-            - 15
-            - 16
+            # - 15
+            # - 16
         box:
           - { runner: ubuntu-20.04, arch: amd64 }
-          - { runner: arm-runner, arch: arm64 }
+          # - { runner: arm-runner, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 90
     steps:
@@ -100,6 +100,7 @@ jobs:
           deb_version=$(grep '^version' Cargo.toml | head -1 | awk -F '"' '{print $2}')
           echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${deb_version} | jq .upload_url --raw-output) >> $GITHUB_ENV
           echo ASSET_NAME=${{ matrix.extension_name }}-${deb_version}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb >> $GITHUB_ENV
+          ls -alh
 
       - name: Upload deb to github release
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -31,7 +31,7 @@ jobs:
             - 15
             - 16
         box:
-          - { runner: ubuntu-20.04, arch: amd64 }
+          - { runner: large-8x8, arch: amd64 }
           - { runner: arm64, arch: arm64 }
     runs-on: 
       - "dind"

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -17,7 +17,7 @@ jobs:
   build-deb:
     # source: https://github.com/supabase/pg_jsonschema/blob/29fcd5b23abe3dd6a78a490082f34113de7813a1/.github/workflows/release.yml
     name: release .deb
-    if: github.event_name == 'release'
+    # if: github.event_name == 'release'
     strategy:
       matrix:
         extension_name:
@@ -36,7 +36,7 @@ jobs:
     runs-on: 
       - "dind"
       - "self-hosted"
-      - ${{ matrix.box.arch }}
+      - ${{ matrix.box.runner }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -6,9 +6,6 @@ defaults:
     working-directory: ./
 
 on:
-  push:
-    branches:
-      - fix-deb-build
   release:
     types:
       - created
@@ -28,11 +25,11 @@ jobs:
           - 0.11.3
         postgres: 
             - 14
-            # - 15
-            # - 16
+            - 15
+            - 16
         box:
           - { runner: ubuntu-20.04, arch: amd64 }
-          # - { runner: arm-runner, arch: arm64 }
+          - { runner: arm-runner, arch: arm64 }
     runs-on: ${{ matrix.box.runner }}
     timeout-minutes: 90
     steps:
@@ -70,8 +67,10 @@ jobs:
           mkdir archive
           cp `find target/release -type f -name "${{ matrix.extension_name }}*"` archive
 
+          deb_version=$(grep '^version' Cargo.toml | head -1 | awk -F '"' '{print $2}')
+
           # name of the package directory before packaging
-          package_dir=${{ matrix.extension_name }}-${{ github.ref_name }}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu
+          package_dir=${{ matrix.extension_name }}-${deb_version}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu
 
           # Copy files into directory structure
           mkdir -p ${package_dir}/usr/lib/postgresql/lib
@@ -79,8 +78,6 @@ jobs:
           cp archive/*.so ${package_dir}/usr/lib/postgresql/lib
           cp archive/*.control ${package_dir}/var/lib/postgresql/extension
           cp archive/*.sql ${package_dir}/var/lib/postgresql/extension
-
-          deb_version=$(grep '^version' Cargo.toml | head -1 | awk -F '"' '{print $2}')
 
           mkdir -p ${package_dir}/DEBIAN
           touch ${package_dir}/DEBIAN/control
@@ -100,7 +97,6 @@ jobs:
           deb_version=$(grep '^version' Cargo.toml | head -1 | awk -F '"' '{print $2}')
           echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${deb_version} | jq .upload_url --raw-output) >> $GITHUB_ENV
           echo ASSET_NAME=${{ matrix.extension_name }}-${deb_version}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb >> $GITHUB_ENV
-          ls -alh
 
       - name: Upload deb to github release
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -104,12 +104,12 @@ jobs:
           echo UPLOAD_URL=$(curl --silent https://api.github.com/repos/${{ github.repository }}/releases/tags/v${deb_version} | jq .upload_url --raw-output) >> $GITHUB_ENV
           echo ASSET_NAME=${{ matrix.extension_name }}-${deb_version}-pg${{ matrix.postgres }}-${{ matrix.box.arch }}-linux-gnu.deb >> $GITHUB_ENV
 
-      # - name: Upload deb to github release
-      #   uses: actions/upload-release-asset@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ env.UPLOAD_URL }}
-      #     asset_path: ./${{ env.ASSET_NAME }}
-      #     asset_name: ${{ env.ASSET_NAME }}
-      #     asset_content_type: application/vnd.debian.binary-package
+      - name: Upload deb to github release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./${{ env.ASSET_NAME }}
+          asset_name: ${{ env.ASSET_NAME }}
+          asset_content_type: application/vnd.debian.binary-package

--- a/.github/workflows/build_extension_deb.yml
+++ b/.github/workflows/build_extension_deb.yml
@@ -31,7 +31,7 @@ jobs:
             - 15
             - 16
         box:
-          - { runner: large-8x8, arch: amd64 }
+          # - { runner: large-8x8, arch: amd64 }
           - { runner: arm64, arch: arm64 }
     runs-on: 
       - "dind"


### PR DESCRIPTION
The path to the built .deb files was wrong. This resulted in the v1.2.0 deb release failing. I [ran those deb builds ](https://github.com/tembo-io/pgmq/actions/runs/9182554935)off this branch with the fix and it looks to be resolved. The debs were attached to the [v1.2.0](https://github.com/tembo-io/pgmq/releases/tag/v1.2.0) release.