### PR TITLE
release pgmq python

### DIFF
--- a/integration_test/Cargo.lock
+++ b/integration_test/Cargo.lock
@@ -866,7 +866,7 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pgmq"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "chrono",
  "log",

--- a/tembo-pgmq-python/pyproject.toml
+++ b/tembo-pgmq-python/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
 name = "tembo-pgmq-python"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python client for the PGMQ Postgres extension."
 authors = ["Adam Hendel <adam@tembo.io>"]
-license = "Apache 2.0"
+license = "PostgreSQL"
 readme = "README.md"
 packages = [{include = "tembo_pgmq_python"}]
 


### PR DESCRIPTION
- updates license in pgmy-py to PostgreSQL, partially addressing https://github.com/tembo-io/pgmq/issues/250
- release metrics features introduced in https://github.com/tembo-io/pgmq/pull/227