### PR TITLE
fix pgmq python ci

### DIFF
--- a/.github/workflows/pgmq_python.yml
+++ b/.github/workflows/pgmq_python.yml
@@ -13,6 +13,7 @@ on:
       - ".github/workflows/pgmq-python.yml"
       - "tembo-pgmq-python/tembo_pgmq_python/**"
       - "tembo-pgmq-python/tests/**"
+      - "tembo-pgmq-python/pyproject.toml"
   push:
     branches:
       - main
@@ -20,6 +21,7 @@ on:
       - ".github/workflows/pgmq-python.yml"
       - "tembo-pgmq-python/tembo_pgmq_python/**"
       - "tembo-pgmq-python/tests/**"
+      - "tembo-pgmq-python/pyproject.toml"
 
 jobs:
   lints:


### PR DESCRIPTION
Python client's CI should also trigger when there are changes to `pyproject.toml`