### PR TITLE
Port (most of) the Rust tests to pg_regress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ sql/pgmq--*.sql
 images/pgmq-pg/Dockerfile
 META.json
 Trunk.toml
+.vscode/
+/results/
+/regression.*

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 EXTENSION    = pgmq
-EXTVERSION   = $(shell grep "^default_version" pgmq.control | sed -E "s/^default_version[[:space:]]*=[[:space:]]*'(.*)'/\1/" | tr -d "'")
+EXTVERSION   = $(shell grep "^default_version" pgmq.control | sed -r "s/default_version[^']+'([^']+).*/\1/")
+DATA         = $(wildcard sql/*--*.sql)
+TESTS        = $(wildcard test/sql/*.sql)
+REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
+REGRESS_OPTS = --inputdir=test
 
-DATA 		     = $(wildcard sql/*--*.sql)
 PG_CONFIG   ?= pg_config
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,0 +1,575 @@
+-- CREATE pgmq.
+CREATE EXTENSION pgmq;
+CREATE EXTENSION pg_partman;
+-- test_unlogged
+-- CREATE with default retention and partition strategy
+SELECT pgmq.create_unlogged('test_unlogged_queue');
+ create_unlogged 
+-----------------
+ 
+(1 row)
+
+SELECT * from pgmq.send('test_unlogged_queue', '{"hello": "world"}');
+ send 
+------
+    1
+(1 row)
+
+SELECT msg_id, read_ct, enqueued_at > NOW(), vt > NOW(), message
+  FROM pgmq.read('test_unlogged_queue', 2, 1);
+ msg_id | read_ct | ?column? | ?column? |      message       
+--------+---------+----------+----------+--------------------
+      1 |       1 | f        | t        | {"hello": "world"}
+(1 row)
+
+-- test_max_queue_name_size
+-- CREATE with default retention and partition strategy
+SELECT pgmq.create(repeat('a', 48));
+ERROR:  queue name is too long, maximum length is 48 characters
+CONTEXT:  PL/pgSQL function pgmq.validate_queue_name(text) line 4 at RAISE
+SQL statement "SELECT pgmq.validate_queue_name(queue_name)"
+PL/pgSQL function pgmq.create_non_partitioned(text) line 3 at PERFORM
+SQL statement "SELECT pgmq.create_non_partitioned(queue_name)"
+PL/pgSQL function pgmq."create"(text) line 3 at PERFORM
+SELECT pgmq.create(repeat('a', 47));
+ create 
+--------
+ 
+(1 row)
+
+-- test_lifecycle
+-- CREATE with default retention and partition strategy
+SELECT pgmq.create('test_default_queue');
+ create 
+--------
+ 
+(1 row)
+
+-- creating a queue must be idempotent
+-- create with same name again, must be no error
+SELECT pgmq.create('test_default_queue');
+NOTICE:  relation "q_test_default_queue" already exists, skipping
+NOTICE:  relation "a_test_default_queue" already exists, skipping
+NOTICE:  relation "q_test_default_queue_vt_idx" already exists, skipping
+NOTICE:  relation "archived_at_idx_test_default_queue" already exists, skipping
+ create 
+--------
+ 
+(1 row)
+
+SELECT * from pgmq.send('test_default_queue', '{"hello": "world"}');
+ send 
+------
+    1
+(1 row)
+
+-- read message
+-- vt=2, limit=1
+\set msg_id 1
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- set VT to 5 seconds
+SELECT vt > clock_timestamp() + '4 seconds'::interval
+  FROM pgmq.set_vt('test_default_queue', :msg_id, 5);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- read again, assert no messages because we just set VT to the future
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
+ ?column? 
+----------
+(0 rows)
+
+-- read again, now using poll to block until message is ready
+SELECT msg_id = :msg_id FROM pgmq.read_with_poll('test_default_queue', 10, 1, 10);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- after reading it, set VT to now
+SELECT msg_id = :msg_id FROM pgmq.set_vt('test_default_queue', :msg_id, 0);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- read again, should have msg_id 1 again
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- send a batch of 2 messages
+SELECT pgmq.create('batch_queue');
+ create 
+--------
+ 
+(1 row)
+
+SELECT ARRAY( SELECT pgmq.send_batch(
+    'batch_queue',
+    ARRAY['{"hello": "world_0"}', '{"hello": "world_1"}']::jsonb[]
+)) = ARRAY[1, 2]::BIGINT[];
+ ?column? 
+----------
+ t
+(1 row)
+
+-- CREATE with 5 seconds per partition, 10 seconds retention
+SELECT pgmq.create_partitioned('test_duration_queue', '5 seconds', '10 seconds');
+ create_partitioned 
+--------------------
+ 
+(1 row)
+
+-- CREATE with 10 messages per partition, 20 messages retention
+SELECT pgmq.create_partitioned('test_numeric_queue', '10 seconds', '20 seconds');
+ create_partitioned 
+--------------------
+ 
+(1 row)
+
+-- get metrics
+SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_messages
+ FROM pgmq.metrics('test_duration_queue');
+     queue_name      | queue_length | newest_msg_age_sec | oldest_msg_age_sec | total_messages 
+---------------------+--------------+--------------------+--------------------+----------------
+ test_duration_queue |            0 |                    |                    |              0
+(1 row)
+
+-- get metrics all
+SELECT * from {PGMQ_SCHEMA}.metrics_all();
+ERROR:  syntax error at or near "{"
+LINE 1: SELECT * from {PGMQ_SCHEMA}.metrics_all();
+                      ^
+-- delete all the queues
+-- delete partitioned queues
+SELECT pgmq.drop_queue(queue, true)
+  FROM unnest('{test_duration_queue, test_numeric_queue}'::text[]) AS queue;
+ drop_queue 
+------------
+ t
+ t
+(2 rows)
+
+-- drop the rest of the queues
+SELECT pgmq.drop_queue(q.queue_name, true)
+  FROM (SELECT queue_name FROM pgmq.list_queues()) AS q;
+ drop_queue 
+------------
+ t
+ t
+ t
+ t
+(4 rows)
+
+SELECT queue_name FROM pgmq.list_queues();
+ queue_name 
+------------
+(0 rows)
+
+-- test_archive
+SELECT pgmq.create('archive_queue');
+ create 
+--------
+ 
+(1 row)
+
+-- no messages in the queue
+SELECT COUNT(*) = 0 FROM pgmq.q_archive_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- no messages in queue archive
+SELECT COUNT(*) = 0 FROM pgmq.a_archive_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- put messages on the queue
+\set msg_id1 1::bigint
+\set msg_id2 2::bigint
+SELECT send = :msg_id1 FROM pgmq.send('archive_queue', '0');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT send = :msg_id2 FROM pgmq.send('archive_queue', '0');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- two messages in the queue
+SELECT COUNT(*) = 2 FROM pgmq.q_archive_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- archive the message. The first two exist so the id should be returned, the
+-- last one doesn't
+SELECT ARRAY(
+    SELECT * FROM pgmq.archive('archive_queue', ARRAY[:msg_id1, :msg_id2])
+) = ARRAY[:msg_id1, :msg_id2];
+ ?column? 
+----------
+ t
+(1 row)
+
+-- should be no messages left on the queue table
+SELECT COUNT(*) = 0 FROM pgmq.q_archive_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- should be two messages in archive
+SELECT COUNT(*) = 2 FROM pgmq.a_archive_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+\set msg_id3 3::bigint
+SELECT send = :msg_id3 FROM pgmq.send('archive_queue', '0');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = 1 FROM pgmq.q_archive_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT * FROM pgmq.archive('archive_queue', :msg_id3);
+ archive 
+---------
+ t
+(1 row)
+
+SELECT COUNT(*) = 0 FROM pgmq.q_archive_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = 3 FROM pgmq.a_archive_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- test_read_read_with_poll
+-- Creating queue
+SELECT pgmq.create('test_read_queue');
+ create 
+--------
+ 
+(1 row)
+
+-- Sending 3 messages to the queue
+SELECT send = :msg_id1 FROM pgmq.send('test_read_queue', '0');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT send = :msg_id2 FROM pgmq.send('test_read_queue', '0');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT send = :msg_id3 FROM pgmq.send('test_read_queue', '0');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Reading with limit respects the limit
+SELECT msg_id = :msg_id1 FROM pgmq.read('test_read_queue', 5, 1);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Reading respects the VT
+SELECT ARRAY(
+    SELECT msg_id FROM pgmq.read('test_read_queue', 10, 5)
+) = ARRAY[:msg_id2, :msg_id3];
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Read with poll will poll until the first message is available
+SELECT clock_timestamp() AS start \gset
+SELECT msg_id = :msg_id1 FROM pgmq.read_with_poll('test_read_queue', 10, 5, 5, 100);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT clock_timestamp() - :'start' > '3 second'::interval;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- test_purge_queue
+SELECT pgmq.create('test_purge_queue');
+ create 
+--------
+ 
+(1 row)
+
+SELECT * from pgmq.send('test_purge_queue', '0');
+ send 
+------
+    1
+(1 row)
+
+SELECT * from pgmq.send('test_purge_queue', '0');
+ send 
+------
+    2
+(1 row)
+
+SELECT * from pgmq.send('test_purge_queue', '0');
+ send 
+------
+    3
+(1 row)
+
+SELECT * from pgmq.send('test_purge_queue', '0');
+ send 
+------
+    4
+(1 row)
+
+SELECT * from pgmq.send('test_purge_queue', '0');
+ send 
+------
+    5
+(1 row)
+
+SELECT * FROM pgmq.purge_queue('test_purge_queue');
+ purge_queue 
+-------------
+           5
+(1 row)
+
+SELECT COUNT(*) = 0 FROM pgmq.q_test_purge_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- test_pop
+SELECT pgmq.create('test_pop_queue');
+ create 
+--------
+ 
+(1 row)
+
+SELECT * FROM pgmq.pop('test_pop_queue');
+ msg_id | read_ct | enqueued_at | vt | message 
+--------+---------+-------------+----+---------
+(0 rows)
+
+SELECT send AS first_msg_id from pgmq.send('test_pop_queue', '0') \gset
+SELECT * from pgmq.send('test_pop_queue', '0');
+ send 
+------
+    2
+(1 row)
+
+SELECT * from pgmq.send('test_pop_queue', '0');
+ send 
+------
+    3
+(1 row)
+
+SELECT msg_id = :first_msg_id FROM pgmq.pop('test_pop_queue');
+ ?column? 
+----------
+ t
+(1 row)
+
+-- test_set_vt
+SELECT pgmq.create('test_set_vt_queue');
+ create 
+--------
+ 
+(1 row)
+
+SELECT * FROM pgmq.set_vt('test_set_vt_queue', 9999, 0);
+ msg_id | read_ct | enqueued_at | vt | message 
+--------+---------+-------------+----+---------
+(0 rows)
+
+SELECT send AS first_msg_id from pgmq.send('test_set_vt_queue', '0') \gset
+-- set message invisible for 100 seconds
+SELECT msg_id FROM pgmq.set_vt('test_set_vt_queue', :first_msg_id, 100);
+ msg_id 
+--------
+      1
+(1 row)
+
+-- read message, it should not be visible
+SELECT msg_id from pgmq.read('test_set_vt_queue', 1, 1);
+ msg_id 
+--------
+(0 rows)
+
+-- make it visible
+SELECT msg_id FROM pgmq.set_vt('test_set_vt_queue', :first_msg_id, 0);
+ msg_id 
+--------
+      1
+(1 row)
+
+-- set vt works if message is readable
+SELECT msg_id from pgmq.read('test_set_vt_queue', 1, 1);
+ msg_id 
+--------
+      1
+(1 row)
+
+-- test_partitioned_delete
+\set partition_interval 1
+\set retention_interval 2
+-- We first will drop pg_partman and assert that create fails without the
+-- extension installed
+DROP EXTENSION pg_partman;
+SELECT * FROM pgmq.create_partitioned(
+    'test_partitioned_queue',
+    :'partition_interval',
+    :'retention_interval'
+);
+ERROR:  pg_partman is required for partitioned queues
+CONTEXT:  PL/pgSQL function pgmq._ensure_pg_partman_installed() line 12 at RAISE
+SQL statement "SELECT pgmq._ensure_pg_partman_installed()"
+PL/pgSQL function pgmq.create_partitioned(text,text,text) line 6 at PERFORM
+-- With the extension existing, the queue is created successfully
+CREATE EXTENSION pg_partman;
+SELECT * FROM pgmq.create_partitioned(
+    'test_partitioned_queue',
+    :'partition_interval',
+    :'retention_interval'
+);
+ create_partitioned 
+--------------------
+ 
+(1 row)
+
+-- queue shows up in list queues
+SELECT queue_name FROM pgmq.list_queues()
+ WHERE queue_name = 'test_partitioned_queue';
+       queue_name       
+------------------------
+ test_partitioned_queue
+(1 row)
+
+-- Sending 3 messages to the queue
+SELECT send AS msg_id1 from pgmq.send('test_partitioned_queue', '0') \gset
+SELECT send AS msg_id2 from pgmq.send('test_partitioned_queue', '0') \gset
+SELECT send AS msg_id3 from pgmq.send('test_partitioned_queue', '0') \gset
+SELECT COUNT(*) = 3 FROM pgmq.q_test_partitioned_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Deleting message 3
+SELECT * FROM pgmq.delete('test_partitioned_queue', :msg_id3);
+ delete 
+--------
+ t
+(1 row)
+
+SELECT COUNT(*) = 2 FROM pgmq.q_test_partitioned_queue;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Deleting batch
+SELECT ARRAY(
+    SELECT archive FROM pgmq.archive(
+        'test_partitioned_queue',
+        ARRAY[:msg_id1, :msg_id2, :msg_id3, -3]
+    )
+) = ARRAY[:msg_id1, :msg_id2]::bigint[];
+ ?column? 
+----------
+ t
+(1 row)
+
+-- test_transaction_create
+BEGIN;
+SELECT pgmq.create('transaction_test_queue');
+ create 
+--------
+ 
+(1 row)
+
+ROLLBACK;
+SELECT tablename FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'q_transaction_test_queue';
+ tablename 
+-----------
+(0 rows)
+
+-- test_transaction_send
+-- TODO: Needs multiple connections.
+-- test_transaction_read
+-- TODO: Needs multiple connections.
+-- test_detach_archive
+SELECT pgmq.create('detach_archive_queue');
+ create 
+--------
+ 
+(1 row)
+
+DROP EXTENSION pgmq CASCADE;
+SELECT tablename FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'a_detach_archive_queue';
+ tablename 
+-----------
+(0 rows)
+
+-- With detach, archive remains
+CREATE EXTENSION pgmq;
+SELECT pgmq.create('detach_archive_queue');
+ create 
+--------
+ 
+(1 row)
+
+SELECT pgmq.detach_archive('detach_archive_queue');
+ detach_archive 
+----------------
+ 
+(1 row)
+
+DROP EXTENSION pgmq CASCADE;
+SELECT tablename FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'a_detach_archive_queue';
+       tablename        
+------------------------
+ a_detach_archive_queue
+(1 row)
+

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -1,0 +1,244 @@
+-- CREATE pgmq.
+CREATE EXTENSION pgmq;
+CREATE EXTENSION pg_partman;
+
+-- test_unlogged
+-- CREATE with default retention and partition strategy
+SELECT pgmq.create_unlogged('test_unlogged_queue');
+SELECT * from pgmq.send('test_unlogged_queue', '{"hello": "world"}');
+SELECT msg_id, read_ct, enqueued_at > NOW(), vt > NOW(), message
+  FROM pgmq.read('test_unlogged_queue', 2, 1);
+
+-- test_max_queue_name_size
+-- CREATE with default retention and partition strategy
+SELECT pgmq.create(repeat('a', 48));
+SELECT pgmq.create(repeat('a', 47));
+
+-- test_lifecycle
+-- CREATE with default retention and partition strategy
+SELECT pgmq.create('test_default_queue');
+
+-- creating a queue must be idempotent
+-- create with same name again, must be no error
+SELECT pgmq.create('test_default_queue');
+
+SELECT * from pgmq.send('test_default_queue', '{"hello": "world"}');
+
+-- read message
+-- vt=2, limit=1
+\set msg_id 1
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
+
+-- set VT to 5 seconds
+SELECT vt > clock_timestamp() + '4 seconds'::interval
+  FROM pgmq.set_vt('test_default_queue', :msg_id, 5);
+
+-- read again, assert no messages because we just set VT to the future
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
+
+-- read again, now using poll to block until message is ready
+SELECT msg_id = :msg_id FROM pgmq.read_with_poll('test_default_queue', 10, 1, 10);
+
+-- after reading it, set VT to now
+SELECT msg_id = :msg_id FROM pgmq.set_vt('test_default_queue', :msg_id, 0);
+
+-- read again, should have msg_id 1 again
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
+
+-- send a batch of 2 messages
+SELECT pgmq.create('batch_queue');
+SELECT ARRAY( SELECT pgmq.send_batch(
+    'batch_queue',
+    ARRAY['{"hello": "world_0"}', '{"hello": "world_1"}']::jsonb[]
+)) = ARRAY[1, 2]::BIGINT[];
+
+-- CREATE with 5 seconds per partition, 10 seconds retention
+SELECT pgmq.create_partitioned('test_duration_queue', '5 seconds', '10 seconds');
+
+-- CREATE with 10 messages per partition, 20 messages retention
+SELECT pgmq.create_partitioned('test_numeric_queue', '10 seconds', '20 seconds');
+
+-- get metrics
+SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_messages
+ FROM pgmq.metrics('test_duration_queue');
+
+-- get metrics all
+SELECT * from {PGMQ_SCHEMA}.metrics_all();
+
+-- delete all the queues
+-- delete partitioned queues
+SELECT pgmq.drop_queue(queue, true)
+  FROM unnest('{test_duration_queue, test_numeric_queue}'::text[]) AS queue;
+
+-- drop the rest of the queues
+SELECT pgmq.drop_queue(q.queue_name, true)
+  FROM (SELECT queue_name FROM pgmq.list_queues()) AS q;
+
+SELECT queue_name FROM pgmq.list_queues();
+
+-- test_archive
+SELECT pgmq.create('archive_queue');
+
+-- no messages in the queue
+SELECT COUNT(*) = 0 FROM pgmq.q_archive_queue;
+
+-- no messages in queue archive
+SELECT COUNT(*) = 0 FROM pgmq.a_archive_queue;
+
+-- put messages on the queue
+\set msg_id1 1::bigint
+\set msg_id2 2::bigint
+SELECT send = :msg_id1 FROM pgmq.send('archive_queue', '0');
+SELECT send = :msg_id2 FROM pgmq.send('archive_queue', '0');
+
+-- two messages in the queue
+SELECT COUNT(*) = 2 FROM pgmq.q_archive_queue;
+
+-- archive the message. The first two exist so the id should be returned, the
+-- last one doesn't
+SELECT ARRAY(
+    SELECT * FROM pgmq.archive('archive_queue', ARRAY[:msg_id1, :msg_id2])
+) = ARRAY[:msg_id1, :msg_id2];
+
+-- should be no messages left on the queue table
+SELECT COUNT(*) = 0 FROM pgmq.q_archive_queue;
+
+-- should be two messages in archive
+SELECT COUNT(*) = 2 FROM pgmq.a_archive_queue;
+
+\set msg_id3 3::bigint
+SELECT send = :msg_id3 FROM pgmq.send('archive_queue', '0');
+SELECT COUNT(*) = 1 FROM pgmq.q_archive_queue;
+SELECT * FROM pgmq.archive('archive_queue', :msg_id3);
+SELECT COUNT(*) = 0 FROM pgmq.q_archive_queue;
+SELECT COUNT(*) = 3 FROM pgmq.a_archive_queue;
+
+-- test_read_read_with_poll
+-- Creating queue
+SELECT pgmq.create('test_read_queue');
+
+-- Sending 3 messages to the queue
+SELECT send = :msg_id1 FROM pgmq.send('test_read_queue', '0');
+SELECT send = :msg_id2 FROM pgmq.send('test_read_queue', '0');
+SELECT send = :msg_id3 FROM pgmq.send('test_read_queue', '0');
+
+-- Reading with limit respects the limit
+SELECT msg_id = :msg_id1 FROM pgmq.read('test_read_queue', 5, 1);
+
+-- Reading respects the VT
+SELECT ARRAY(
+    SELECT msg_id FROM pgmq.read('test_read_queue', 10, 5)
+) = ARRAY[:msg_id2, :msg_id3];
+
+-- Read with poll will poll until the first message is available
+SELECT clock_timestamp() AS start \gset
+SELECT msg_id = :msg_id1 FROM pgmq.read_with_poll('test_read_queue', 10, 5, 5, 100);
+SELECT clock_timestamp() - :'start' > '3 second'::interval;
+
+-- test_purge_queue
+SELECT pgmq.create('test_purge_queue');
+SELECT * from pgmq.send('test_purge_queue', '0');
+SELECT * from pgmq.send('test_purge_queue', '0');
+SELECT * from pgmq.send('test_purge_queue', '0');
+SELECT * from pgmq.send('test_purge_queue', '0');
+SELECT * from pgmq.send('test_purge_queue', '0');
+
+SELECT * FROM pgmq.purge_queue('test_purge_queue');
+SELECT COUNT(*) = 0 FROM pgmq.q_test_purge_queue;
+
+-- test_pop
+SELECT pgmq.create('test_pop_queue');
+SELECT * FROM pgmq.pop('test_pop_queue');
+
+SELECT send AS first_msg_id from pgmq.send('test_pop_queue', '0') \gset
+SELECT * from pgmq.send('test_pop_queue', '0');
+SELECT * from pgmq.send('test_pop_queue', '0');
+
+SELECT msg_id = :first_msg_id FROM pgmq.pop('test_pop_queue');
+
+-- test_set_vt
+SELECT pgmq.create('test_set_vt_queue');
+SELECT * FROM pgmq.set_vt('test_set_vt_queue', 9999, 0);
+
+SELECT send AS first_msg_id from pgmq.send('test_set_vt_queue', '0') \gset
+
+-- set message invisible for 100 seconds
+SELECT msg_id FROM pgmq.set_vt('test_set_vt_queue', :first_msg_id, 100);
+
+-- read message, it should not be visible
+SELECT msg_id from pgmq.read('test_set_vt_queue', 1, 1);
+
+-- make it visible
+SELECT msg_id FROM pgmq.set_vt('test_set_vt_queue', :first_msg_id, 0);
+
+-- set vt works if message is readable
+SELECT msg_id from pgmq.read('test_set_vt_queue', 1, 1);
+
+-- test_partitioned_delete
+\set partition_interval 1
+\set retention_interval 2
+
+-- We first will drop pg_partman and assert that create fails without the
+-- extension installed
+DROP EXTENSION pg_partman;
+
+SELECT * FROM pgmq.create_partitioned(
+    'test_partitioned_queue',
+    :'partition_interval',
+    :'retention_interval'
+);
+
+-- With the extension existing, the queue is created successfully
+CREATE EXTENSION pg_partman;
+SELECT * FROM pgmq.create_partitioned(
+    'test_partitioned_queue',
+    :'partition_interval',
+    :'retention_interval'
+);
+
+-- queue shows up in list queues
+SELECT queue_name FROM pgmq.list_queues()
+ WHERE queue_name = 'test_partitioned_queue';
+
+-- Sending 3 messages to the queue
+SELECT send AS msg_id1 from pgmq.send('test_partitioned_queue', '0') \gset
+SELECT send AS msg_id2 from pgmq.send('test_partitioned_queue', '0') \gset
+SELECT send AS msg_id3 from pgmq.send('test_partitioned_queue', '0') \gset
+
+SELECT COUNT(*) = 3 FROM pgmq.q_test_partitioned_queue;
+
+-- Deleting message 3
+SELECT * FROM pgmq.delete('test_partitioned_queue', :msg_id3);
+SELECT COUNT(*) = 2 FROM pgmq.q_test_partitioned_queue;
+
+-- Deleting batch
+SELECT ARRAY(
+    SELECT archive FROM pgmq.archive(
+        'test_partitioned_queue',
+        ARRAY[:msg_id1, :msg_id2, :msg_id3, -3]
+    )
+) = ARRAY[:msg_id1, :msg_id2]::bigint[];
+
+-- test_transaction_create
+BEGIN;
+SELECT pgmq.create('transaction_test_queue');
+ROLLBACK;
+SELECT tablename FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'q_transaction_test_queue';
+
+-- test_transaction_send
+-- TODO: Needs multiple connections.
+
+-- test_transaction_read
+-- TODO: Needs multiple connections.
+
+-- test_detach_archive
+SELECT pgmq.create('detach_archive_queue');
+DROP EXTENSION pgmq CASCADE;
+SELECT tablename FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'a_detach_archive_queue';
+
+-- With detach, archive remains
+CREATE EXTENSION pgmq;
+SELECT pgmq.create('detach_archive_queue');
+SELECT pgmq.detach_archive('detach_archive_queue');
+DROP EXTENSION pgmq CASCADE;
+SELECT tablename FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'a_detach_archive_queue';


### PR DESCRIPTION
Pretty much a direct port from
`integration_test/tests/integration_tests.rs` to `test/sql/base.sql`, with the expected output in `test/expected/base.out`. The only tests not ported here are `test_transaction_send()` and `test_transaction_read()`, because they require multiple connections. Will have to look into TAP tests for that.

Update the `Makefile` with the configuration necessary for `make installcheck` to run the tests, and also simplify the line reading the version from `pgmq.control`. Tell Git to ignore temporary files output by `installcheck`, as well as `.vscode` directory (to which I add spellings).