### PR TITLE
Port test_transaction_send & test_transaction_read

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -55,23 +55,7 @@ jobs:
     steps:
       - run: pg-start ${{ matrix.pg }}
       - uses: actions/checkout@v4
-      - run: apt install -y pkg-config
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: "pgmq-extension-test-${{ matrix.pg }}"
-          workspaces: |
-            pgmq
-      - name: Install pg_partman
-        run: |
-          git clone https://github.com/pgpartman/pg_partman.git && \
-          cd pg_partman && \
-          git checkout v4.7.4 && \
-          make && \
-          make install
+      - run: pgxn install 'pg_partman=4.7.3'
       - run: pg-build-test
 
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Trunk.toml
 .vscode/
 /results/
 /regression.*
+/output_iso/

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ DATA         = $(wildcard sql/*--*.sql)
 TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test
+EXTRA_CLEAN  = $(EXTENSION)-$(EXTVERSION).zip sql/$(EXTENSION)--$(EXTVERSION).sql META.json Trunk.toml
+
+# pg_isolation_regress available in v14 and higher.
+ifeq ($(shell test $$(pg_config --version | awk '{print $$2}' | awk 'BEGIN { FS = "." }; { print $$1 }') -ge 14; echo $$?),0)
+ISOLATION   = $(patsubst test/specs/%.spec,%,$(wildcard test/specs/*.spec))
+ISOLATION_OPTS = $(REGRESS_OPTS)
+endif
 
 PG_CONFIG   ?= pg_config
 
@@ -33,12 +40,6 @@ META.json:
 
 Trunk.toml:
 	sed 's/@@VERSION@@/$(EXTVERSION)/g' Trunk.toml.in > Trunk.toml
-
-clean:
-	@rm -rf "$(EXTENSION)-$(EXTVERSION).zip"
-	@rm -rf "sql/$(EXTENSION)--$(EXTVERSION).sql"
-	@rm -rf META.json
-	@rm -rf Trunk.toml
 
 install-pg-partman:
 	git clone https://github.com/pgpartman/pg_partman.git && \

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -535,10 +535,6 @@ SELECT tablename FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'q_tra
 -----------
 (0 rows)
 
--- test_transaction_send
--- TODO: Needs multiple connections.
--- test_transaction_read
--- TODO: Needs multiple connections.
 -- test_detach_archive
 SELECT pgmq.create('detach_archive_queue');
  create 

--- a/test/expected/transaction_tests.out
+++ b/test/expected/transaction_tests.out
@@ -1,0 +1,62 @@
+Parsed test spec with 2 sessions
+
+starting permutation: c1create c1begin c1send c2read c1commit c2read c1delete
+step c1create: SELECT pgmq.create('transaction_test_queue');
+create
+------
+      
+(1 row)
+
+step c1begin: BEGIN;
+step c1send: SELECT * FROM pgmq.send('transaction_test_queue', '1');
+send
+----
+   1
+(1 row)
+
+step c2read: SELECT msg_id FROM pgmq.read('transaction_test_queue', 0, 1)
+msg_id
+------
+(0 rows)
+
+step c1commit: COMMIT;
+step c2read: SELECT msg_id FROM pgmq.read('transaction_test_queue', 0, 1)
+msg_id
+------
+     1
+(1 row)
+
+step c1delete: SELECT * FROM pgmq.delete('transaction_test_queue', 1);
+delete
+------
+t     
+(1 row)
+
+
+starting permutation: c1send c1begin c2begin c1read c2read c1rollback c2read
+step c1send: SELECT * FROM pgmq.send('transaction_test_queue', '1');
+send
+----
+   2
+(1 row)
+
+step c1begin: BEGIN;
+step c2begin: BEGIN;
+step c1read: SELECT msg_id FROM pgmq.read('transaction_test_queue', 0, 1)
+msg_id
+------
+     2
+(1 row)
+
+step c2read: SELECT msg_id FROM pgmq.read('transaction_test_queue', 0, 1)
+msg_id
+------
+(0 rows)
+
+step c1rollback: ROLLBACK;
+step c2read: SELECT msg_id FROM pgmq.read('transaction_test_queue', 0, 1)
+msg_id
+------
+     2
+(1 row)
+

--- a/test/specs/transaction_tests.spec
+++ b/test/specs/transaction_tests.spec
@@ -1,0 +1,26 @@
+# https://github.com/postgres/postgres/tree/master/src/test/isolation
+
+setup {
+  CREATE EXTENSION IF NOT EXISTS pg_partman;
+  CREATE EXTENSION IF NOT EXISTS pgmq;
+}
+
+# test_transaction_send
+session conn1
+step c1create { SELECT pgmq.create('transaction_test_queue'); }
+step c1begin { BEGIN; }
+step c1send  { SELECT * FROM pgmq.send('transaction_test_queue', '1'); }
+step c1commit { COMMIT; }
+step c1delete { SELECT * FROM pgmq.delete('transaction_test_queue', 1); }
+step c1read { SELECT msg_id FROM pgmq.read('transaction_test_queue', 0, 1) }
+step c1rollback { ROLLBACK; }
+
+session conn2
+step c2begin { BEGIN; }
+step c2read { SELECT msg_id FROM pgmq.read('transaction_test_queue', 0, 1) }
+
+# test_transaction_send
+permutation c1create c1begin c1send c2read c1commit c2read c1delete
+
+# test_transaction_read
+permutation c1send c1begin c2begin c1read c2read c1rollback c2read

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -225,12 +225,6 @@ SELECT pgmq.create('transaction_test_queue');
 ROLLBACK;
 SELECT tablename FROM pg_tables WHERE schemaname = 'pgmq' AND tablename = 'q_transaction_test_queue';
 
--- test_transaction_send
--- TODO: Needs multiple connections.
-
--- test_transaction_read
--- TODO: Needs multiple connections.
-
 -- test_detach_archive
 SELECT pgmq.create('detach_archive_queue');
 DROP EXTENSION pgmq CASCADE;


### PR DESCRIPTION
Use ISOLATION tests to manage multiple database connections. The port is pretty straightforward, although `pg_isolation_regress` is only installed on Postgres 14 and higher. So don't the `ISOLATION` variables in the `Makefile` for earlier versions.

Also use the `pgxn` client so simplify the installation of `pg_partman` in `extension_ci.yml`, and remove the Rust configuration for running tests, as they are no longer used.

Also: use `EXTRA_CLEAN` to add additional files to the `clean` target, rather than override the target defined by PGXS.