### PR TITLE
docs: Community `PGMQ` Python Client Support for `SQLAlchemy` ORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To update PGMQ versions, follow the instructions in [UPDATING.md](UPDATING.md).
 ## Client Libraries
 
 - [Rust](https://github.com/tembo-io/pgmq/tree/main/pgmq-rs)
-- [Python](https://github.com/tembo-io/pgmq/tree/main/tembo-pgmq-python)
+- [Python (only for psycopg3)](https://github.com/tembo-io/pgmq/tree/main/tembo-pgmq-python)
 
 Community
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Community
 - [Kotlin JVM (JDBC)](https://github.com/vdsirotkin/pgmq-kotlin-jvm)
 - [Javascript (NodeJs)](https://github.com/Muhammad-Magdi/pgmq-js)
 - [.NET](https://github.com/brianpursley/Npgmq)
+- [Python (with SQLAlchemy)](https://github.com/jason810496/pgmq-sqlalchemy)
 
 ## SQL Examples
 


### PR DESCRIPTION
Hi team,

Thank you for developing `tembo_pgmq_python`.

For my use cases, using `SQLAlchemy` ORM as the `PGMQ` client is more flexible (as most Python backend developers won't directly use Python Postgres DBAPIs).

Currently, the `PGMQ` Python client only supports `psycopg` (also known as `psycopg3`).

I have created a fork called [pgmq-sqlalchemy](https://github.com/jason810496/pgmq-sqlalchemy), which supports constructing from both `SQLAlchemy` async and sync `engines`, `sessionmakers`, or built from DSN.
The package is [thoroughly tested](https://app.codecov.io/gh/jason810496/pgmq-sqlalchemy) (with all combinations of DBAPIs and construction methods) and provides [detailed documentation](https://pgmq-sqlalchemy.readthedocs.io/en/latest/).

