### PR TITLE
update pgxn release workflow

### DIFF
--- a/.github/workflows/pgxn-release.yml
+++ b/.github/workflows/pgxn-release.yml
@@ -8,11 +8,14 @@ jobs:
     name: Release on PGXN
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
+    defaults:
+      run:
+        working-directory: ./pgmq-extension
     steps:
     - name: Check out the repo
       uses: actions/checkout@v4
     - name: Bundle the Release
-      run: cd pgmq-extension && make dist
+      run: make dist
     - name: Release on PGXN
       env:
         PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}

--- a/pgmq-extension/README.md
+++ b/pgmq-extension/README.md
@@ -1,0 +1,1 @@
+/Users/adamhendel/repos/pgmq/README.md

--- a/pgmq-extension/UPDATING.md
+++ b/pgmq-extension/UPDATING.md
@@ -1,0 +1,1 @@
+/Users/adamhendel/repos/pgmq/UPDATING.md


### PR DESCRIPTION
The extension lives in `./pgmq-extension`, so symlinking the required docs for the pgxn release into that directory and updating the workflow.