### PR TITLE
reject escape characters in queue names

### DIFF
--- a/pgmq-extension/sql/pgmq--1.4.1--1.4.2.sql
+++ b/pgmq-extension/sql/pgmq--1.4.1--1.4.2.sql
@@ -1,3 +1,14 @@
+CREATE OR REPLACE FUNCTION pgmq.format_table_name(queue_name text, prefix text)
+RETURNS TEXT AS $$
+BEGIN
+    IF queue_name ~ '\$|;|--|'''
+    THEN
+        RAISE EXCEPTION 'queue name contains invalid characters: $, ;, --, or \''';
+    END IF;
+    RETURN lower(prefix || '_' || queue_name);
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION pgmq.create_non_partitioned(queue_name TEXT)
 RETURNS void AS $$
 DECLARE

--- a/pgmq-extension/sql/pgmq--1.4.1--1.4.2.sql
+++ b/pgmq-extension/sql/pgmq--1.4.1--1.4.2.sql
@@ -1,7 +1,7 @@
 CREATE OR REPLACE FUNCTION pgmq.format_table_name(queue_name text, prefix text)
 RETURNS TEXT AS $$
 BEGIN
-    IF queue_name ~ '\$|;|--|''|\s'
+    IF queue_name ~ '\$|;|--|'''
     THEN
         RAISE EXCEPTION 'queue name contains invalid characters: $, ;, --, or \''';
     END IF;

--- a/pgmq-extension/sql/pgmq--1.4.1--1.4.2.sql
+++ b/pgmq-extension/sql/pgmq--1.4.1--1.4.2.sql
@@ -78,7 +78,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pgmq.create_partitioned(
+CREATE FUNCTION pgmq.create_partitioned(
   queue_name TEXT,
   partition_interval TEXT DEFAULT '10000',
   retention_interval TEXT DEFAULT '100000'
@@ -89,6 +89,8 @@ DECLARE
   a_partition_col TEXT;
   qtable TEXT := pgmq.format_table_name(queue_name, 'q');
   atable TEXT := pgmq.format_table_name(queue_name, 'a');
+  fq_qtable TEXT := 'pgmq.' || qtable;
+  fq_atable TEXT := 'pgmq.' || atable;
 BEGIN
   PERFORM pgmq.validate_queue_name(queue_name);
   PERFORM pgmq._ensure_pg_partman_installed();
@@ -114,7 +116,7 @@ BEGIN
   -- https://github.com/pgpartman/pg_partman/blob/master/doc/pg_partman.md
   -- p_parent_table - the existing parent table. MUST be schema qualified, even if in public schema.
   PERFORM public.create_parent(
-    FORMAT('pgmq.%s', qtable),
+    fq_qtable,
     partition_col, 'native', partition_interval
   );
 
@@ -175,7 +177,7 @@ BEGIN
   -- https://github.com/pgpartman/pg_partman/blob/master/doc/pg_partman.md
   -- p_parent_table - the existing parent table. MUST be schema qualified, even if in public schema.
   PERFORM public.create_parent(
-    FORMAT('%s', 'pgmq.' || atable),
+    fq_atable,
     a_partition_col, 'native', partition_interval
   );
 

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -44,7 +44,7 @@ CREATE TYPE pgmq.queue_record AS (
 CREATE FUNCTION pgmq.format_table_name(queue_name text, prefix text)
 RETURNS TEXT AS $$
 BEGIN
-    IF queue_name ~ '\$|;|--|''|\s'
+    IF queue_name ~ '\$|;|--|'''
     THEN
         RAISE EXCEPTION 'queue name contains invalid characters: $, ;, --, or \''';
     END IF;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -721,6 +721,8 @@ DECLARE
   a_partition_col TEXT;
   qtable TEXT := pgmq.format_table_name(queue_name, 'q');
   atable TEXT := pgmq.format_table_name(queue_name, 'a');
+  fq_qtable TEXT := 'pgmq.' || qtable;
+  fq_atable TEXT := 'pgmq.' || atable;
 BEGIN
   PERFORM pgmq.validate_queue_name(queue_name);
   PERFORM pgmq._ensure_pg_partman_installed();
@@ -746,7 +748,7 @@ BEGIN
   -- https://github.com/pgpartman/pg_partman/blob/master/doc/pg_partman.md
   -- p_parent_table - the existing parent table. MUST be schema qualified, even if in public schema.
   PERFORM public.create_parent(
-    FORMAT('pgmq.%s', qtable),
+    fq_qtable,
     partition_col, 'native', partition_interval
   );
 
@@ -807,7 +809,7 @@ BEGIN
   -- https://github.com/pgpartman/pg_partman/blob/master/doc/pg_partman.md
   -- p_parent_table - the existing parent table. MUST be schema qualified, even if in public schema.
   PERFORM public.create_parent(
-    FORMAT('%s', 'pgmq.' || atable),
+    fq_atable,
     a_partition_col, 'native', partition_interval
   );
 

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -631,22 +631,9 @@ SELECT
      delete from pgmq.q_abc',
      1
   );
-NOTICE:  identifier "q_abc where false;
-     create table public.attack_vector(id int);
-     delete from pgmq.q_abc" will be truncated to "q_abc where false;
-     create table public.attack_vector(id in"
-ERROR:  relation "pgmq.q_abc where false;
-     create table public.attack_vector(id in" does not exist
-LINE 2:         DELETE FROM pgmq."q_abc where false;
-                            ^
-QUERY:  
-        DELETE FROM pgmq."q_abc where false;
-     create table public.attack_vector(id int);
-     delete from pgmq.q_abc"
-        WHERE msg_id = $1
-        RETURNING msg_id
-        
-CONTEXT:  PL/pgSQL function pgmq.delete(text,bigint) line 15 at EXECUTE
+ERROR:  queue name contains invalid characters: $, ;, --, or \'
+CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
+PL/pgSQL function pgmq.delete(text,bigint) line 5 during statement block local variable initialization
 --Special characters in queue name
 SELECT pgmq.create('queue-hyphened');
  create 
@@ -667,30 +654,6 @@ SELECT msg_id, read_ct, message FROM pgmq.read('queue-hyphened', 1, 1);
 (1 row)
 
 SELECT pgmq.archive('queue-hyphened', 1);
- archive 
----------
- t
-(1 row)
-
-SELECT pgmq.create('dollar$-signed');
- create 
---------
- 
-(1 row)
-
-SELECT pgmq.send('dollar$-signed', '{"hello":"world"}');
- send 
-------
-    1
-(1 row)
-
-SELECT msg_id, read_ct, message FROM pgmq.read('dollar$-signed', 1, 1);
- msg_id | read_ct |      message       
---------+---------+--------------------
-      1 |       1 | {"hello": "world"}
-(1 row)
-
-SELECT pgmq.archive('dollar$-signed', 1);
  archive 
 ---------
  t
@@ -744,30 +707,6 @@ SELECT pgmq.archive('queue-hyphened-part', 1);
  t
 (1 row)
 
-SELECT pgmq.create_partitioned('dollar$-signed-part');
- create_partitioned 
---------------------
- 
-(1 row)
-
-SELECT pgmq.send('dollar$-signed-part', '{"hello":"world"}');
- send 
-------
-    1
-(1 row)
-
-SELECT msg_id, read_ct, message FROM pgmq.read('dollar$-signed-part', 1, 1);
- msg_id | read_ct |      message       
---------+---------+--------------------
-      1 |       1 | {"hello": "world"}
-(1 row)
-
-SELECT pgmq.archive('dollar$-signed-part', 1);
- archive 
----------
- t
-(1 row)
-
 SELECT pgmq.create_partitioned('QueueCasedPart');
  create_partitioned 
 --------------------
@@ -792,6 +731,49 @@ SELECT pgmq.archive('QueueCasedPart', 1);
  t
 (1 row)
 
+-- fails with invalid queue name
+SELECT pgmq.create('dollar$-signed');
+ERROR:  queue name contains invalid characters: $, ;, --, or \'
+CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
+PL/pgSQL function pgmq.create_non_partitioned(text) line 3 during statement block local variable initialization
+SQL statement "SELECT pgmq.create_non_partitioned(queue_name)"
+PL/pgSQL function pgmq."create"(text) line 3 at PERFORM
+SELECT pgmq.create_partitioned('dollar$-signed-part');
+ERROR:  queue name contains invalid characters: $, ;, --, or \'
+CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
+PL/pgSQL function pgmq.create_partitioned(text,text,text) line 5 during statement block local variable initialization
+-- input validation success
+SELECT pgmq.format_table_name('cat', 'q');
+ format_table_name 
+-------------------
+ q_cat
+(1 row)
+
+SELECT pgmq.format_table_name('cat-dog', 'a');
+ format_table_name 
+-------------------
+ a_cat-dog
+(1 row)
+
+SELECT pgmq.format_table_name('cat_dog', 'q');
+ format_table_name 
+-------------------
+ q_cat_dog
+(1 row)
+
+-- input validation failure
+SELECT pgmq.format_table_name('dollar$fail', 'q');
+ERROR:  queue name contains invalid characters: $, ;, --, or \'
+CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
+SELECT pgmq.format_table_name('double--hyphen-fail', 'a');
+ERROR:  queue name contains invalid characters: $, ;, --, or \'
+CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
+SELECT pgmq.format_table_name('semicolon;fail', 'a');
+ERROR:  queue name contains invalid characters: $, ;, --, or \'
+CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
+SELECT pgmq.format_table_name($$single'quote-fail$$, 'a');
+ERROR:  queue name contains invalid characters: $, ;, --, or \'
+CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
 --Cleanup tests
 DROP EXTENSION pgmq CASCADE;
 DROP EXTENSION pg_partman CASCADE;

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -465,7 +465,7 @@ SELECT * FROM pgmq.create_partitioned(
 ERROR:  pg_partman is required for partitioned queues
 CONTEXT:  PL/pgSQL function pgmq._ensure_pg_partman_installed() line 12 at RAISE
 SQL statement "SELECT pgmq._ensure_pg_partman_installed()"
-PL/pgSQL function pgmq.create_partitioned(text,text,text) line 9 at PERFORM
+PL/pgSQL function pgmq.create_partitioned(text,text,text) line 11 at PERFORM
 -- With the extension existing, the queue is created successfully
 CREATE EXTENSION pg_partman;
 SELECT * FROM pgmq.create_partitioned(

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -617,6 +617,7 @@ SELECT pgmq.convert_archive_partitioned('long_queue_name_');
  
 (1 row)
 
+\set SHOW_CONTEXT never
 --Failed SQL injection attack
 SELECT pgmq.create('abc');
  create 
@@ -632,8 +633,6 @@ SELECT
      1
   );
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
-CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
-PL/pgSQL function pgmq.delete(text,bigint) line 5 during statement block local variable initialization
 --Special characters in queue name
 SELECT pgmq.create('queue-hyphened');
  create 
@@ -734,14 +733,8 @@ SELECT pgmq.archive('QueueCasedPart', 1);
 -- fails with invalid queue name
 SELECT pgmq.create('dollar$-signed');
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
-CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
-PL/pgSQL function pgmq.create_non_partitioned(text) line 3 during statement block local variable initialization
-SQL statement "SELECT pgmq.create_non_partitioned(queue_name)"
-PL/pgSQL function pgmq."create"(text) line 3 at PERFORM
 SELECT pgmq.create_partitioned('dollar$-signed-part');
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
-CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
-PL/pgSQL function pgmq.create_partitioned(text,text,text) line 5 during statement block local variable initialization
 -- input validation success
 SELECT pgmq.format_table_name('cat', 'q');
  format_table_name 
@@ -764,16 +757,12 @@ SELECT pgmq.format_table_name('cat_dog', 'q');
 -- input validation failure
 SELECT pgmq.format_table_name('dollar$fail', 'q');
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
-CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
 SELECT pgmq.format_table_name('double--hyphen-fail', 'a');
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
-CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
 SELECT pgmq.format_table_name('semicolon;fail', 'a');
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
-CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
 SELECT pgmq.format_table_name($$single'quote-fail$$, 'a');
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
-CONTEXT:  PL/pgSQL function pgmq.format_table_name(text,text) line 5 at RAISE
 --Cleanup tests
 DROP EXTENSION pgmq CASCADE;
 DROP EXTENSION pg_partman CASCADE;

--- a/pgmq-extension/test/sql/base.sql
+++ b/pgmq-extension/test/sql/base.sql
@@ -253,6 +253,8 @@ SELECT pgmq.convert_archive_partitioned('long_queue_name_12345678901234567890123
 SELECT pgmq.create('long_queue_name_');
 SELECT pgmq.convert_archive_partitioned('long_queue_name_');
 
+\set SHOW_CONTEXT never
+
 --Failed SQL injection attack
 SELECT pgmq.create('abc');
 SELECT

--- a/pgmq-extension/test/sql/base.sql
+++ b/pgmq-extension/test/sql/base.sql
@@ -269,11 +269,6 @@ SELECT pgmq.send('queue-hyphened', '{"hello":"world"}');
 SELECT msg_id, read_ct, message FROM pgmq.read('queue-hyphened', 1, 1);
 SELECT pgmq.archive('queue-hyphened', 1);
 
-SELECT pgmq.create('dollar$-signed');
-SELECT pgmq.send('dollar$-signed', '{"hello":"world"}');
-SELECT msg_id, read_ct, message FROM pgmq.read('dollar$-signed', 1, 1);
-SELECT pgmq.archive('dollar$-signed', 1);
-
 SELECT pgmq.create('QueueCased');
 SELECT pgmq.send('QueueCased', '{"hello":"world"}');
 SELECT msg_id, read_ct, message FROM pgmq.read('QueueCased', 1, 1);
@@ -284,15 +279,25 @@ SELECT pgmq.send('queue-hyphened-part', '{"hello":"world"}');
 SELECT msg_id, read_ct, message FROM pgmq.read('queue-hyphened-part', 1, 1);
 SELECT pgmq.archive('queue-hyphened-part', 1);
 
-SELECT pgmq.create_partitioned('dollar$-signed-part');
-SELECT pgmq.send('dollar$-signed-part', '{"hello":"world"}');
-SELECT msg_id, read_ct, message FROM pgmq.read('dollar$-signed-part', 1, 1);
-SELECT pgmq.archive('dollar$-signed-part', 1);
-
 SELECT pgmq.create_partitioned('QueueCasedPart');
 SELECT pgmq.send('QueueCasedPart', '{"hello":"world"}');
 SELECT msg_id, read_ct, message FROM pgmq.read('QueueCasedPart', 1, 1);
 SELECT pgmq.archive('QueueCasedPart', 1);
+
+-- fails with invalid queue name
+SELECT pgmq.create('dollar$-signed');
+SELECT pgmq.create_partitioned('dollar$-signed-part');
+
+-- input validation success
+SELECT pgmq.format_table_name('cat', 'q');
+SELECT pgmq.format_table_name('cat-dog', 'a');
+SELECT pgmq.format_table_name('cat_dog', 'q');
+
+-- input validation failure
+SELECT pgmq.format_table_name('dollar$fail', 'q');
+SELECT pgmq.format_table_name('double--hyphen-fail', 'a');
+SELECT pgmq.format_table_name('semicolon;fail', 'a');
+SELECT pgmq.format_table_name($$single'quote-fail$$, 'a');
 
 --Cleanup tests
 DROP EXTENSION pgmq CASCADE;


### PR DESCRIPTION
the following characters will no longer be allowed in queue names: `$`, `'`, `;`, `--`.  Also, we now only use `%s` on number values and in the raise notices.

This should hopefully close https://github.com/tembo-io/pgmq/issues/295

cc @olirice 
