### PR TITLE
Security Issue with SQLx 0.7.2

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.29.1"
+version = "0.29.2"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/tembo-io/pgmq"
 chrono = { version = "0.4.23", features = [ "serde" ] }
 serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = [ "raw_value" ] }
-sqlx = { version = "0.7.2", features = [ "runtime-tokio" , "postgres", "chrono", "json" ] }
+sqlx = { version = "0.8.1", features = [ "runtime-tokio" , "postgres", "chrono", "json" ] }
 thiserror = "1.0.38"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.17"


### PR DESCRIPTION
There seems to have been a critical security issue with SQLx that forced all clients to update. Here is a PR of just updating the version. Let me know if I need to make anymore changes!

[Link to RUSTSEC Security Issue](https://rustsec.org/advisories/RUSTSEC-2024-0363.html)

UPDATED:
 - Version bump from 0.7.2 to 0.8.1.

I have run the tests locally and it does seem to partial pass but it keeps throwing duplicate key constraints which seems to me indicates something wrong with the test more than just updating the version because it will pass previously failed tests and just keep swapping between failed and passed. Let me know if I should dig into this further as well.