### PR TITLE
tembo_pgmq_python: Add python async interface

### DIFF
--- a/.github/workflows/pgmq_python.yml
+++ b/.github/workflows/pgmq_python.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: |
           curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.7.1 python3 -
-          poetry install
+          poetry install --extras "async"
       - name: Unit and Integration Tests
         run: make test
 

--- a/tembo-pgmq-python/README.md
+++ b/tembo-pgmq-python/README.md
@@ -8,6 +8,13 @@ Install with `pip` from pypi.org:
 pip install tembo-pgmq-python
 ```
 
+In order to use async version install with the optional dependecies:
+
+``` bash
+pip install tembo-pgmq-python[async]
+```
+
+
 Dependencies:
 
 Postgres running the [Tembo PGMQ extension](https://github.com/tembo-io/tembo/tree/main/pgmq).
@@ -39,6 +46,20 @@ from tembo_pgmq_python import PGMQueue, Message
 
 queue = PGMQueue()
 ```
+
+### Note on the async version
+
+Initialization for the async version requires an explicit call of the initializer:
+
+``` bash
+from tembo_pgmq_python.async_queue import PGMQueue
+
+async def main():
+    queue = PGMQueue()
+    await queue.init()
+```
+
+Then, the interface is exactly the same as the sync version.
 
 ### Initialize a connection to Postgres without environment variables
 

--- a/tembo-pgmq-python/pyproject.toml
+++ b/tembo-pgmq-python/pyproject.toml
@@ -16,6 +16,10 @@ packages = [{include = "tembo_pgmq_python"}]
 python = ">=3.9"
 psycopg = {extras = ["binary", "pool"], version = "^3"}
 orjson = "^3"
+asyncpg = { version = "^0.29.0", optional = true }
+
+[tool.poetry.extras]
+async = ["asyncpg"]
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/tembo-pgmq-python/tembo_pgmq_python/async_queue.py
+++ b/tembo-pgmq-python/tembo_pgmq_python/async_queue.py
@@ -1,0 +1,241 @@
+from dataclasses import dataclass, field
+from typing import Optional, List
+import asyncpg
+import os
+
+from orjson import dumps, loads
+
+from tembo_pgmq_python.messages import Message, QueueMetrics
+
+
+@dataclass
+class PGMQueue:
+    """Base class for interacting with a queue"""
+
+    host: str = field(default_factory=lambda: os.getenv("PG_HOST", "localhost"))
+    port: str = field(default_factory=lambda: os.getenv("PG_PORT", "5432"))
+    database: str = field(default_factory=lambda: os.getenv("PG_DATABASE", "postgres"))
+    username: str = field(default_factory=lambda: os.getenv("PG_USERNAME", "postgres"))
+    password: str = field(default_factory=lambda: os.getenv("PG_PASSWORD", "postgres"))
+    delay: int = 0
+    vt: int = 30
+    pool_size: int = 10
+    pool: asyncpg.pool.Pool = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.host = self.host or "localhost"
+        self.port = self.port or "5432"
+        self.database = self.database or "postgres"
+        self.username = self.username or "postgres"
+        self.password = self.password or "postgres"
+
+        if not all([self.host, self.port, self.database, self.username, self.password]):
+            raise ValueError("Incomplete database connection information provided.")
+
+    async def init(self):
+        self.pool = await asyncpg.create_pool(
+            user=self.username,
+            database=self.database,
+            password=self.password,
+            host=self.host,
+            port=self.port,
+        )
+        async with self.pool.acquire() as conn:
+            await conn.fetch("create extension if not exists pgmq cascade;")
+
+    async def create_partitioned_queue(
+        self,
+        queue: str,
+        partition_interval: int = 10000,
+        retention_interval: int = 100000,
+    ) -> None:
+        """Create a new queue
+
+        Note: Partitions are created pg_partman which must be configured in postgresql.conf
+            Set `pg_partman_bgw.interval` to set the interval for partition creation and deletion.
+            A value of 10 will create new/delete partitions every 10 seconds. This value should be tuned
+            according to the volume of messages being sent to the queue.
+
+        Args:
+            queue: The name of the queue.
+            partition_interval: The number of messages per partition. Defaults to 10,000.
+            retention_interval: The number of messages to retain. Messages exceeding this number will be dropped.
+                Defaults to 100,000.
+        """
+
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                "SELECT pgmq.create($1, $2::text, $3::text);",
+                queue,
+                partition_interval,
+                retention_interval,
+            )
+
+    async def create_queue(self, queue: str, unlogged: bool = False) -> None:
+        """Create a new queue."""
+        async with self.pool.acquire() as conn:
+            if unlogged:
+                await conn.execute("SELECT pgmq.create_unlogged($1);", queue)
+            else:
+                await conn.execute("SELECT pgmq.create($1);", queue)
+
+    async def validate_queue_name(self, queue_name: str) -> None:
+        """Validate the length of a queue name."""
+        async with self.pool.acquire() as conn:
+            await conn.execute("SELECT pgmq.validate_queue_name($1);", queue_name)
+
+    async def drop_queue(self, queue: str, partitioned: bool = False) -> bool:
+        """Drop a queue."""
+        async with self.pool.acquire() as conn:
+            result = await conn.fetchrow("SELECT pgmq.drop_queue($1, $2);", queue, partitioned)
+        return result[0]
+
+    async def list_queues(self) -> List[str]:
+        """List all queues."""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("SELECT queue_name FROM pgmq.list_queues();")
+        return [row["queue_name"] for row in rows]
+
+    async def send(self, queue: str, message: dict, delay: int = 0) -> int:
+        """Send a message to a queue."""
+        async with self.pool.acquire() as conn:
+            result = await conn.fetchrow(
+                "SELECT * FROM pgmq.send($1, $2::jsonb, $3);", queue, dumps(message).decode("utf-8"), delay
+            )
+        return result[0]
+
+    async def send_batch(self, queue: str, messages: List[dict], delay: int = 0) -> List[int]:
+        """Send a batch of messages to a queue."""
+        jsonb_array = [dumps(message).decode("utf-8") for message in messages]
+
+        async with self.pool.acquire() as conn:
+            result = await conn.fetch(
+                "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3);",
+                queue,
+                jsonb_array,
+                delay,
+            )
+        return [message[0] for message in result]
+
+    async def read(self, queue: str, vt: Optional[int] = None) -> Optional[Message]:
+        """Read a message from a queue."""
+        batch_size = 1
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("SELECT * FROM pgmq.read($1, $2, $3);", queue, vt or self.vt, batch_size)
+        messages = [
+            Message(msg_id=row[0], read_ct=row[1], enqueued_at=row[2], vt=row[3], message=loads(row[4])) for row in rows
+        ]
+        return messages[0] if len(messages) == 1 else None
+
+    async def read_batch(self, queue: str, vt: Optional[int] = None, batch_size=1) -> Optional[List[Message]]:
+        """Read a batch of messages from a queue."""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("SELECT * FROM pgmq.read($1, $2, $3);", queue, vt or self.vt, batch_size)
+
+        return [
+            Message(msg_id=row[0], read_ct=row[1], enqueued_at=row[2], vt=row[3], message=loads(row[4])) for row in rows
+        ]
+
+    async def read_with_poll(
+        self,
+        queue: str,
+        vt: Optional[int] = None,
+        qty: int = 1,
+        max_poll_seconds: int = 5,
+        poll_interval_ms: int = 100,
+    ) -> Optional[List[Message]]:
+        """Read messages from a queue with polling."""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM pgmq.read_with_poll($1, $2, $3, $4, $5);",
+                queue,
+                vt or self.vt,
+                qty,
+                max_poll_seconds,
+                poll_interval_ms,
+            )
+
+        return [
+            Message(msg_id=row[0], read_ct=row[1], enqueued_at=row[2], vt=row[3], message=loads(row[4])) for row in rows
+        ]
+
+    async def pop(self, queue: str) -> Message:
+        """Pop a message from a queue."""
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch("SELECT * FROM pgmq.pop($1);", queue)
+
+        messages = [
+            Message(msg_id=row[0], read_ct=row[1], enqueued_at=row[2], vt=row[3], message=loads(row[4])) for row in rows
+        ]
+        return messages[0]
+
+    async def delete(self, queue: str, msg_id: int) -> bool:
+        """Delete a message from a queue."""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT pgmq.delete($1::text, $2::int);", queue, msg_id)
+
+        return row[0]
+
+    async def delete_batch(self, queue: str, msg_ids: List[int]) -> List[int]:
+        """Delete multiple messages from a queue."""
+        async with self.pool.acquire() as conn:
+            results = await conn.fetch("SELECT * FROM pgmq.delete($1::text, $2::int[]);", queue, msg_ids)
+        return [result[0] for result in results]
+
+    async def archive(self, queue: str, msg_id: int) -> bool:
+        """Archive a message from a queue."""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT pgmq.archive($1::text, $2::int);", queue, msg_id)
+
+        return row[0]
+
+    async def archive_batch(self, queue: str, msg_ids: List[int]) -> List[int]:
+        """Archive multiple messages from a queue."""
+        async with self.pool.acquire() as conn:
+            results = await conn.fetch("SELECT * FROM pgmq.archive($1::text, $2::int[]);", queue, msg_ids)
+        return [result[0] for result in results]
+
+    async def purge(self, queue: str) -> int:
+        """Purge a queue."""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT pgmq.purge_queue($1);", queue)
+
+        return row[0]
+
+    async def metrics(self, queue: str) -> QueueMetrics:
+        async with self.pool.acquire() as conn:
+            result = await conn.fetchrow("SELECT * FROM pgmq.metrics($1);", queue)
+        return QueueMetrics(
+            queue_name=result[0],
+            queue_length=result[1],
+            newest_msg_age_sec=result[2],
+            oldest_msg_age_sec=result[3],
+            total_messages=result[4],
+            scrape_time=result[5],
+        )
+
+    async def metrics_all(self) -> List[QueueMetrics]:
+        async with self.pool.acquire() as conn:
+            results = await conn.fetch("SELECT * FROM pgmq.metrics_all();")
+        return [
+            QueueMetrics(
+                queue_name=row[0],
+                queue_length=row[1],
+                newest_msg_age_sec=row[2],
+                oldest_msg_age_sec=row[3],
+                total_messages=row[4],
+                scrape_time=row[5],
+            )
+            for row in results
+        ]
+
+    async def set_vt(self, queue: str, msg_id: int, vt: int) -> Message:
+        """Set the visibility timeout for a specific message."""
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM pgmq.set_vt($1, $2, $3);", queue, msg_id, vt)
+        return Message(msg_id=row[0], read_ct=row[1], enqueued_at=row[2], vt=row[3], message=row[4])
+
+    async def detach_archive(self, queue: str) -> None:
+        """Detach an archive from a queue."""
+        async with self.pool.acquire() as conn:
+            await conn.fetch("select pgmq.detach_archive($1);", queue)

--- a/tembo-pgmq-python/tembo_pgmq_python/messages.py
+++ b/tembo-pgmq-python/tembo_pgmq_python/messages.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class Message:
+    msg_id: int
+    read_ct: int
+    enqueued_at: datetime
+    vt: datetime
+    message: dict
+
+
+@dataclass
+class QueueMetrics:
+    queue_name: str
+    queue_length: int
+    newest_msg_age_sec: int
+    oldest_msg_age_sec: int
+    total_messages: int
+    scrape_time: datetime

--- a/tembo-pgmq-python/tembo_pgmq_python/queue.py
+++ b/tembo-pgmq-python/tembo_pgmq_python/queue.py
@@ -1,28 +1,9 @@
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Optional, List
 from psycopg.types.json import Jsonb
 from psycopg_pool import ConnectionPool
 import os
-
-
-@dataclass
-class Message:
-    msg_id: int
-    read_ct: int
-    enqueued_at: datetime
-    vt: datetime
-    message: dict
-
-
-@dataclass
-class QueueMetrics:
-    queue_name: str
-    queue_length: int
-    newest_msg_age_sec: int
-    oldest_msg_age_sec: int
-    total_messages: int
-    scrape_time: datetime
+from tembo_pgmq_python.messages import Message, QueueMetrics
 
 
 @dataclass

--- a/tembo-pgmq-python/tests/test_async_integration.py
+++ b/tembo-pgmq-python/tests/test_async_integration.py
@@ -1,0 +1,222 @@
+import unittest
+import time
+from tembo_pgmq_python.messages import Message
+from tembo_pgmq_python.async_queue import PGMQueue
+from datetime import datetime, timezone, timedelta
+
+# Function to load environment variables
+
+
+class BaseTestPGMQueue(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        """Purge the queue before each test to ensure a clean state."""
+        self.queue = PGMQueue(
+            host="localhost",
+            port="5432",
+            username="postgres",
+            password="postgres",
+            database="postgres",
+        )
+        await self.queue.init()
+
+        # Test database connection first
+        try:
+            pool = self.queue.pool
+            async with pool.acquire() as conn:
+                await conn.fetch("SELECT 1")
+                print("Connection successful (without env)")
+        except Exception as e:
+            raise Exception(f"Database connection failed: {e}")
+
+        self.test_queue = "test_queue"
+        self.test_message = {"hello": "world"}
+        await self.queue.create_queue(self.test_queue)
+        await self.queue.purge(self.test_queue)
+
+    async def asyncTearDown(self):
+        await self.queue.pool.close()
+
+    async def test_create_queue(self):
+        """Test creating a queue."""
+        await self.queue.create_queue("test_queue_2")
+        msg_id = await self.queue.send("test_queue_2", self.test_message)
+        self.assertIsInstance(msg_id, int)
+
+    async def test_send_and_read_message(self):
+        """Test sending and reading a message from the queue."""
+        msg_id = await self.queue.send(self.test_queue, self.test_message)
+        message: Message = await self.queue.read(self.test_queue, vt=20)
+        self.assertEqual(message.message, self.test_message)
+        self.assertEqual(message.msg_id, msg_id, "Read the wrong message")
+
+    async def test_send_and_read_message_without_vt(self):
+        """Test sending and reading a message from the queue without VT."""
+        msg_id = await self.queue.send(self.test_queue, self.test_message)
+        message: Message = await self.queue.read(self.test_queue)
+        self.assertEqual(message.message, self.test_message)
+        self.assertEqual(message.msg_id, msg_id, "Read the wrong message")
+
+    async def test_send_message_with_delay(self):
+        """Test sending a message with a delay."""
+        msg_id = await self.queue.send(self.test_queue, self.test_message, delay=5)
+        message = await self.queue.read(self.test_queue, vt=20)
+        self.assertIsNone(message, "Message should not be visible yet")
+        time.sleep(5)
+        message: Message = await self.queue.read(self.test_queue, vt=20)
+        self.assertIsNotNone(message, "Message should be visible after delay")
+        self.assertEqual(message.message, self.test_message)
+        self.assertEqual(message.msg_id, msg_id, "Read the wrong message")
+
+    async def test_archive_message(self):
+        """Test archiving a message in the queue."""
+        _ = await self.queue.send(self.test_queue, self.test_message)
+        message = await self.queue.read(self.test_queue, vt=20)
+        await self.queue.archive(self.test_queue, message.msg_id)
+        message = await self.queue.read(self.test_queue, vt=20)
+        self.assertIsNone(message, "No message expected in queue")
+
+    async def test_delete_message(self):
+        """Test deleting a message from the queue."""
+        msg_id = await self.queue.send(self.test_queue, self.test_message)
+        await self.queue.delete(self.test_queue, msg_id)
+        message = await self.queue.read(self.test_queue, vt=20)
+        self.assertIsNone(message, "No message expected in queue")
+
+    async def test_send_batch(self):
+        """Test sending a batch of messages to the queue."""
+        messages = [self.test_message, self.test_message]
+        msg_ids = await self.queue.send_batch(self.test_queue, messages)
+        self.assertEqual(len(msg_ids), 2)
+
+    async def test_read_batch(self):
+        """Test reading a batch of messages from the queue."""
+        messages = [self.test_message, self.test_message]
+        await self.queue.send_batch(self.test_queue, messages)
+        read_messages = await self.queue.read_batch(self.test_queue, vt=20, batch_size=2)
+        self.assertEqual(len(read_messages), 2)
+        for message in read_messages:
+            self.assertEqual(message.message, self.test_message)
+        no_message = await self.queue.read(self.test_queue, vt=20)
+        self.assertIsNone(no_message, "Messages should be invisible after read_batch")
+
+    async def test_pop_message(self):
+        """Test popping a message from the queue."""
+        msg_id = await self.queue.send(self.test_queue, self.test_message)
+        message = await self.queue.pop(self.test_queue)
+        self.assertEqual(message.message, self.test_message)
+        self.assertEqual(message.msg_id, msg_id, "Popped the wrong message")
+
+    async def test_purge_queue(self):
+        """Test purging the queue."""
+        messages = [self.test_message, self.test_message]
+        await self.queue.send_batch(self.test_queue, messages)
+        purged = await self.queue.purge(self.test_queue)
+        self.assertEqual(purged, len(messages))
+
+    async def test_metrics(self):
+        """Test getting queue stats."""
+        await self.queue.create_queue(self.test_queue)
+        await self.queue.send(self.test_queue, self.test_message)
+        stats = await self.queue.metrics(self.test_queue)
+
+    async def test_metrics_all(self):
+        """Test getting metrics for all queues."""
+        await self.queue.create_queue(self.test_queue)
+        await self.queue.send(self.test_queue, self.test_message)
+        all_stats = await self.queue.metrics_all()
+        self.assertGreaterEqual(len(all_stats), 1)
+        for stats in all_stats:
+            self.assertIsInstance(stats.queue_name, str)
+            self.assertIsInstance(stats.queue_length, int)
+            self.assertIsInstance(stats.total_messages, int)
+            self.assertIsNotNone(stats.scrape_time)
+
+    async def test_read_with_poll(self):
+        """Test reading messages from the queue with polling."""
+        await self.queue.send(self.test_queue, self.test_message)
+        messages = await self.queue.read_with_poll(
+            self.test_queue, vt=20, qty=1, max_poll_seconds=5, poll_interval_ms=100
+        )
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].message, self.test_message)
+
+    async def test_archive_batch(self):
+        """Test archiving multiple messages in the queue."""
+        messages = [self.test_message, self.test_message]
+        msg_ids = await self.queue.send_batch(self.test_queue, messages)
+        await self.queue.archive_batch(self.test_queue, msg_ids)
+        read_messages = await self.queue.read_batch(self.test_queue, vt=20, batch_size=2)
+        self.assertEqual(len(read_messages), 0)
+
+    async def test_delete_batch(self):
+        """Test deleting multiple messages from the queue."""
+        messages = [self.test_message, self.test_message]
+        msg_ids = await self.queue.send_batch(self.test_queue, messages)
+        await self.queue.delete_batch(self.test_queue, msg_ids)
+        read_messages = await self.queue.read_batch(self.test_queue, vt=20, batch_size=2)
+        self.assertEqual(len(read_messages), 0)
+
+    async def test_set_vt(self):
+        """Test setting the visibility timeout for a specific message."""
+        msg_id = await self.queue.send(self.test_queue, self.test_message)
+        updated_message = await self.queue.set_vt(self.test_queue, msg_id, vt=60)
+        self.assertEqual(
+            updated_message.vt.second,
+            (datetime.now(timezone.utc) + timedelta(seconds=60)).second,
+        )
+
+    async def test_list_queues(self):
+        """Test listing all queues."""
+        queues = await self.queue.list_queues()
+        self.assertIn(self.test_queue, queues)
+
+    async def test_detach_archive(self):
+        """Test detaching an archive from a queue."""
+        await self.queue.send(self.test_queue, self.test_message)
+        await self.queue.archive(self.test_queue, 1)
+        await self.queue.detach_archive(self.test_queue)
+        # This is just a basic call to ensure the method works without exceptions.
+
+    async def test_drop_queue(self):
+        """Test dropping a queue."""
+        await self.queue.create_queue("test_queue_to_drop")
+        await self.queue.drop_queue("test_queue_to_drop")
+        queues = await self.queue.list_queues()
+        self.assertNotIn("test_queue_to_drop", queues)
+
+    async def test_validate_queue_name(self):
+        """Test validating the length of a queue name."""
+        valid_queue_name = "a" * 47
+        invalid_queue_name = "a" * 49
+        # Valid queue name should not raise an exception
+        await self.queue.validate_queue_name(valid_queue_name)
+        # Invalid queue name should raise an exception
+        with self.assertRaises(Exception) as context:
+            await self.queue.validate_queue_name(invalid_queue_name)
+        self.assertIn("queue name is too long", str(context.exception))
+
+
+class TestPGMQueueWithEnv(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        """Set up a connection to the PGMQueue using environment variables and create a test queue."""
+
+        self.queue = PGMQueue()
+        await self.queue.init()
+
+        # Test database connection first
+        try:
+            pool = self.queue.pool
+            async with pool.acquire() as conn:
+                await conn.fetch("SELECT 1")
+                print("Connection successful (with env)")
+        except Exception as e:
+            raise Exception(f"Database connection failed: {e}")
+
+        self.test_queue = "test_queue"
+        self.test_message = {"hello": "world"}
+        await self.queue.create_queue(self.test_queue)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hey there,

First, thanks for your work on making PostgreSQL even more powerful!

I wanted to adapt PGMQ, but the lack of a modern async Python interface was a showstopper.
This PR brings such implementation to help the adoption of PGMQ for Python's users.

**A few notes on implementation**:

1. The database driver is [asyncpg](https://pypi.org/project/asyncpg/). Its most widely used async driver was also adopted by [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy/blob/main/pyproject.toml#L61-L64).
2. Unfortunately, Python's async and sync functions have different interfaces by definition. Therefore, I can't provide an abstract interface that both sync and async versions will implement.
3. Also, there is no async version of `__post_init__` or `__init__`. Therefore, I added an explicit `init` method for the async version. **This is the only difference in the interface**.
4. I adopted tests for the async version but didn't adopt benches for it. If it's required, I can do it.

I'm looking forward to your comments.
Thanks!