### PR TITLE
add pg17 support

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -139,10 +139,9 @@ jobs:
           working-directory: ./
           file: ./images/pgmq-pg/Dockerfile
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: |
-            quay.io/tembo/pg${{matrix.pg}}-pgmq:latest
             quay.io/tembo/pg${{matrix.pg}}-pgmq:v${{ steps.versions.outputs.SHORT_SHA }}
 
       - name: Build and push -- Releases

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
+        # add 17 when trunk supports it
         pg-version: [14, 15, 16]
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +94,7 @@ jobs:
       - large-8x8
     strategy:
       matrix:
-        pg: [14, 15, 16]
+        pg: [14, 15, 16, 17]
     outputs:
       short_sha: ${{ steps.versions.outputs.SHORT_SHA }}
     steps:
@@ -141,6 +142,7 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: |
+            quay.io/tembo/pg${{matrix.pg}}-pgmq:latest
             quay.io/tembo/pg${{matrix.pg}}-pgmq:v${{ steps.versions.outputs.SHORT_SHA }}
 
       - name: Build and push -- Releases

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -139,7 +139,7 @@ jobs:
           working-directory: ./
           file: ./images/pgmq-pg/Dockerfile
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             quay.io/tembo/pg${{matrix.pg}}-pgmq:latest

--- a/pgmq-extension/README.md
+++ b/pgmq-extension/README.md
@@ -20,15 +20,12 @@ A lightweight message queue. Like [AWS SQS](https://aws.amazon.com/sqs/) and [RS
 - Messages stay in the queue until explicitly removed
 - Messages can be archived, instead of deleted, for long-term retention and replayability
 
-## Support
-
-Postgres 12-16.
+Supported on Postgres 14-17.
 
 ## Table of Contents
 
 - [Postgres Message Queue (PGMQ)](#postgres-message-queue-pgmq)
   - [Features](#features)
-  - [Support](#support)
   - [Table of Contents](#table-of-contents)
   - [Installation](#installation)
     - [Updating](#updating)
@@ -52,7 +49,7 @@ Postgres 12-16.
 The fastest way to get started is by running the Tembo Docker image, where PGMQ comes pre-installed in Postgres.
 
 ```bash
-docker run -d --name pgmq-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io/tembo/pg16-pgmq:latest
+docker run -d --name pgmq-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io/tembo/pg17-pgmq:latest
 ```
 
 If you'd like to build from source, you can follow the instructions in [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Build images, update CI and readme for pg17. pgt.dev does not yet support pg17, so we will need to update again once that happens