### PR TITLE
Add new conditional parameter for read

### DIFF
--- a/docs/api/sql/functions.md
+++ b/docs/api/sql/functions.md
@@ -79,7 +79,8 @@ Read 1 or more messages from a queue. The VT specifies the amount of time in sec
 pgmq.read(
     queue_name text,
     vt integer,
-    qty integer)
+    qty integer,
+    conditional jsonb DEFAULT '{}')
 
 RETURNS SETOF <a href="../types/#message_record">pgmq.message_record</a>
  </code>
@@ -92,8 +93,11 @@ RETURNS SETOF <a href="../types/#message_record">pgmq.message_record</a>
 | queue_name  | text     | The name of the queue   |
 | vt          | integer  | Time in seconds that the message become invisible after reading |
 | qty         | integer  | The number of messages to read from the queue. Defaults to 1 |
+| conditional | jsonb    | Filters the messages by their json content. Defaults to '{}' - no filtering |
 
-Example:
+Examples:
+
+Read messages from a queue
 
 ```sql
 select * from pgmq.read('my_queue', 10, 2);
@@ -102,6 +106,16 @@ select * from pgmq.read('my_queue', 10, 2);
       1 |       1 | 2023-10-28 19:14:47.356595-05 | 2023-10-28 19:17:08.608922-05 | {"hello": "world_0"}
       2 |       1 | 2023-10-28 19:14:47.356595-05 | 2023-10-28 19:17:08.608974-05 | {"hello": "world_1"}
 (2 rows)
+```
+
+Read a message from a queue with message filtering
+
+```sql
+select * from pgmq.read('my_queue', 10, 2, '{"hello": "world_1"}');
+ msg_id | read_ct |          enqueued_at          |              vt               |       message        
+--------+---------+-------------------------------+-------------------------------+----------------------
+      2 |       1 | 2023-10-28 19:14:47.356595-05 | 2023-10-28 19:17:08.608974-05 | {"hello": "world_1"}
+(1 row)
 ```
 
 ---
@@ -119,7 +133,8 @@ Same as read(). Also provides convenient long-poll functionality.
     vt integer,
     qty integer,
     max_poll_seconds integer DEFAULT 5,
-    poll_interval_ms integer DEFAULT 100
+    poll_interval_ms integer DEFAULT 100,
+    conditional jsonb DEFAULT '{}'
 )
 RETURNS SETOF <a href="../types/#message_record">pgmq.message_record</a>
  </code>
@@ -134,6 +149,7 @@ RETURNS SETOF <a href="../types/#message_record">pgmq.message_record</a>
 | qty   | integer        | The number of messages to read from the queue. Defaults to 1.      |
 | max_poll_seconds   | integer        | Time in seconds to wait for new messages to reach the queue. Defaults to 5.      |
 | poll_interval_ms   | integer        | Milliseconds between the internal poll operations. Defaults to 100.      |
+| conditional | jsonb    | Filters the messages by their json content. Defaults to '{}' - no filtering |
 
 Example:
 

--- a/pgmq-extension/pgmq.control
+++ b/pgmq-extension/pgmq.control
@@ -1,5 +1,5 @@
 comment = 'A lightweight message queue. Like AWS SQS and RSMQ but on Postgres.'
-default_version = '1.4.4'
+default_version = '1.5.0'
 module_pathname = '$libdir/pgmq'
 schema = 'pgmq'
 relocatable = false

--- a/pgmq-extension/sql/pgmq--1.4.4--1.5.0.sql
+++ b/pgmq-extension/sql/pgmq--1.4.4--1.5.0.sql
@@ -1,0 +1,98 @@
+-- read
+-- reads a number of messages from a queue, setting a visibility timeout on them
+DROP FUNCTION pgmq.read(TEXT, INTEGER, INTEGER);
+CREATE OR REPLACE FUNCTION pgmq.read(
+    queue_name TEXT,
+    vt INTEGER,
+    qty INTEGER,
+    conditional JSONB DEFAULT '{}'
+)
+RETURNS SETOF pgmq.message_record AS $$
+DECLARE
+    sql TEXT;
+    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+BEGIN
+    sql := FORMAT(
+        $QUERY$
+        WITH cte AS
+        (
+            SELECT msg_id
+            FROM pgmq.%I
+            WHERE vt <= clock_timestamp() AND message @> %I
+            ORDER BY msg_id ASC
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+        )
+        UPDATE pgmq.%I m
+        SET
+            vt = clock_timestamp() + %L,
+            read_ct = read_ct + 1
+        FROM cte
+        WHERE m.msg_id = cte.msg_id
+        RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
+        $QUERY$,
+        qtable, conditional, qtable, make_interval(secs => vt)
+    );
+    RETURN QUERY EXECUTE sql USING qty;
+END;
+$$ LANGUAGE plpgsql;
+
+---- read_with_poll
+---- reads a number of messages from a queue, setting a visibility timeout on them
+DROP FUNCTION pgmq.read_with_poll(TEXT, INTEGER, INTEGER, INTEGER, INTEGER);
+CREATE OR REPLACE FUNCTION pgmq.read_with_poll(
+    queue_name TEXT,
+    vt INTEGER,
+    qty INTEGER,
+    max_poll_seconds INTEGER DEFAULT 5,
+    poll_interval_ms INTEGER DEFAULT 100,
+    conditional JSONB DEFAULT '{}'
+)
+RETURNS SETOF pgmq.message_record AS $$
+DECLARE
+    r pgmq.message_record;
+    stop_at TIMESTAMP;
+    sql TEXT;
+    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+BEGIN
+    stop_at := clock_timestamp() + make_interval(secs => max_poll_seconds);
+    LOOP
+      IF (SELECT clock_timestamp() >= stop_at) THEN
+        RETURN;
+      END IF;
+
+      sql := FORMAT(
+          $QUERY$
+          WITH cte AS
+          (
+              SELECT msg_id
+              FROM pgmq.%I
+              WHERE vt <= clock_timestamp() AND message @> %I
+              ORDER BY msg_id ASC
+              LIMIT $1
+              FOR UPDATE SKIP LOCKED
+          )
+          UPDATE pgmq.%I m
+          SET
+              vt = clock_timestamp() + %L,
+              read_ct = read_ct + 1
+          FROM cte
+          WHERE m.msg_id = cte.msg_id
+          RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
+          $QUERY$,
+          qtable, conditional, qtable, make_interval(secs => vt)
+      );
+
+      FOR r IN
+        EXECUTE sql USING qty
+      LOOP
+        RETURN NEXT r;
+      END LOOP;
+      IF FOUND THEN
+        RETURN;
+      ELSE
+        PERFORM pg_sleep(poll_interval_ms / 1000);
+      END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/pgmq-extension/sql/pgmq--1.4.4--1.5.0.sql
+++ b/pgmq-extension/sql/pgmq--1.4.4--1.5.0.sql
@@ -18,7 +18,7 @@ BEGIN
         (
             SELECT msg_id
             FROM pgmq.%I
-            WHERE vt <= clock_timestamp() AND message @> %I
+            WHERE vt <= clock_timestamp() AND (message @> %L OR (%L = '{}'::jsonb AND message IS NULL))
             ORDER BY msg_id ASC
             LIMIT $1
             FOR UPDATE SKIP LOCKED
@@ -31,7 +31,7 @@ BEGIN
         WHERE m.msg_id = cte.msg_id
         RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
         $QUERY$,
-        qtable, conditional, qtable, make_interval(secs => vt)
+        qtable, conditional, conditional, qtable, make_interval(secs => vt)
     );
     RETURN QUERY EXECUTE sql USING qty;
 END;
@@ -67,7 +67,7 @@ BEGIN
           (
               SELECT msg_id
               FROM pgmq.%I
-              WHERE vt <= clock_timestamp() AND message @> %I
+              WHERE vt <= clock_timestamp() AND (message @> %L OR (%L = '{}'::jsonb AND message IS NULL))
               ORDER BY msg_id ASC
               LIMIT $1
               FOR UPDATE SKIP LOCKED
@@ -80,7 +80,7 @@ BEGIN
           WHERE m.msg_id = cte.msg_id
           RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
           $QUERY$,
-          qtable, conditional, qtable, make_interval(secs => vt)
+          qtable, conditional, conditional, qtable, make_interval(secs => vt)
       );
 
       FOR r IN

--- a/pgmq-extension/sql/pgmq--1.4.4--1.5.0.sql
+++ b/pgmq-extension/sql/pgmq--1.4.4--1.5.0.sql
@@ -94,6 +94,8 @@ BEGIN
         PERFORM pg_sleep(poll_interval_ms / 1000);
       END IF;
     END LOOP;
+END;
+$$ LANGUAGE plpgsql;
 
 DROP FUNCTION IF EXISTS pgmq.drop_queue(TEXT, BOOLEAN);
 

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -71,7 +71,7 @@ BEGIN
         (
             SELECT msg_id
             FROM pgmq.%I
-            WHERE vt <= clock_timestamp() AND message @> %I
+            WHERE vt <= clock_timestamp() AND (message @> %L OR (%L = '{}'::jsonb AND message IS NULL))
             ORDER BY msg_id ASC
             LIMIT $1
             FOR UPDATE SKIP LOCKED
@@ -84,7 +84,7 @@ BEGIN
         WHERE m.msg_id = cte.msg_id
         RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
         $QUERY$,
-        qtable, conditional, qtable, make_interval(secs => vt)
+        qtable, conditional, conditional, qtable, make_interval(secs => vt)
     );
     RETURN QUERY EXECUTE sql USING qty;
 END;
@@ -119,7 +119,7 @@ BEGIN
           (
               SELECT msg_id
               FROM pgmq.%I
-              WHERE vt <= clock_timestamp() AND message @> %I
+              WHERE vt <= clock_timestamp() AND (message @> %L OR (%L = '{}'::jsonb AND message IS NULL))
               ORDER BY msg_id ASC
               LIMIT $1
               FOR UPDATE SKIP LOCKED
@@ -132,7 +132,7 @@ BEGIN
           WHERE m.msg_id = cte.msg_id
           RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message;
           $QUERY$,
-          qtable, conditional, qtable, make_interval(secs => vt)
+          qtable, conditional, conditional, qtable, make_interval(secs => vt)
       );
 
       FOR r IN

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -72,6 +72,13 @@ SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
  t
 (1 row)
 
+-- read message using conditional
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1, '{"hello": "world"}');
+ ?column? 
+----------
+ t
+(1 row)
+
 -- set VT to 5 seconds
 SELECT vt > clock_timestamp() + '4 seconds'::interval
   FROM pgmq.set_vt('test_default_queue', :msg_id, 5);
@@ -88,6 +95,21 @@ SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
 
 -- read again, now using poll to block until message is ready
 SELECT msg_id = :msg_id FROM pgmq.read_with_poll('test_default_queue', 10, 1, 10);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- set VT to 5 seconds again for another read_with_poll test
+SELECT vt > clock_timestamp() + '4 seconds'::interval
+  FROM pgmq.set_vt('test_default_queue', :msg_id, 5);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- read again, now using poll to block until message is ready
+SELECT msg_id = :msg_id FROM pgmq.read_with_poll('test_default_queue', 10, 1, 10, 100, '{"hello": "world"}');
  ?column? 
 ----------
  t

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -64,9 +64,9 @@ SELECT * from pgmq.send('test_default_queue', '{"hello": "world"}');
 (1 row)
 
 -- read message
--- vt=2, limit=1
+-- vt=0, limit=1
 \set msg_id 1
-SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 0, 1);
  ?column? 
 ----------
  t

--- a/pgmq-extension/test/sql/base.sql
+++ b/pgmq-extension/test/sql/base.sql
@@ -25,9 +25,9 @@ SELECT pgmq.create('test_default_queue');
 SELECT * from pgmq.send('test_default_queue', '{"hello": "world"}');
 
 -- read message
--- vt=2, limit=1
+-- vt=0, limit=1
 \set msg_id 1
-SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 0, 1);
 
 -- read message using conditional
 SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1, '{"hello": "world"}');

--- a/pgmq-extension/test/sql/base.sql
+++ b/pgmq-extension/test/sql/base.sql
@@ -29,6 +29,9 @@ SELECT * from pgmq.send('test_default_queue', '{"hello": "world"}');
 \set msg_id 1
 SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
 
+-- read message using conditional
+SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1, '{"hello": "world"}');
+
 -- set VT to 5 seconds
 SELECT vt > clock_timestamp() + '4 seconds'::interval
   FROM pgmq.set_vt('test_default_queue', :msg_id, 5);
@@ -38,6 +41,13 @@ SELECT msg_id = :msg_id FROM pgmq.read('test_default_queue', 2, 1);
 
 -- read again, now using poll to block until message is ready
 SELECT msg_id = :msg_id FROM pgmq.read_with_poll('test_default_queue', 10, 1, 10);
+
+-- set VT to 5 seconds again for another read_with_poll test
+SELECT vt > clock_timestamp() + '4 seconds'::interval
+  FROM pgmq.set_vt('test_default_queue', :msg_id, 5);
+
+-- read again, now using poll to block until message is ready
+SELECT msg_id = :msg_id FROM pgmq.read_with_poll('test_default_queue', 10, 1, 10, 100, '{"hello": "world"}');
 
 -- after reading it, set VT to now
 SELECT msg_id = :msg_id FROM pgmq.set_vt('test_default_queue', :msg_id, 0);


### PR DESCRIPTION
/claim #288
Closes #288

This adds a new parameter for read, adds tests and docs for it and creates a migration file due to the changed function signature.

However `pgmq.archive()` and `pgmq.delete()` are unchanged because they already receive a msg_id parameter, so there's no need to filter with a conditional, and would cause issues if the conditional isn't true.