### PR TITLE
add test for reading null message

### DIFF
--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -797,6 +797,25 @@ SELECT pgmq.format_table_name('semicolon;fail', 'a');
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
 SELECT pgmq.format_table_name($$single'quote-fail$$, 'a');
 ERROR:  queue name contains invalid characters: $, ;, --, or \'
+-- test null message
+SELECT pgmq.create('null_message_queue');
+ create 
+--------
+ 
+(1 row)
+
+SELECT pgmq.send('null_message_queue', NULL);
+ send 
+------
+    1
+(1 row)
+
+SELECT msg_id, read_ct, message FROM pgmq.read('null_message_queue', 1, 1);
+ msg_id | read_ct | message 
+--------+---------+---------
+      1 |       1 | 
+(1 row)
+
 --Cleanup tests
 DROP EXTENSION pgmq CASCADE;
 DROP EXTENSION pg_partman CASCADE;

--- a/pgmq-extension/test/sql/base.sql
+++ b/pgmq-extension/test/sql/base.sql
@@ -315,6 +315,11 @@ SELECT pgmq.format_table_name('double--hyphen-fail', 'a');
 SELECT pgmq.format_table_name('semicolon;fail', 'a');
 SELECT pgmq.format_table_name($$single'quote-fail$$, 'a');
 
+-- test null message
+SELECT pgmq.create('null_message_queue');
+SELECT pgmq.send('null_message_queue', NULL);
+SELECT msg_id, read_ct, message FROM pgmq.read('null_message_queue', 1, 1);
+
 --Cleanup tests
 DROP EXTENSION pgmq CASCADE;
 DROP EXTENSION pg_partman CASCADE;


### PR DESCRIPTION
Adds test to cover case where `message` is null and no conditional is provided on `pgmq.read()`