### PR TITLE
Update the pgmq extension README to utilize the Scarf Gateway

### DIFF
--- a/pgmq-extension/README.md
+++ b/pgmq-extension/README.md
@@ -49,7 +49,7 @@ Supported on Postgres 14-17.
 The fastest way to get started is by running the Tembo Docker image, where PGMQ comes pre-installed in Postgres.
 
 ```bash
-docker run -d --name pgmq-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 quay.io/tembo/pg17-pgmq:latest
+docker run -d --name pgmq-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 tembo.docker.scarf.sh/tembo/pg17-pgmq:latest
 ```
 
 If you'd like to build from source, you can follow the instructions in [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
The Scarf Gateway helps collect GDPR-compliant analytics on downloads of open source software. This change was suggested in direct discussions with the Tembo team. While the default domain that is provided here is the .docker.scarf.sh domain, the Scarf Gateway also supports utilizing a custom domain. If that is desired, we can adjust the PR accordingly here. 

@ryw 