### PR TITLE
Add Python extension implementation for send with timestamp

### DIFF
--- a/tembo-pgmq-python/tembo_pgmq_python/async_queue.py
+++ b/tembo-pgmq-python/tembo_pgmq_python/async_queue.py
@@ -155,45 +155,79 @@ class PGMQueue:
         return queues
 
     @transaction
-    async def send(self, queue: str, message: dict, delay: int = 0, conn=None) -> int:
+    async def send(self, queue: str, message: dict, delay: int = 0, tz: str = None, conn=None) -> int:
         """Send a message to a queue."""
-        self.logger.debug(f"send called with queue='{queue}', message={message}, delay={delay}, conn={conn}")
+        self.logger.debug(f"send called with queue='{queue}', message={message}, delay={delay}, tz={tz}, conn={conn}")
         if conn is None:
             async with self.pool.acquire() as conn:
-                return await self._send_internal(queue, message, delay, conn)
+                return await self._send_internal(queue, message, delay, tz, conn)
         else:
-            return await self._send_internal(queue, message, delay, conn)
+            return await self._send_internal(queue, message, delay, tz, conn)
 
-    async def _send_internal(self, queue, message, delay, conn):
-        self.logger.debug(f"Sending message to queue '{queue}' with delay={delay}")
-        result = await conn.fetchrow(
-            "SELECT * FROM pgmq.send($1, $2::jsonb, $3);",
-            queue,
-            dumps(message).decode("utf-8"),
-            delay,
-        )
+    async def _send_internal(self, queue, message, delay, tz, conn):
+        self.logger.debug(f"Sending message to queue '{queue}' with delay={delay}, tz={tz}")
+        result = None
+        if delay:
+            result = await conn.fetchrow(
+                "SELECT * FROM pgmq.send($1, $2::jsonb, $3);",
+                queue,
+                dumps(message).decode("utf-8"),
+                delay,
+            )
+        elif tz:
+            result = await conn.fetchrow(
+                "SELECT * FROM pgmq.send($1, $2::jsonb, $3);",
+                queue,
+                dumps(message).decode("utf-8"),
+                tz,
+            )
+        else:
+            result = await conn.fetchrow(
+                "SELECT * FROM pgmq.send($1, $2::jsonb);",
+                queue,
+                dumps(message).decode("utf-8"),
+            )
         self.logger.debug(f"Message sent with msg_id={result[0]}")
         return result[0]
 
     @transaction
-    async def send_batch(self, queue: str, messages: List[dict], delay: int = 0, conn=None) -> List[int]:
+    async def send_batch(
+        self, queue: str, messages: List[dict], delay: int = 0, tz: str = None, conn=None
+    ) -> List[int]:
         """Send a batch of messages to a queue."""
-        self.logger.debug(f"send_batch called with queue='{queue}', messages={messages}, delay={delay}, conn={conn}")
+        self.logger.debug(
+            f"send_batch called with queue='{queue}', messages={messages}, delay={delay}, tz={tz}, conn={conn}"
+        )
         if conn is None:
             async with self.pool.acquire() as conn:
-                return await self._send_batch_internal(queue, messages, delay, conn)
+                return await self._send_batch_internal(queue, messages, delay, tz, conn)
         else:
-            return await self._send_batch_internal(queue, messages, delay, conn)
+            return await self._send_batch_internal(queue, messages, delay, tz, conn)
 
-    async def _send_batch_internal(self, queue, messages, delay, conn):
-        self.logger.debug(f"Sending batch of messages to queue '{queue}' with delay={delay}")
+    async def _send_batch_internal(self, queue, messages, delay, tz, conn):
+        self.logger.debug(f"Sending batch of messages to queue '{queue}' with delay={delay}, tz={tz}")
         jsonb_array = [dumps(message).decode("utf-8") for message in messages]
-        result = await conn.fetch(
-            "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3);",
-            queue,
-            jsonb_array,
-            delay,
-        )
+        result = None
+        if delay:
+            result = await conn.fetch(
+                "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3);",
+                queue,
+                jsonb_array,
+                delay,
+            )
+        elif tz:
+            result = await conn.fetch(
+                "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3);",
+                queue,
+                jsonb_array,
+                tz,
+            )
+        else:
+            result = await conn.fetch(
+                "SELECT * FROM pgmq.send_batch($1, $2::jsonb[]);",
+                queue,
+                jsonb_array,
+            )
         msg_ids = [message[0] for message in result]
         self.logger.debug(f"Batch messages sent with msg_ids={msg_ids}")
         return msg_ids

--- a/tembo-pgmq-python/tembo_pgmq_python/queue.py
+++ b/tembo-pgmq-python/tembo_pgmq_python/queue.py
@@ -112,20 +112,38 @@ class PGMQueue:
         return [row[0] for row in rows]
 
     @transaction
-    def send(self, queue: str, message: dict, delay: int = 0, conn=None) -> int:
+    def send(self, queue: str, message: dict, delay: int = 0, tz: str = None, conn=None) -> int:
         """Send a message to a queue."""
         self.logger.debug(f"send called with conn: {conn}")
-        query = "select * from pgmq.send(%s, %s, %s);"
-        result = self._execute_query_with_result(query, [queue, Jsonb(message), delay], conn=conn)
+        result = None
+        if delay:
+            query = "select * from pgmq.send(%s, %s, %s);"
+            result = self._execute_query_with_result(query, [queue, Jsonb(message), delay], conn=conn)
+        elif tz:
+            query = "select * from pgmq.send(%s, %s, %s);"
+            result = self._execute_query_with_result(query, [queue, Jsonb(message), tz], conn=conn)
+        else:
+            query = "select * from pgmq.send(%s, %s);"
+            result = self._execute_query_with_result(query, [queue, Jsonb(message)], conn=conn)
         return result[0][0]
 
     @transaction
-    def send_batch(self, queue: str, messages: List[dict], delay: int = 0, conn=None) -> List[int]:
+    def send_batch(self, queue: str, messages: List[dict], delay: int = 0, tz: str = None, conn=None) -> List[int]:
         """Send a batch of messages to a queue."""
         self.logger.debug(f"send_batch called with conn: {conn}")
-        query = "select * from pgmq.send_batch(%s, %s, %s);"
-        params = [queue, [Jsonb(message) for message in messages], delay]
-        result = self._execute_query_with_result(query, params, conn=conn)
+        result = None
+        if delay:
+            query = "select * from pgmq.send_batch(%s, %s, %s);"
+            params = [queue, [Jsonb(message) for message in messages], delay]
+            result = self._execute_query_with_result(query, params, conn=conn)
+        elif tz:
+            query = "select * from pgmq.send_batch(%s, %s, %s);"
+            params = [queue, [Jsonb(message) for message in messages], tz]
+            result = self._execute_query_with_result(query, params, conn=conn)
+        else:
+            query = "select * from pgmq.send_batch(%s, %s);"
+            params = [queue, [Jsonb(message) for message in messages]]
+            result = self._execute_query_with_result(query, params, conn=conn)
         return [message[0] for message in result]
 
     @transaction

--- a/tembo-pgmq-python/tests/test_async_integration.py
+++ b/tembo-pgmq-python/tests/test_async_integration.py
@@ -68,6 +68,18 @@ class BaseTestPGMQueue(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(message.message, self.test_message)
         self.assertEqual(message.msg_id, msg_id, "Read the wrong message")
 
+    async def test_send_message_with_tz(self):
+        """Test sending a message with a timestamp delay."""
+        timestamp = str(datetime.now(timezone.utc) + timedelta(seconds=5))
+        msg_id = await self.queue.send(self.test_queue, self.test_message, tz=timestamp)
+        message = await self.queue.read(self.test_queue, vt=20)
+        self.assertIsNone(message, "Message should not be visible yet")
+        time.sleep(5)
+        message: Message = await self.queue.read(self.test_queue, vt=20)
+        self.assertIsNotNone(message, "Message should be visible after delay")
+        self.assertEqual(message.message, self.test_message)
+        self.assertEqual(message.msg_id, msg_id, "Read the wrong message")
+
     async def test_archive_message(self):
         """Test archiving a message in the queue."""
         _ = await self.queue.send(self.test_queue, self.test_message)

--- a/tembo-pgmq-python/tests/test_integration.py
+++ b/tembo-pgmq-python/tests/test_integration.py
@@ -66,6 +66,18 @@ class BaseTestPGMQueue(unittest.TestCase):
         self.assertEqual(message.message, self.test_message)
         self.assertEqual(message.msg_id, msg_id, "Read the wrong message")
 
+    def test_send_message_with_tz(self):
+        """Test sending a message with a timestamp delay."""
+        timestamp = str(datetime.now(timezone.utc) + timedelta(seconds=5))
+        msg_id = self.queue.send(self.test_queue, self.test_message, tz=timestamp)
+        message = self.queue.read(self.test_queue, vt=20)
+        self.assertIsNone(message, "Message should not be visible yet")
+        time.sleep(5)
+        message: Message = self.queue.read(self.test_queue, vt=20)
+        self.assertIsNotNone(message, "Message should be visible after timestamp delay")
+        self.assertEqual(message.message, self.test_message)
+        self.assertEqual(message.msg_id, msg_id, "Read the wrong message")
+
     def test_archive_message(self):
         """Test archiving a message in the queue."""
         msg_id = self.queue.send(self.test_queue, self.test_message)


### PR DESCRIPTION
Needs #320 first to be merged.

This adds the Python extension part of send with timestamp, and adds tests for it.