### PR TITLE
Makefile: use pg_config path from environment variable instead of hardcoded binary

### DIFF
--- a/pgmq-extension/Makefile
+++ b/pgmq-extension/Makefile
@@ -8,7 +8,7 @@ EXTRA_CLEAN   = $(EXTENSION)-$(EXTVERSION).zip sql/$(EXTENSION)--$(EXTVERSION).s
 PG_PARTMAN_VER = 5.1.0
 
 # pg_isolation_regress available in v14 and higher.
-ifeq ($(shell test $$(pg_config --version | awk '{print $$2}' | awk 'BEGIN { FS = "." }; { print $$1 }') -ge 14; echo $$?),0)
+ifeq ($(shell test $$($(PG_CONFIG) --version | awk '{print $$2}' | awk 'BEGIN { FS = "." }; { print $$1 }') -ge 14; echo $$?),0)
 ISOLATION   = $(patsubst test/specs/%.spec,%,$(wildcard test/specs/*.spec))
 ISOLATION_OPTS = $(REGRESS_OPTS)
 endif


### PR DESCRIPTION
The use of `pg_config` binary was inconsistent in the Makefile, I realized this while building `pg_vectorize` locally, it installs `pgmq` in its `make setup` step and supplies the pg_config path as an env var which was getting ignored here due to the use of hardcoded path, which would fail on machines that don't have postgres installed and pg_vectorize setup would fail with this error:

```shell

/bin/sh: 1: pg_config: not found
/bin/sh: 1: test: -ge: unexpected operator
```