### PR TITLE
Fix regression: not respecting interval in read_with_poll

### DIFF
--- a/pgmq-extension/sql/pgmq--1.4.4--1.5.0.sql
+++ b/pgmq-extension/sql/pgmq--1.4.4--1.5.0.sql
@@ -97,7 +97,7 @@ BEGIN
       IF FOUND THEN
         RETURN;
       ELSE
-        PERFORM pg_sleep(poll_interval_ms / 1000);
+        PERFORM pg_sleep(poll_interval_ms::numeric / 1000);
       END IF;
     END LOOP;
 END;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -149,7 +149,7 @@ BEGIN
       IF FOUND THEN
         RETURN;
       ELSE
-        PERFORM pg_sleep(poll_interval_ms / 1000);
+        PERFORM pg_sleep(poll_interval_ms::numeric / 1000);
       END IF;
     END LOOP;
 END;

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -434,7 +434,7 @@ SELECT ARRAY(
 
 -- Read with poll will poll until the first message is available
 SELECT clock_timestamp() AS start \gset
-SELECT msg_id = :msg_id1 FROM pgmq.read_with_poll('test_read_queue', 10, 5, 5, 100);
+SELECT msg_id = :msg_id1 FROM pgmq.read_with_poll('test_read_queue', 10, 5, 6, 100);
  ?column? 
 ----------
  t

--- a/pgmq-extension/test/sql/base.sql
+++ b/pgmq-extension/test/sql/base.sql
@@ -172,7 +172,7 @@ SELECT ARRAY(
 
 -- Read with poll will poll until the first message is available
 SELECT clock_timestamp() AS start \gset
-SELECT msg_id = :msg_id1 FROM pgmq.read_with_poll('test_read_queue', 10, 5, 5, 100);
+SELECT msg_id = :msg_id1 FROM pgmq.read_with_poll('test_read_queue', 10, 5, 6, 100);
 SELECT clock_timestamp() - :'start' > '3 second'::interval;
 
 -- test_purge_queue


### PR DESCRIPTION
The regression happened in the port to PL/pgSQL.

Division of integers on postgres yields integer results. Our unit conversion from milliseconds to seconds didn't consider that, and returned wrong results. This caused `pgmq.read_with_poll` to sleep 0s instead of `poll_interval_ms` if `poll_interval_ms` was under 1000, using 100% of CPU.

The fix is simply converting `poll_interval_ms` to `numeric` before doing the division, which produces a `numeric` result as originally intended.