### PR TITLE
Add Supabase to "Who uses pgmq?"

### DIFF
--- a/pgmq-extension/README.md
+++ b/pgmq-extension/README.md
@@ -350,6 +350,7 @@ As the pgmq community grows, we'd love to see who is using it. Please send a PR 
 Currently, officially using pgmq:
 
 1. [Tembo](https://tembo.io) [[@ChuckHend](https://github.com/ChuckHend)]
+2. [Supabase](https://supabase.com) [[@Supabase](https://github.com/supabase)]
 
 ## ✨ Contributors
 


### PR DESCRIPTION
Supabase just released Supabase Queues which uses pgmq under the hood (yay!). Is it ok to count them in?

:partying_face: 