### PR TITLE
Enable PGMQ to run without installing an extension

### DIFF
--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -4,7 +4,14 @@
 -- When installed as an extension, we don't need to create the `pgmq` schema
 -- because it is automatically created by postgres due to being declared in
 -- the extension control file
-CREATE SCHEMA IF NOT EXISTS pgmq;
+DO
+$$
+BEGIN
+    IF (SELECT NOT EXISTS( SELECT 1 FROM pg_extension WHERE extname = 'pgmq')) THEN
+      CREATE SCHEMA IF NOT EXISTS pgmq;
+    END IF;
+END
+$$;
 
 -- Table where queues and metadata about them is stored
 CREATE TABLE pgmq.meta (

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -595,7 +595,7 @@ SELECT * FROM pgmq.create_partitioned(
     :'retention_interval'
 );
 ERROR:  pg_partman is required for partitioned queues
-CONTEXT:  PL/pgSQL function pgmq._ensure_pg_partman_installed() line 12 at RAISE
+CONTEXT:  PL/pgSQL function pgmq._ensure_pg_partman_installed() line 4 at RAISE
 SQL statement "SELECT pgmq._ensure_pg_partman_installed()"
 PL/pgSQL function pgmq.create_partitioned(text,text,text) line 12 at PERFORM
 -- With the extension existing, the queue is created successfully


### PR DESCRIPTION
This pull request enables the installation of PGMQ using a simple `psql` command:

```
psql < pgmq.sql
```

It does NOT affect the existing functionality, nor does it impact PGMQ's ability to be installed as an extension.

This addresses the following issues directly and inderectly:
- #205
- #347
- #373 
- #378

To achieve this the following was changed:
- The `pgmq` schema gets created if it doesn't already exist
- The actual implementation of `send` and `send_batch` are moved higher up the SQL file so they can be found when referenced by the convenience functions with less arguments
- A new `_extension_exists` function is introduced to check the existance of arbitrary extensions
- The implementation of `_ensure_pg_partman_installed` has been retrofitted to use the new `_extension_exists` function.
- All references to the `pgmq` extension have been guarded with `_extension_exists('pgmq')`