### PR TITLE
pgmq.drop_queue return false when queue does not exist

### DIFF
--- a/pgmq-extension/sql/pgmq--1.5.1--1.5.2.sql
+++ b/pgmq-extension/sql/pgmq--1.5.1--1.5.2.sql
@@ -1,0 +1,90 @@
+DROP FUNCTION pgmq.drop_queue(TEXT);
+CREATE FUNCTION pgmq.drop_queue(queue_name TEXT)
+RETURNS BOOLEAN AS $$
+DECLARE
+    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+    qtable_seq TEXT := qtable || '_msg_id_seq';
+    fq_qtable TEXT := 'pgmq.' || qtable;
+    atable TEXT := pgmq.format_table_name(queue_name, 'a');
+    fq_atable TEXT := 'pgmq.' || atable;
+    partitioned BOOLEAN;
+BEGIN
+    EXECUTE FORMAT(
+        $QUERY$
+        SELECT is_partitioned FROM pgmq.meta WHERE queue_name = %L
+        $QUERY$,
+        queue_name
+    ) INTO partitioned;
+
+    -- check if the queue exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_name = qtable and table_schema = 'pgmq'
+    ) THEN
+        RAISE NOTICE 'pgmq queue `%` does not exist', queue_name;
+        RETURN FALSE;
+    END IF;
+
+    IF pgmq._extension_exists('pgmq') THEN
+        EXECUTE FORMAT(
+            $QUERY$
+            ALTER EXTENSION pgmq DROP TABLE pgmq.%I
+            $QUERY$,
+            qtable
+        );
+
+        EXECUTE FORMAT(
+            $QUERY$
+            ALTER EXTENSION pgmq DROP SEQUENCE pgmq.%I
+            $QUERY$,
+            qtable_seq
+        );
+
+        EXECUTE FORMAT(
+            $QUERY$
+            ALTER EXTENSION pgmq DROP TABLE pgmq.%I
+            $QUERY$,
+            atable
+        );
+    END IF;
+
+    EXECUTE FORMAT(
+        $QUERY$
+        DROP TABLE IF EXISTS pgmq.%I
+        $QUERY$,
+        qtable
+    );
+
+    EXECUTE FORMAT(
+        $QUERY$
+        DROP TABLE IF EXISTS pgmq.%I
+        $QUERY$,
+        atable
+    );
+
+     IF EXISTS (
+          SELECT 1
+          FROM information_schema.tables
+          WHERE table_name = 'meta' and table_schema = 'pgmq'
+     ) THEN
+        EXECUTE FORMAT(
+            $QUERY$
+            DELETE FROM pgmq.meta WHERE queue_name = %L
+            $QUERY$,
+            queue_name
+        );
+     END IF;
+
+     IF partitioned THEN
+        EXECUTE FORMAT(
+          $QUERY$
+          DELETE FROM %I.part_config where parent_table in (%L, %L)
+          $QUERY$,
+          pgmq._get_pg_partman_schema(), fq_qtable, fq_atable
+        );
+     END IF;
+
+    RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -618,7 +618,7 @@ BEGIN
         FROM information_schema.tables
         WHERE table_name = qtable and table_schema = 'pgmq'
     ) THEN
-        RAISE NOTICE 'pgmq queue `%s` does not exist', queue_name;
+        RAISE NOTICE 'pgmq queue `%` does not exist', queue_name;
         RETURN FALSE;
     END IF;
 

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -612,6 +612,16 @@ BEGIN
         queue_name
     ) INTO partitioned;
 
+    -- check if the queue exists
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_name = qtable and table_schema = 'pgmq'
+    ) THEN
+        RAISE NOTICE 'pgmq queue `%s` does not exist', queue_name;
+        RETURN FALSE;
+    END IF;
+
     IF pgmq._extension_exists('pgmq') THEN
         EXECUTE FORMAT(
             $QUERY$

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -255,6 +255,27 @@ SELECT COUNT(1) from pgmq.metrics_all();
      9
 (1 row)
 
+-- delete an existing queue returns true
+select pgmq.create('exists');
+ create 
+--------
+ 
+(1 row)
+
+select pgmq.drop_queue('exists');
+ drop_queue 
+------------
+ t
+(1 row)
+
+-- delete a queue does not exists returns false
+select pgmq.drop_queue('does_not_exist');
+NOTICE:  pgmq queue `does_not_exists` does not exist
+ drop_queue 
+------------
+ f
+(1 row)
+
 -- delete all the queues
 -- delete partitioned queues
 SELECT pgmq.drop_queue(queue, true)

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -270,7 +270,7 @@ select pgmq.drop_queue('exists');
 
 -- delete a queue does not exists returns false
 select pgmq.drop_queue('does_not_exist');
-NOTICE:  pgmq queue `does_not_exists` does not exist
+NOTICE:  pgmq queue `does_not_exist` does not exist
  drop_queue 
 ------------
  f

--- a/pgmq-extension/test/sql/base.sql
+++ b/pgmq-extension/test/sql/base.sql
@@ -104,6 +104,12 @@ SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_m
 -- get metrics all
 SELECT COUNT(1) from pgmq.metrics_all();
 
+-- delete an existing queue returns true
+select pgmq.create('exists');
+select pgmq.drop_queue('exists');
+-- delete a queue does not exists returns false
+select pgmq.drop_queue('does_not_exist');
+
 -- delete all the queues
 -- delete partitioned queues
 SELECT pgmq.drop_queue(queue, true)


### PR DESCRIPTION
Updates `pgmq.drop_queue()` does not fail when attempting to drop a queue that does not exist. Instead it will just return `false` and creates a notice. Closes #275.

The implementation simply checks if the queue table exists prior to attempting to delete it.

Previous behavior:

```text
postgres=# select pgmq.drop_queue('dne');
ERROR:  relation "pgmq.q_dne" does not exist
CONTEXT:  SQL statement "
            ALTER EXTENSION pgmq DROP TABLE pgmq.q_dne
            "
PL/pgSQL function pgmq.drop_queue(text) line 18 at EXECUTE
```

New behavior

```text
postgres=# select pgmq.drop_queue('dne');
NOTICE:  pgmq queue `dne` does not exist
 drop_queue 
------------
 f
(1 row)
```

