### PR TITLE
fix queue name length check

### DIFF
--- a/pgmq-extension/sql/pgmq--1.5.1--1.5.2.sql
+++ b/pgmq-extension/sql/pgmq--1.5.1--1.5.2.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION pgmq.validate_queue_name(queue_name TEXT)
+RETURNS void AS $$
+BEGIN
+  IF length(queue_name) > 47 THEN
+    -- complete table identifier must be <= 63
+    -- https://www.postgresql.org/docs/17/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+    -- e.g. template_pgmq_q_my_queue is an identifier for my_queue when partitioned
+    -- template_pgmq_q_ (16) + <a max length queue name> (47) = 63 
+    RAISE EXCEPTION 'queue name is too long, maximum length is 47 characters';
+  END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -678,8 +678,12 @@ $$ LANGUAGE plpgsql;
 CREATE FUNCTION pgmq.validate_queue_name(queue_name TEXT)
 RETURNS void AS $$
 BEGIN
-  IF length(queue_name) >= 48 THEN
-    RAISE EXCEPTION 'queue name is too long, maximum length is 48 characters';
+  IF length(queue_name) > 47 THEN
+    -- complete table identifier must be <= 63
+    -- https://www.postgresql.org/docs/17/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+    -- e.g. template_pgmq_q_my_queue is an identifier for my_queue when partitioned
+    -- template_pgmq_q_ (16) + <a max length queue name> (47) = 63 
+    RAISE EXCEPTION 'queue name is too long, maximum length is 47 characters';
   END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -25,8 +25,8 @@ SELECT msg_id, read_ct, enqueued_at > NOW(), vt > NOW(), message, headers
 -- test_max_queue_name_size
 -- CREATE with default retention and partition strategy
 SELECT pgmq.create(repeat('a', 48));
-ERROR:  queue name is too long, maximum length is 48 characters
-CONTEXT:  PL/pgSQL function pgmq.validate_queue_name(text) line 4 at RAISE
+ERROR:  queue name is too long, maximum length is 47 characters
+CONTEXT:  PL/pgSQL function pgmq.validate_queue_name(text) line 8 at RAISE
 SQL statement "SELECT pgmq.validate_queue_name(queue_name)"
 PL/pgSQL function pgmq.create_non_partitioned(text) line 7 at PERFORM
 SQL statement "SELECT pgmq.create_non_partitioned(queue_name)"
@@ -34,6 +34,17 @@ PL/pgSQL function pgmq."create"(text) line 3 at PERFORM
 SELECT pgmq.create(repeat('a', 47));
  create 
 --------
+ 
+(1 row)
+
+SELECT pgmq.create_partitioned(repeat('p', 48));
+ERROR:  queue name is too long, maximum length is 47 characters
+CONTEXT:  PL/pgSQL function pgmq.validate_queue_name(text) line 8 at RAISE
+SQL statement "SELECT pgmq.validate_queue_name(queue_name)"
+PL/pgSQL function pgmq.create_partitioned(text,text,text) line 11 at PERFORM
+SELECT pgmq.create_partitioned(repeat('p', 47));
+ create_partitioned 
+--------------------
  
 (1 row)
 
@@ -252,7 +263,7 @@ SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_m
 SELECT COUNT(1) from pgmq.metrics_all();
  count 
 -------
-     9
+    10
 (1 row)
 
 -- delete all the queues
@@ -283,6 +294,7 @@ WARNING:  drop_queue(queue_name, partitioned) is deprecated and will be removed 
 WARNING:  drop_queue(queue_name, partitioned) is deprecated and will be removed in PGMQ v2.0. Use drop_queue(queue_name) instead
 WARNING:  drop_queue(queue_name, partitioned) is deprecated and will be removed in PGMQ v2.0. Use drop_queue(queue_name) instead
 WARNING:  drop_queue(queue_name, partitioned) is deprecated and will be removed in PGMQ v2.0. Use drop_queue(queue_name) instead
+WARNING:  drop_queue(queue_name, partitioned) is deprecated and will be removed in PGMQ v2.0. Use drop_queue(queue_name) instead
  drop_queue 
 ------------
  t
@@ -292,7 +304,8 @@ WARNING:  drop_queue(queue_name, partitioned) is deprecated and will be removed 
  t
  t
  t
-(7 rows)
+ t
+(8 rows)
 
 SELECT queue_name FROM pgmq.list_queues();
  queue_name 

--- a/pgmq-extension/test/sql/base.sql
+++ b/pgmq-extension/test/sql/base.sql
@@ -13,6 +13,8 @@ SELECT msg_id, read_ct, enqueued_at > NOW(), vt > NOW(), message, headers
 -- CREATE with default retention and partition strategy
 SELECT pgmq.create(repeat('a', 48));
 SELECT pgmq.create(repeat('a', 47));
+SELECT pgmq.create_partitioned(repeat('p', 48));
+SELECT pgmq.create_partitioned(repeat('p', 47));
 
 -- test_lifecycle
 -- CREATE with default retention and partition strategy


### PR DESCRIPTION
Closes #349.

Maybe a better solution would be to have separate checks for paritioned vs. non-partitioned queues. Non partitioned queue names could be a bit longer.