### PR TITLE
Add Kotlin Multiplatform (sqlx4k) link to README.md

### DIFF
--- a/pgmq-extension/README.md
+++ b/pgmq-extension/README.md
@@ -71,6 +71,7 @@ Community
 - [Java (JDBC)](https://github.com/roy20021/pgmq-jdbc-client)
 - [Java (Spring Boot)](https://github.com/adamalexandru4/pgmq-spring)
 - [Kotlin JVM (JDBC)](https://github.com/vdsirotkin/pgmq-kotlin-jvm)
+- [Kotlin Multiplatform (sqlx4k)](https://github.com/smyrgeorge/sqlx4k/tree/main/sqlx4k-postgres-pgmq)
 - [Javascript (NodeJs)](https://github.com/Muhammad-Magdi/pgmq-js)
 - [TypeScript (NodeJs](https://github.com/waitingsong/pgmq-js) + [Midway.js](https://midwayjs.org/))
 - [TypeScript (Deno)](https://github.com/tmountain/deno-pgmq)


### PR DESCRIPTION
Hello!

Please accept this pull request that adds a link to sqlx4k-pgmq client.
Sqlx4k is a Kotlin Multiplatform sql toolkit library that supports several databases, for several platform targets.
Here is the client: https://github.com/smyrgeorge/sqlx4k/tree/main/sqlx4k-postgres-pgmq

Regards