### PR TITLE
Update set_vt to accept timestamp

### DIFF
--- a/docs/api/sql/functions.md
+++ b/docs/api/sql/functions.md
@@ -833,11 +833,9 @@ select * from pgmq.drop_queue('my_unlogged');
 Sets the visibility timeout of a message to a specified time duration in the future. Returns the record of the message that was updated.
 
 ```text
-pgmq.set_vt(
-    queue_name text,
-    msg_id bigint,
-    vt integer
-)
+pgmq.set_vt(queue_name text, msg_id bigint, vt integer)
+pgmq.set_vt(queue_name text, msg_id bigint, vt timestamp with time zone)
+
 RETURNS SETOF pgmq.message_record
 ```
 
@@ -848,6 +846,7 @@ RETURNS SETOF pgmq.message_record
 | queue_name  | text         | The name of the queue   |
 | msg_id      | bigint       | ID of the message to set visibility time  |
 | vt   | integer      | Duration from now, in seconds, that the message's VT should be set to   |
+| vt   | timestamp with time zone | Timestamp when the message becomes visible   |
 
 Example:
 
@@ -867,11 +866,9 @@ select * from pgmq.set_vt('my_queue', 1, 30);
 Sets the visibility timeout of multiple messages to a specified time duration in the future. Returns the records of the messages that were updated.
 
 ```text
-pgmq.set_vt(
-    queue_name text,
-    msg_ids bigint[],
-    vt integer
-)
+pgmq.set_vt(queue_name text, msg_ids bigint[], vt integer)
+pgmq.set_vt(queue_name text, msg_ids bigint[], vt timestamp with time zone)
+
 RETURNS SETOF pgmq.message_record
 ```
 
@@ -882,6 +879,7 @@ RETURNS SETOF pgmq.message_record
 | queue_name  | text         | The name of the queue   |
 | msg_ids      | bigint[]       | Array of message IDs to set visibility time  |
 | vt   | integer      | Duration from now, in seconds, that the messages' VT should be set to   |
+| vt   | timestamp with time zone | Timestamp when the messages become visible   |
 
 Example:
 

--- a/pgmq-extension/pgmq.control
+++ b/pgmq-extension/pgmq.control
@@ -1,5 +1,5 @@
 comment = 'A lightweight message queue. Like AWS SQS and RSMQ but on Postgres.'
-default_version = '1.9.0'
+default_version = '1.10.0'
 module_pathname = '$libdir/pgmq'
 schema = 'pgmq'
 relocatable = false

--- a/pgmq-extension/sql/pgmq--1.9.0--1.10.0.sql
+++ b/pgmq-extension/sql/pgmq--1.9.0--1.10.0.sql
@@ -1,0 +1,60 @@
+-- Sets timestamp vt of a message, returns it
+CREATE FUNCTION pgmq.set_vt(queue_name TEXT, msg_id BIGINT, vt TIMESTAMP WITH TIME ZONE)
+RETURNS SETOF pgmq.message_record AS $$
+DECLARE
+    sql TEXT;
+    result pgmq.message_record;
+    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+BEGIN
+    sql := FORMAT(
+        $QUERY$
+        UPDATE pgmq.%I
+        SET vt = $1
+        WHERE msg_id = $2
+        RETURNING *;
+        $QUERY$, 
+        qtable
+    );
+    RETURN QUERY EXECUTE sql USING vt, msg_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Sets integer vt of a message, returns it
+CREATE OR REPLACE FUNCTION pgmq.set_vt(queue_name TEXT, msg_id BIGINT, vt INTEGER)
+RETURNS SETOF pgmq.message_record AS $$
+    SELECT * FROM pgmq.set_vt(queue_name, msg_id, clock_timestamp() + make_interval(secs => vt));
+$$ LANGUAGE sql;
+
+-- Sets timestamp vt of multiple messages, returns them
+CREATE FUNCTION pgmq.set_vt(
+    queue_name TEXT,
+    msg_ids BIGINT[],
+    vt TIMESTAMP WITH TIME ZONE
+)
+RETURNS SETOF pgmq.message_record AS $$
+DECLARE
+    sql TEXT;
+    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+BEGIN
+    sql := FORMAT(
+        $QUERY$
+        UPDATE pgmq.%I
+        SET vt = $1
+        WHERE msg_id = ANY($2)
+        RETURNING *;
+        $QUERY$,
+        qtable
+    );
+    RETURN QUERY EXECUTE sql USING vt, msg_ids;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Sets integer vt of multiple messages, returns them
+CREATE OR REPLACE FUNCTION pgmq.set_vt(
+    queue_name TEXT,
+    msg_ids BIGINT[],
+    vt INTEGER
+)
+RETURNS SETOF pgmq.message_record AS $$
+    SELECT * FROM pgmq.set_vt(queue_name, msg_ids, clock_timestamp() + make_interval(secs => vt));
+$$ LANGUAGE sql;

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -827,8 +827,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Sets vt of a message, returns it
-CREATE FUNCTION pgmq.set_vt(queue_name TEXT, msg_id BIGINT, vt INTEGER)
+-- Sets timestamp vt of a message, returns it
+CREATE FUNCTION pgmq.set_vt(queue_name TEXT, msg_id BIGINT, vt TIMESTAMP WITH TIME ZONE)
 RETURNS SETOF pgmq.message_record AS $$
 DECLARE
     sql TEXT;
@@ -838,30 +838,33 @@ BEGIN
     sql := FORMAT(
         $QUERY$
         UPDATE pgmq.%I
-        SET vt = (clock_timestamp() + %L)
-        WHERE msg_id = %L
+        SET vt = $1
+        WHERE msg_id = $2
         RETURNING *;
-        $QUERY$,
-        qtable, make_interval(secs => vt), msg_id
+        $QUERY$, 
+        qtable
     );
-    RETURN QUERY EXECUTE sql;
+    RETURN QUERY EXECUTE sql USING vt, msg_id;
 END;
 $$ LANGUAGE plpgsql;
 
--- Sets vt of multiple messages, returns them
-CREATE OR REPLACE FUNCTION pgmq.set_vt(
+-- Sets integer vt of a message, returns it
+CREATE FUNCTION pgmq.set_vt(queue_name TEXT, msg_id BIGINT, vt INTEGER)
+RETURNS SETOF pgmq.message_record AS $$
+    SELECT * FROM pgmq.set_vt(queue_name, msg_id, clock_timestamp() + make_interval(secs => vt));
+$$ LANGUAGE sql;
+
+-- Sets timestamp vt of multiple messages, returns them
+CREATE FUNCTION pgmq.set_vt(
     queue_name TEXT,
     msg_ids BIGINT[],
-    vt INTEGER
+    vt TIMESTAMP WITH TIME ZONE
 )
 RETURNS SETOF pgmq.message_record AS $$
 DECLARE
     sql TEXT;
     qtable TEXT := pgmq.format_table_name(queue_name, 'q');
-    new_vt TIMESTAMP WITH TIME ZONE;
 BEGIN
-    new_vt := clock_timestamp() + make_interval(secs => vt);
-
     sql := FORMAT(
         $QUERY$
         UPDATE pgmq.%I
@@ -871,9 +874,19 @@ BEGIN
         $QUERY$,
         qtable
     );
-    RETURN QUERY EXECUTE sql USING new_vt, msg_ids;
+    RETURN QUERY EXECUTE sql USING vt, msg_ids;
 END;
 $$ LANGUAGE plpgsql;
+
+-- Sets integer vt of multiple messages, returns them
+CREATE FUNCTION pgmq.set_vt(
+    queue_name TEXT,
+    msg_ids BIGINT[],
+    vt INTEGER
+)
+RETURNS SETOF pgmq.message_record AS $$
+    SELECT * FROM pgmq.set_vt(queue_name, msg_ids, clock_timestamp() + make_interval(secs => vt));
+$$ LANGUAGE sql;
 
 CREATE FUNCTION pgmq._get_pg_partman_schema()
 RETURNS TEXT AS $$

--- a/pgmq-extension/test/expected/base.out
+++ b/pgmq-extension/test/expected/base.out
@@ -650,6 +650,35 @@ SELECT msg_id from pgmq.read('test_set_vt_queue', 1, 1);
       1
 (1 row)
 
+-- set message vt to a specific timestamp in the future
+SELECT clock_timestamp() + interval '65 seconds' AS future_ts \gset
+SELECT msg_id, vt = (:'future_ts')::timestamptz FROM pgmq.set_vt('test_set_vt_queue', :first_msg_id, (:'future_ts')::timestamptz);
+ msg_id | ?column? 
+--------+----------
+      1 | t
+(1 row)
+
+-- read message, it should not be visible
+SELECT msg_id from pgmq.read('test_set_vt_queue', 1, 1);
+ msg_id 
+--------
+(0 rows)
+
+-- make it visible
+SELECT clock_timestamp() AS current_ts \gset
+SELECT msg_id, vt = (:'current_ts')::timestamptz FROM pgmq.set_vt('test_set_vt_queue', :first_msg_id, (:'current_ts')::timestamptz);
+ msg_id | ?column? 
+--------+----------
+      1 | t
+(1 row)
+
+-- set vt works if message is readable again
+SELECT msg_id from pgmq.read('test_set_vt_queue', 1, 1);
+ msg_id 
+--------
+      1
+(1 row)
+
 -- test batch set_vt
 SELECT pgmq.create('test_batch_set_vt_queue');
  create 
@@ -686,6 +715,40 @@ SELECT ARRAY(
 (1 row)
 
 -- both messages should be visible now
+SELECT ARRAY(
+    SELECT msg_id FROM pgmq.read('test_batch_set_vt_queue', 1, 5)
+) = ARRAY[:batch_msg_id1, :batch_msg_id2]::bigint[];
+ ?column? 
+----------
+ t
+(1 row)
+
+-- set both messages vt to a specific timestamp in the future
+SELECT clock_timestamp() + interval '65 seconds' AS future_ts \gset
+SELECT msg_id, vt = (:'future_ts')::timestamptz FROM pgmq.set_vt('test_batch_set_vt_queue', ARRAY[:batch_msg_id1, :batch_msg_id2], (:'future_ts')::timestamptz);
+ msg_id | ?column? 
+--------+----------
+      1 | t
+      2 | t
+(2 rows)
+
+-- read messages, none should be visible
+SELECT COUNT(*) = 0 FROM pgmq.read('test_batch_set_vt_queue', 1, 5);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- make them visible again using batch set_vt
+SELECT clock_timestamp() AS current_ts \gset
+SELECT msg_id, vt = (:'current_ts')::timestamptz FROM pgmq.set_vt('test_batch_set_vt_queue', ARRAY[:batch_msg_id1, :batch_msg_id2], (:'current_ts')::timestamptz);
+ msg_id | ?column? 
+--------+----------
+      1 | t
+      2 | t
+(2 rows)
+
+-- both messages should be visible again
 SELECT ARRAY(
     SELECT msg_id FROM pgmq.read('test_batch_set_vt_queue', 1, 5)
 ) = ARRAY[:batch_msg_id1, :batch_msg_id2]::bigint[];


### PR DESCRIPTION
Fixes #483 

I just took a guess on the versioning (1.10.0) but let me know if you prefer 1.9.1 instead and I can update the PR.

I tested locally and also ran `make installcheck` locally and the tests are passing.

Is there anything I am missing in order to implement this change?

I noticed that [Release 1.5.0](https://github.com/pgmq/pgmq/releases/tag/v1.5.0), with a similar change made for pgmq.send to support timestampz, has a warning that it could break existing code if it relied on implicit casting.  I wonder if this change would need a similar warning for set_vt.
