### PR TITLE
chore: Add SemVer compatibility check to CI

### DIFF
--- a/.github/workflows/crate_ci.yml
+++ b/.github/workflows/crate_ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install minimal nightly with clippy and rustfmt
+      - name: Install minimal rust toolchain with clippy and rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
@@ -30,9 +30,20 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Cargo format
-        run: cargo fmt --all --check
+        run: make check-fmt
       - name: Clippy
-        run: cargo clippy --all-features
+        run: make check-clippy
+
+  semver:
+    name: Check SemVer compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: taiki-e/install-action@9adcff13829681f1e2f4a678b775043ab5c7fc2c
+        with:
+          tool: cargo-semver-checks
+      - name: Check SemVer
+        run: make check-semver
 
   tests:
     name: Run tests

--- a/.github/workflows/crate_ci.yml
+++ b/.github/workflows/crate_ci.yml
@@ -30,9 +30,9 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Cargo format
-        run: make check-fmt
+        run: make check.fmt
       - name: Clippy
-        run: make check-clippy
+        run: make check.clippy
 
   semver:
     name: Check SemVer compatibility
@@ -43,7 +43,7 @@ jobs:
         with:
           tool: cargo-semver-checks
       - name: Check SemVer
-        run: make check-semver
+        run: make check.semver
 
   tests:
     name: Run tests

--- a/pgmq-rs/Makefile
+++ b/pgmq-rs/Makefile
@@ -2,10 +2,9 @@ POSTGRES_PASSWORD:=postgres
 DATABASE_URL:=postgres://postgres:postgres@0.0.0.0:5432/postgres
 EXTENSION_DB:=postgres://postgres:postgres@0.0.0.0:5432/pgmq_ext_test
 
-format:
-	cargo sqlx prepare --database-url ${DATABASE_URL}
-	cargo +nightly fmt --all
-	cargo clippy --all-features
+# Initialize a new installation of the repo (e.g., install deps)
+init:
+	cargo binstall cargo-insta cargo-semver-checks sqlx-cli cargo-readme
 
 update.readme:
 	cargo readme \
@@ -30,3 +29,21 @@ test.pgmqext_sql:
 
 setup.env:
 	sqlx migrate run --database-url ${DATABASE_URL}
+
+# Reformat all rust code
+fmt:
+	cargo fmt --all
+
+# Check if there are any semver-incompatible changes. If there are, the crate's first non-zero semver value will need be
+# bumped in order to release the changes.
+# Note: This will catch most semver-incompatible changes, but not all.
+check-semver:
+	cargo semver-checks
+
+# Check the crate does not have any Clippy errors
+check-clippy:
+	cargo clippy --all-features
+
+# Check that the crate is formatted correctly
+check-fmt:
+	cargo fmt --all --check

--- a/pgmq-rs/Makefile
+++ b/pgmq-rs/Makefile
@@ -37,13 +37,13 @@ fmt:
 # Check if there are any semver-incompatible changes. If there are, the crate's first non-zero semver value will need be
 # bumped in order to release the changes.
 # Note: This will catch most semver-incompatible changes, but not all.
-check-semver:
+check.semver:
 	cargo semver-checks
 
 # Check the crate does not have any Clippy errors
-check-clippy:
+check.clippy:
 	cargo clippy --all-features
 
 # Check that the crate is formatted correctly
-check-fmt:
+check.fmt:
 	cargo fmt --all --check


### PR DESCRIPTION
This PR adds a SemVer compatibility check to the GitHub CI. This will help reviewers catch potential SemVer incompatibilities in PRs.

Note: in my experience, the `cargo-semver-checks` crate catches most incompatibilities, but not all, so reviewers should still pay attention to potential SemVer-breaking changes.

This PR also makes some changes to the `Makefile` to add an `init` command to install all binaries used by the `Makefile`, and adds individual lint commands that are then used in CI. This ensures that CI runs the same lints that are run when running the commands locally.