### PR TITLE
chore: Add docs check and minimal versions check

### DIFF
--- a/.github/workflows/crate_ci.yml
+++ b/.github/workflows/crate_ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: make check.fmt
       - name: Clippy
         run: make check.clippy
+      - name: Check docs
+        run: make check.docs
 
   semver:
     name: Check SemVer compatibility
@@ -44,6 +46,17 @@ jobs:
           tool: cargo-semver-checks
       - name: Check SemVer
         run: make check.semver
+
+  minimal-versions:
+    name: Check dependency minimal versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: taiki-e/install-action@9adcff13829681f1e2f4a678b775043ab5c7fc2c
+        with:
+          tool: cargo-minimal-versions,cargo-hack
+      - name: Check versions
+        run: make check.minimal-versions
 
   tests:
     name: Run tests

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -24,17 +24,17 @@ install-sql-github = ["install-sql", "reqwest"]
 install-sql-embedded = ["install-sql", "include_dir"]
 
 [dependencies]
-chrono = { version = "0.4.23", features = ["serde"] }
+chrono = { version = "0.4.34", features = ["serde"] }
 serde = { version = "1.0.152" }
 serde_json = { version = "1.0.91", features = ["raw_value"] }
 sqlx = { version = "0.8.1", features = ["runtime-tokio", "postgres", "chrono", "json"] }
 thiserror = "1.0.38"
-tokio = { version = "1", default-features = false, features = ["macros", "time"] }
-log = "0.4.17"
-url = "2.3.1"
+tokio = { version = "1.38.0", default-features = false, features = ["macros", "time"] }
+log = "0.4.18"
+url = "2.4.0"
 
 # Optional dependencies for the `cli` feature
-clap = { version = "4.0", features = ["derive"], optional = true }
+clap = { version = "4.1", features = ["derive"], optional = true }
 env_logger = { version = "0.10.0", optional = true }
 
 # Optional dependencies for the `install-sql-github` and `install-sql-embedded` features
@@ -42,10 +42,10 @@ futures-util = { version = "0.3.31", optional = true }
 include_dir = { version = "0.7.4", optional = true }
 regex = { version = "1.12.3", optional = true }
 itertools = { version = "0.14.0", optional = true }
-reqwest = { version = "0.11", features = ["json"], optional = true }
+reqwest = { version = "0.13.0", features = ["json"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 cargo-readme = "3.2.0"
 criterion = "0.4"
 env_logger = "0.10.0"

--- a/pgmq-rs/Makefile
+++ b/pgmq-rs/Makefile
@@ -4,7 +4,7 @@ EXTENSION_DB:=postgres://postgres:postgres@0.0.0.0:5432/pgmq_ext_test
 
 # Initialize a new installation of the repo (e.g., install deps)
 init:
-	cargo binstall cargo-insta cargo-semver-checks sqlx-cli cargo-readme
+	cargo binstall cargo-insta cargo-semver-checks sqlx-cli cargo-readme cargo-minimal-versions cargo-hack
 
 update.readme:
 	cargo readme \
@@ -47,3 +47,11 @@ check.clippy:
 # Check that the crate is formatted correctly
 check.fmt:
 	cargo fmt --all --check
+
+check.docs:
+	RUSTDOCFLAGS="-D rustdoc::all" cargo doc --all-features --lib --no-deps
+
+# Check that our dependencies are declared as the correct minimal versions. For example, if we depend on a crate
+# with version "1.0.0", ensure we don’t accidentally depend on a feature added in version "1.5.0".
+check.minimal-versions:
+	cargo minimal-versions check --direct --all-features

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -669,13 +669,13 @@ impl PGMQueue {
         Ok(messages)
     }
 
-    /// Similar to [`read_batch`], but allows waiting until a message is available
+    /// Similar to [`Self::read_batch`], but allows waiting until a message is available
     ///
     /// You can specify a maximum duration for polling (defaults to 5 seconds),
     /// and an interval between calls (defaults to 250ms). A lower interval
     /// implies higher maximum latency, but less load on the database.
     ///
-    /// Refer to the [`read_batch`] function for more details.
+    /// Refer to the [`Self::read_batch`] function for more details.
     ///
     pub async fn read_batch_with_poll<T: for<'de> Deserialize<'de>>(
         &self,

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -46,7 +46,7 @@ impl PGMQueueExt {
     #[cfg(feature = "install-sql-github")]
     #[deprecated(
         note = "Use install_sql_from_github_with_cxn/install_sql_from_github or install_sql_embedded_with_cxn/install_sql_embedded instead.",
-        since = "0.32.2"
+        since = "0.33.0"
     )]
     pub async fn install_sql_with_cxn(
         &self,
@@ -60,7 +60,7 @@ impl PGMQueueExt {
     #[cfg(feature = "install-sql-github")]
     #[deprecated(
         note = "Use install_sql_from_github_with_cxn/install_sql_from_github or install_sql_embedded_with_cxn/install_sql_embedded instead.",
-        since = "0.32.2"
+        since = "0.33.0"
     )]
     pub async fn install_sql(&self, version: Option<&String>) -> Result<(), PgmqError> {
         self.install_sql_from_github(version.map(|v| v.as_str()))

--- a/pgmq-rs/src/pg_ext/visibility_timeout_offest.rs
+++ b/pgmq-rs/src/pg_ext/visibility_timeout_offest.rs
@@ -28,7 +28,7 @@ use std::ops::Deref;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(10u32));
 /// ```
 ///
-/// ## Convert from `u32` capped
+/// ## Convert from `u32` -- capped
 /// ```
 /// # use pgmq::pg_ext::VisibilityTimeoutOffset;
 /// assert_eq!(i32::MAX, *VisibilityTimeoutOffset::from(u32::MAX));
@@ -40,43 +40,43 @@ use std::ops::Deref;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(10i64));
 /// ```
 ///
-/// ## Convert from `i64` capped max
+/// ## Convert from `i64` -- capped max
 /// ```
 /// # use pgmq::pg_ext::VisibilityTimeoutOffset;
 /// assert_eq!(i32::MAX, *VisibilityTimeoutOffset::from(i64::MAX));
 /// ```
 ///
-/// ## Convert from `i64` capped min
+/// ## Convert from `i64` -- capped min
 /// ```
 /// # use pgmq::pg_ext::VisibilityTimeoutOffset;
 /// assert_eq!(i32::MIN, *VisibilityTimeoutOffset::from(i64::MIN));
 /// ```
 ///
-/// ## Convert from [`chrono::Duration`]`
+/// ## Convert from [`chrono::Duration`]
 /// ```
 /// # use pgmq::pg_ext::VisibilityTimeoutOffset;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(chrono::Duration::seconds(10)));
 /// ```
 ///
-/// ## Convert from [`chrono::Duration`]` capped max
+/// ## Convert from [`chrono::Duration`] -- capped max
 /// ```
 /// # use pgmq::pg_ext::VisibilityTimeoutOffset;
 /// assert_eq!(VisibilityTimeoutOffset::MAX, VisibilityTimeoutOffset::from(chrono::Duration::MAX));
 /// ```
 ///
-/// ## Convert from [`chrono::Duration`]` capped min
+/// ## Convert from [`chrono::Duration`] -- capped min
 /// ```
 /// # use pgmq::pg_ext::VisibilityTimeoutOffset;
 /// assert_eq!(VisibilityTimeoutOffset::MAX, VisibilityTimeoutOffset::from(chrono::Duration::MAX));
 /// ```
 ///
-/// ## Convert from [`std::time::Duration`]`
+/// ## Convert from [`std::time::Duration`]
 /// ```
 /// # use pgmq::pg_ext::VisibilityTimeoutOffset;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(std::time::Duration::from_secs(10)));
 /// ```
 ///
-/// ## Convert from [`std::time::Duration`]` capped max
+/// ## Convert from [`std::time::Duration`] -- capped max
 /// ```
 /// # use pgmq::pg_ext::VisibilityTimeoutOffset;
 /// assert_eq!(VisibilityTimeoutOffset::MAX, VisibilityTimeoutOffset::from(std::time::Duration::MAX));

--- a/pgmq-rs/src/util.rs
+++ b/pgmq-rs/src/util.rs
@@ -126,7 +126,7 @@ pub fn check_input(input: &str) -> Result<(), PgmqError> {
 #[cfg(feature = "install-sql-github")]
 #[deprecated(
     note = "Use pgmq::install::install_sql_from_github or pgmq::install::install_sql_from_embedded instead.",
-    since = "0.32.2"
+    since = "0.33.0"
 )]
 pub async fn install_pgmq(
     pool: &Pool<Postgres>,


### PR DESCRIPTION
This PR adds the following checks to the crate's `Makefile` and CI:

1. `check.docs` -- Checks that the docs build without any errors/warnings.
2. `check.minimal-versions` -- Checks that our dependencies are declared as the correct minimal versions. For example, if we depend on a crate with version "1.0.0", ensure we don’t accidentally depend on a feature added in version "1.5.0".

This PR also fixes the errors raised by these checks.