### PR TITLE
feat: Allow using `Message` to directly parse a SQL row

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -52,7 +52,7 @@ env_logger = "0.10.0"
 rand = "0.8.5"
 regex = "1.5.4"
 lazy_static = "1.4.0"
-insta = "1.46.3"
+insta = { version = "1.46.3", features = ["json"] }
 
 # If a consumer has both the `time` and `chrono` features of `sqlx` enabled, `sqlx` will default to using
 # `OffsetDateTime` (from `time`) for timestamp fields instead of `DateTime<Utc>` (from `chrono`), causing a compilation

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -6,7 +6,7 @@ use crate::util::{check_input, connect};
 use log::info;
 use serde::{Deserialize, Serialize};
 use sqlx::types::chrono::Utc;
-use sqlx::{Acquire, Pool, Postgres, Row};
+use sqlx::{Acquire, FromRow, Pool, Postgres, Row};
 pub use visibility_timeout_offest::VisibilityTimeoutOffset;
 
 const DEFAULT_POLL_TIMEOUT_S: i32 = 5;
@@ -337,21 +337,14 @@ impl PGMQueueExt {
         let updated = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.set_vt(queue_name=>$1::text, msg_id=>$2::bigint, vt=>$3::integer);"#
         )
-        .bind(queue_name)
-        .bind(msg_id)
-        .bind(vt)
-        .fetch_one(executor)
-        .await?;
-        let raw_msg = updated.try_get("message")?;
-        let parsed_msg = serde_json::from_value::<T>(raw_msg)?;
+            .bind(queue_name)
+            .bind(msg_id)
+            .bind(vt)
+            .fetch_one(executor)
+            .await
+            .and_then(|row| Message::<T>::from_row(&row))?;
 
-        Ok(Message {
-            msg_id: updated.try_get("msg_id")?,
-            vt: updated.try_get("vt")?,
-            read_ct: updated.try_get("read_ct")?,
-            enqueued_at: updated.try_get("enqueued_at")?,
-            message: parsed_msg,
-        })
+        Ok(updated)
     }
     // Set the visibility time on an existing message.
     pub async fn set_vt<T: for<'de> Deserialize<'de>>(
@@ -440,23 +433,15 @@ impl PGMQueueExt {
         let row = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)"#,
         )
-        .bind(queue_name)
-        .bind(vt)
-        .bind(1)
-        .fetch_optional(executor)
-        .await?;
+            .bind(queue_name)
+            .bind(vt)
+            .bind(1)
+            .fetch_optional(executor)
+            .await?;
         match row {
             Some(row) => {
                 // happy path - successfully read a message
-                let raw_msg = row.try_get("message")?;
-                let parsed_msg = serde_json::from_value::<T>(raw_msg)?;
-                Ok(Some(Message {
-                    msg_id: row.try_get("msg_id")?,
-                    vt: row.try_get("vt")?,
-                    read_ct: row.try_get("read_ct")?,
-                    enqueued_at: row.try_get("enqueued_at")?,
-                    message: parsed_msg,
-                }))
+                Ok(Some(Message::<T>::from_row(&row)?))
             }
             None => {
                 // no message found
@@ -512,22 +497,10 @@ impl PGMQueueExt {
             Err(e) => Err(e)?,
             Ok(rows) => {
                 // happy path - successfully read messages
-                let mut messages: Vec<Message<T>> = Vec::new();
-                for row in rows.iter() {
-                    let raw_msg = row.try_get("message")?;
-                    let parsed_msg = serde_json::from_value::<T>(raw_msg);
-                    if let Err(e) = parsed_msg {
-                        return Err(PgmqError::JsonParsingError(e));
-                    } else if let Ok(parsed_msg) = parsed_msg {
-                        messages.push(Message {
-                            msg_id: row.try_get("msg_id")?,
-                            vt: row.try_get("vt")?,
-                            read_ct: row.try_get("read_ct")?,
-                            enqueued_at: row.try_get("enqueued_at")?,
-                            message: parsed_msg,
-                        })
-                    }
-                }
+                let messages = rows
+                    .into_iter()
+                    .map(|row| Message::<T>::from_row(&row))
+                    .collect::<Result<Vec<Message<T>>, sqlx::Error>>()?;
                 Ok(Some(messages))
             }
         }
@@ -619,15 +592,7 @@ impl PGMQueueExt {
         match row {
             Some(row) => {
                 // happy path - successfully read a message
-                let raw_msg = row.try_get("message")?;
-                let parsed_msg = serde_json::from_value::<T>(raw_msg)?;
-                Ok(Some(Message {
-                    msg_id: row.try_get("msg_id")?,
-                    vt: row.try_get("vt")?,
-                    read_ct: row.try_get("read_ct")?,
-                    enqueued_at: row.try_get("enqueued_at")?,
-                    message: parsed_msg,
-                }))
+                Ok(Some(Message::<T>::from_row(&row)?))
             }
             None => {
                 // no message found

--- a/pgmq-rs/src/snapshots/pgmq__types__tests__serialize_message_body.snap
+++ b/pgmq-rs/src/snapshots/pgmq__types__tests__serialize_message_body.snap
@@ -1,0 +1,8 @@
+---
+source: src/types.rs
+expression: value
+---
+{
+  "a": "a",
+  "b": 1234
+}

--- a/pgmq-rs/src/types.rs
+++ b/pgmq-rs/src/types.rs
@@ -1,15 +1,13 @@
+use chrono::serde::ts_seconds::deserialize as from_ts;
 use serde::Deserialize;
 use sqlx::types::chrono::{DateTime, Utc};
-use std::time::Duration;
-
 use sqlx::FromRow;
+use std::time::Duration;
 
 pub const VT_DEFAULT: i32 = 30;
 pub const READ_LIMIT_DEFAULT: i32 = 1;
 pub const POLL_TIMEOUT_DEFAULT: Duration = Duration::from_secs(5);
 pub const POLL_INTERVAL_DEFAULT: Duration = Duration::from_millis(250);
-
-use chrono::serde::ts_seconds::deserialize as from_ts;
 
 pub const QUEUE_PREFIX: &str = r#"q"#;
 pub const ARCHIVE_PREFIX: &str = r#"a"#;
@@ -37,5 +35,6 @@ pub struct Message<T = serde_json::Value> {
     /// The number of times the message has been read. Increments on read.
     pub read_ct: i32,
     /// The message body.
+    #[sqlx(json)]
     pub message: T,
 }

--- a/pgmq-rs/src/util.rs
+++ b/pgmq-rs/src/util.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use sqlx::error::Error;
 use sqlx::postgres::PgRow;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
-use sqlx::{Acquire, Row};
+use sqlx::{Acquire, FromRow, Row};
 use sqlx::{ConnectOptions, Transaction};
 use sqlx::{Pool, Postgres};
 use url::{ParseError, Url};
@@ -45,23 +45,12 @@ pub async fn fetch_one_message<T: for<'de> Deserialize<'de>>(
     connection: &Pool<Postgres>,
 ) -> Result<Option<Message<T>>, PgmqError> {
     // explore: .fetch_optional()
-    let row: Result<PgRow, Error> = sqlx::query(query).fetch_one(connection).await;
+    let row = sqlx::query(query)
+        .fetch_one(connection)
+        .await
+        .and_then(|row| Message::<T>::from_row(&row));
     match row {
-        Ok(row) => {
-            // happy path - successfully read a message
-            let raw_msg = row.get("message");
-            let parsed_msg = serde_json::from_value::<T>(raw_msg);
-            match parsed_msg {
-                Ok(parsed_msg) => Ok(Some(Message {
-                    msg_id: row.get("msg_id"),
-                    vt: row.get("vt"),
-                    read_ct: row.get("read_ct"),
-                    enqueued_at: row.get("enqueued_at"),
-                    message: parsed_msg,
-                })),
-                Err(e) => Err(PgmqError::JsonParsingError(e)),
-            }
-        }
+        Ok(row) => Ok(Some(row)),
         Err(sqlx::error::Error::RowNotFound) => Ok(None),
         Err(e) => Err(e)?,
     }

--- a/pgmq-rs/tests/integration_test.rs
+++ b/pgmq-rs/tests/integration_test.rs
@@ -708,7 +708,7 @@ async fn test_parsing_error_modes() {
     // we expect a parse error
     match read_msg {
         Err(e) => {
-            if let PgmqError::JsonParsingError { .. } = e {
+            if let PgmqError::DatabaseError(sqlx::Error::ColumnDecode { .. }) = e {
                 // got the parsing error. good.
             } else {
                 // got some other error. bad.


### PR DESCRIPTION
Problem
-------
`Message` implements `FromRow` (via a `derive`), but it can't actually be used to directly parse a SQL row because the `message` field needs to be deserialized from JSON. This results in a lot of duplicated work to manually parse SQL rows.

Solution
--------
Add the `#[sqlx(json)]` attribute to the `message` field to tell `sqlx` to deserialize the field when parsing a SQL row.

Note:
- This will change the error returned when the JSON can't be deserialized from `PgmqError::JsonParsingError` to `PgmqError::DatabaseError(sqlx::Error::ColumnDecode)`. I'm not sure if this would be considered a breaking change.
- I didn't switch to `query_as` and instead am directly calling the `FromRow::from_row` trait method. This is because `query_as` requires `Send + Unpin` marker traits for the `T` type parameter, which I'm pretty sure would be a breaking change. However, if the above error type change is a breaking change, then I can switch to using `query_as`