### PR TITLE
feat: Add "send batch" functionality to `PGMQueueExt`

### DIFF
--- a/pgmq-rs/Makefile
+++ b/pgmq-rs/Makefile
@@ -42,7 +42,7 @@ check.semver:
 
 # Check the crate does not have any Clippy errors
 check.clippy:
-	cargo clippy --all-features
+	cargo clippy --all-features -- -D warnings
 
 # Check that the crate is formatted correctly
 check.fmt:

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -390,15 +390,15 @@ impl PGMQueueExt {
         check_input(queue_name)?;
         let delay: VisibilityTimeoutOffset = delay.into();
         let msg = serde_json::to_value(message)?;
-        let sent = sqlx::query(
-            "SELECT send as msg_id from pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, delay=>$3::int);",
+        let msg_id: i64 = sqlx::query_scalar(
+            "SELECT * from pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, delay=>$3::int);",
         )
-            .bind(queue_name)
-            .bind(msg)
-            .bind(delay)
-            .fetch_one(executor)
-            .await?;
-        Ok(sent.try_get("msg_id")?)
+        .bind(queue_name)
+        .bind(msg)
+        .bind(delay)
+        .fetch_one(executor)
+        .await?;
+        Ok(msg_id)
     }
 
     pub async fn send_delay<T: Serialize>(
@@ -451,18 +451,14 @@ impl PGMQueueExt {
             .iter()
             .map(serde_json::to_value)
             .collect::<Result<Vec<serde_json::Value>, _>>()?;
-        let sent = sqlx::query(
-            "SELECT send_batch as msg_id from pgmq.send_batch(queue_name=>$1::text, msgs=>$2::jsonb[], delay=>$3::integer);",
+        let sent: Vec<i64> = sqlx::query_scalar(
+            "SELECT * from pgmq.send_batch(queue_name=>$1::text, msgs=>$2::jsonb[], delay=>$3::integer);",
         )
             .bind(queue_name)
             .bind(msgs)
             .bind(delay)
             .fetch_all(executor)
             .await?;
-        let sent = sent
-            .into_iter()
-            .map(|row| row.try_get("msg_id"))
-            .collect::<Result<Vec<i64>, _>>()?;
         Ok(sent)
     }
 

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -363,15 +363,8 @@ impl PGMQueueExt {
         message: &T,
         executor: E,
     ) -> Result<i64, PgmqError> {
-        check_input(queue_name)?;
-        let msg = serde_json::json!(&message);
-        let prepared = sqlx::query(
-            "SELECT send as msg_id from pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, delay=>0::integer);",
-        )
-        .bind(queue_name)
-        .bind(msg);
-        let sent = prepared.fetch_one(executor).await?;
-        Ok(sent.try_get("msg_id")?)
+        self.send_delay_with_cxn(queue_name, message, 0, executor)
+            .await
     }
 
     pub async fn send<T: Serialize>(
@@ -396,15 +389,15 @@ impl PGMQueueExt {
     ) -> Result<i64, PgmqError> {
         check_input(queue_name)?;
         let delay: VisibilityTimeoutOffset = delay.into();
-        let msg = serde_json::json!(&message);
+        let msg = serde_json::to_value(message)?;
         let sent = sqlx::query(
             "SELECT send as msg_id from pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, delay=>$3::int);",
         )
-        .bind(queue_name)
-        .bind(msg)
-        .bind(delay)
-        .fetch_one(executor)
-        .await?;
+            .bind(queue_name)
+            .bind(msg)
+            .bind(delay)
+            .fetch_one(executor)
+            .await?;
         Ok(sent.try_get("msg_id")?)
     }
 
@@ -415,6 +408,71 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
     ) -> Result<i64, PgmqError> {
         self.send_delay_with_cxn(queue_name, message, delay, &self.connection)
+            .await
+    }
+
+    pub async fn send_batch_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: Serialize,
+    >(
+        &self,
+        queue_name: &str,
+        messages: &[T],
+        executor: E,
+    ) -> Result<Vec<i64>, PgmqError> {
+        self.send_batch_with_delay_with_cxn(queue_name, messages, 0, executor)
+            .await
+    }
+
+    pub async fn send_batch<T: Serialize>(
+        &self,
+        queue_name: &str,
+        messages: &[T],
+    ) -> Result<Vec<i64>, PgmqError> {
+        self.send_batch_with_cxn(queue_name, messages, &self.connection)
+            .await
+    }
+
+    pub async fn send_batch_with_delay_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: Serialize,
+    >(
+        &self,
+        queue_name: &str,
+        messages: &[T],
+        delay: impl Into<VisibilityTimeoutOffset>,
+        executor: E,
+    ) -> Result<Vec<i64>, PgmqError> {
+        check_input(queue_name)?;
+        let delay: VisibilityTimeoutOffset = delay.into();
+        let msgs = messages
+            .iter()
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<serde_json::Value>, _>>()?;
+        let sent = sqlx::query(
+            "SELECT send_batch as msg_id from pgmq.send_batch(queue_name=>$1::text, msgs=>$2::jsonb[], delay=>$3::integer);",
+        )
+            .bind(queue_name)
+            .bind(msgs)
+            .bind(delay)
+            .fetch_all(executor)
+            .await?;
+        let sent = sent
+            .into_iter()
+            .map(|row| row.try_get("msg_id"))
+            .collect::<Result<Vec<i64>, _>>()?;
+        Ok(sent)
+    }
+
+    pub async fn send_batch_with_delay<T: Serialize>(
+        &self,
+        queue_name: &str,
+        messages: &[T],
+        delay: impl Into<VisibilityTimeoutOffset>,
+    ) -> Result<Vec<i64>, PgmqError> {
+        self.send_batch_with_delay_with_cxn(queue_name, messages, delay, &self.connection)
             .await
     }
 

--- a/pgmq-rs/src/util.rs
+++ b/pgmq-rs/src/util.rs
@@ -4,10 +4,8 @@ use crate::{errors::PgmqError, types::Message};
 
 use log::LevelFilter;
 use serde::Deserialize;
-use sqlx::error::Error;
-use sqlx::postgres::PgRow;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
-use sqlx::{Acquire, FromRow, Row};
+use sqlx::{Acquire, FromRow};
 use sqlx::{ConnectOptions, Transaction};
 use sqlx::{Pool, Postgres};
 use url::{ParseError, Url};

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -5,6 +5,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Postgres, Row};
 use std::env;
+use std::time::Duration;
 
 // always test extension sdk in its own database
 // to avoid conflict with client only sdk
@@ -266,12 +267,12 @@ async fn test_ext_send_read_delete_vt_offset() {
     .await;
 }
 
-async fn test_ext_send_delay_core(delay: impl Into<VisibilityTimeoutOffset>) {
+async fn test_ext_send_delay_core(delay: impl Copy + Into<VisibilityTimeoutOffset>) {
     let test_queue = format!(
         "test_ext_send_delay_{}",
         rand::thread_rng().gen_range(0..100000)
     );
-    let vt = 1;
+    let vt = 4;
     let queue = init_queue_ext(&test_queue).await;
     let msg = MyMessage::default();
     queue.send_delay(&test_queue, &msg, delay).await.unwrap();
@@ -280,8 +281,10 @@ async fn test_ext_send_delay_core(delay: impl Into<VisibilityTimeoutOffset>) {
     let no_messages = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
     assert!(no_messages.is_none());
 
-    // After 5 seconds, message is found
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    // After the delay, message is found
+    let duration: VisibilityTimeoutOffset = delay.into();
+    tokio::time::sleep(Duration::from_secs(duration.as_seconds() as u64)).await;
+
     let one_messages = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
     assert!(one_messages.is_some());
 }
@@ -319,6 +322,103 @@ async fn test_ext_send_delay_std() {
 #[tokio::test]
 async fn test_ext_send_delay_vt_offset() {
     test_ext_send_delay_core(VisibilityTimeoutOffset::seconds(5)).await;
+}
+
+#[tokio::test]
+async fn test_ext_send_batch() {
+    let test_queue = format!(
+        "test_ext_send_batch_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+    let msgs = [
+        MyMessage::default(),
+        MyMessage::default(),
+        MyMessage::default(),
+    ];
+    let msg_ids = queue.send_batch(&test_queue, &msgs).await.unwrap();
+    assert_eq!(3, msg_ids.len());
+
+    let vt = 4;
+    let msg1 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg2 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg3 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg4 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    assert!(msg1.is_some());
+    assert!(msg2.is_some());
+    assert!(msg3.is_some());
+    assert!(msg4.is_none());
+}
+
+async fn test_ext_send_batch_delay_core(delay: impl Copy + Into<VisibilityTimeoutOffset>) {
+    let test_queue = format!(
+        "test_ext_send_batch_delay_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+    let msgs = [
+        MyMessage::default(),
+        MyMessage::default(),
+        MyMessage::default(),
+    ];
+    let msg_ids = queue
+        .send_batch_with_delay(&test_queue, &msgs, delay)
+        .await
+        .unwrap();
+    assert_eq!(3, msg_ids.len());
+
+    // No messages are found due to visibility timeout
+    let vt = 4;
+    let no_messages = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    assert!(no_messages.is_none());
+
+    // After the delay, messages are found
+    let duration: VisibilityTimeoutOffset = delay.into();
+    tokio::time::sleep(Duration::from_secs(duration.as_seconds() as u64)).await;
+
+    let msg1 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg2 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg3 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg4 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    assert!(msg1.is_some());
+    assert!(msg2.is_some());
+    assert!(msg3.is_some());
+    assert!(msg4.is_none());
+}
+
+#[tokio::test]
+async fn test_ext_send_batch_delay_i32() {
+    test_ext_send_batch_delay_core(5i32).await;
+}
+
+#[tokio::test]
+async fn test_ext_send_batch_delay_i64() {
+    test_ext_send_batch_delay_core(5i64).await;
+}
+
+#[tokio::test]
+async fn test_ext_send_batch_delay_u32() {
+    test_ext_send_batch_delay_core(5u32).await;
+}
+
+#[tokio::test]
+async fn test_ext_send_batch_delay_u64() {
+    test_ext_send_batch_delay_core(5u64).await;
+}
+
+#[tokio::test]
+async fn test_ext_send_batch_delay_chrono() {
+    test_ext_send_batch_delay_core(chrono::Duration::seconds(5)).await;
+}
+
+#[tokio::test]
+async fn test_ext_send_batch_delay_std() {
+    test_ext_send_batch_delay_core(std::time::Duration::from_secs(5)).await;
+}
+
+#[tokio::test]
+async fn test_ext_send_batch_delay_vt_offset() {
+    test_ext_send_batch_delay_core(VisibilityTimeoutOffset::seconds(5)).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR adds support for batch enqueueing messages from the `PGMQueueExt` rust client.

This PR also updates the `make check.clippy` command to disallow clippy warnings instead of just errors. This will cause clippy to emit an error for unused imports and any other warning-level lint.

Relates to https://github.com/pgmq/pgmq/issues/494