### PR TITLE
feat: Add "read batch" functionality to `PGMQueueExt`

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.33.2"
+version = "0.33.3"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -5,6 +5,7 @@ use crate::types::{Message, QUEUE_PREFIX};
 use crate::util::{check_input, connect};
 use log::info;
 use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgRow;
 use sqlx::types::chrono::Utc;
 use sqlx::{Acquire, FromRow, Pool, Postgres, Row};
 pub use visibility_timeout_offest::VisibilityTimeoutOffset;
@@ -482,27 +483,11 @@ impl PGMQueueExt {
         vt: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<Option<Message<T>>, PgmqError> {
-        check_input(queue_name)?;
-        let vt: VisibilityTimeoutOffset = vt.into();
-        let row = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)"#,
-        )
-            .bind(queue_name)
-            .bind(vt)
-            .bind(1)
-            .fetch_optional(executor)
-            .await?;
-        match row {
-            Some(row) => {
-                // happy path - successfully read a message
-                Ok(Some(Message::<T>::from_row(&row)?))
-            }
-            None => {
-                // no message found
-                Ok(None)
-            }
-        }
+        self.read_batch_with_cxn(queue_name, vt, 1, executor)
+            .await
+            .map(|result| result.into_iter().next())
     }
+
     pub async fn read<T: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
@@ -511,6 +496,43 @@ impl PGMQueueExt {
         self.read_with_cxn(queue_name, vt, &self.connection).await
     }
 
+    pub async fn read_batch_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        executor: E,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        check_input(queue_name)?;
+        let vt: VisibilityTimeoutOffset = vt.into();
+        let rows = sqlx::query(
+            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)"#,
+        )
+            .bind(queue_name)
+            .bind(vt)
+            .bind(qty)
+            .fetch_all(executor)
+            .await?;
+
+        Self::handle_read_batch_result(rows)
+    }
+
+    pub async fn read_batch<T: for<'de> Deserialize<'de>>(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        self.read_batch_with_cxn(queue_name, vt, qty, &self.connection)
+            .await
+    }
+
+    // Todo: In a future SemVer-breaking release, we can update this to return
+    //  `Result<Vec<Message<T>>, PgmqError>` to match `read_batch`/`read_batch_with_cxn`.
     pub async fn read_batch_with_poll_with_cxn<
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
@@ -529,7 +551,7 @@ impl PGMQueueExt {
         let poll_timeout_s = poll_timeout.map_or(DEFAULT_POLL_TIMEOUT_S, |t| t.as_secs() as i32);
         let poll_interval_ms =
             poll_interval.map_or(DEFAULT_POLL_INTERVAL_MS, |i| i.as_millis() as i32);
-        let result = sqlx::query(
+        let rows = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_with_poll(
                 queue_name=>$1::text,
                 vt=>$2::integer,
@@ -544,20 +566,9 @@ impl PGMQueueExt {
         .bind(poll_timeout_s)
         .bind(poll_interval_ms)
         .fetch_all(executor)
-        .await;
+        .await?;
 
-        match result {
-            Err(sqlx::error::Error::RowNotFound) => Ok(None),
-            Err(e) => Err(e)?,
-            Ok(rows) => {
-                // happy path - successfully read messages
-                let messages = rows
-                    .into_iter()
-                    .map(|row| Message::<T>::from_row(&row))
-                    .collect::<Result<Vec<Message<T>>, sqlx::Error>>()?;
-                Ok(Some(messages))
-            }
-        }
+        Self::handle_read_batch_result(rows).map(Some)
     }
 
     pub async fn read_batch_with_poll<T: for<'de> Deserialize<'de>>(
@@ -577,6 +588,23 @@ impl PGMQueueExt {
             &self.connection,
         )
         .await
+    }
+
+    /// Helper method to convert [`PgRow`] to [`Message`] for the `read*`/`read_batch*` methods.
+    /// This is needed, vs using [`sqlx::query_as`] to directly convert the result to
+    /// [`Message`], because in order to use [`sqlx::query_as`] we need to add trait constraints
+    /// to the `T` type parameter used in the `read*`/`read_batch*` methods, which
+    /// would be a breaking change.
+    // Todo: In a future SemVer-breaking release, replace this method using `query_as`
+    //  to directly parse the SQL query rows to `Vec<Message<T>`.
+    fn handle_read_batch_result<T: for<'de> Deserialize<'de>>(
+        rows: Vec<PgRow>,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        let messages = rows
+            .into_iter()
+            .map(|row| Message::<T>::from_row(&row))
+            .collect::<Result<Vec<Message<T>>, _>>()?;
+        Ok(messages)
     }
 
     pub async fn archive_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -353,7 +353,7 @@ async fn test_ext_send_batch() {
 #[tokio::test]
 async fn test_ext_send_batch_read_batch() {
     let test_queue = format!(
-        "test_ext_send_batch_{}",
+        "test_ext_send_batch_read_batch_{}",
         rand::thread_rng().gen_range(0..100000)
     );
     let queue = init_queue_ext(&test_queue).await;
@@ -390,6 +390,26 @@ async fn test_ext_send_batch_read_batch() {
         .await
         .unwrap();
     assert!(msgs_read.is_empty());
+}
+
+#[tokio::test]
+async fn test_ext_read_batch_with_poll_empty_queue() {
+    let test_queue = format!(
+        "test_ext_read_batch_with_poll_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let vt = 4;
+
+    // read_batch_with_poll should return Ok(Some(<empty vec>)) if no items are available to be read.
+    // Todo: In a future SemVer breaking change, the expected return value would be Ok(<empty vec>)
+    let msg_read = queue
+        .read_batch_with_poll::<MyMessage>(&test_queue, vt, 1, Some(Duration::from_secs(1)), None)
+        .await
+        .unwrap();
+    assert!(msg_read.is_some());
+    assert!(msg_read.unwrap().is_empty());
 }
 
 async fn test_ext_send_batch_delay_core(delay: impl Copy + Into<VisibilityTimeoutOffset>) {

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -350,6 +350,48 @@ async fn test_ext_send_batch() {
     assert!(msg4.is_none());
 }
 
+#[tokio::test]
+async fn test_ext_send_batch_read_batch() {
+    let test_queue = format!(
+        "test_ext_send_batch_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let vt = 4;
+    let msgs_read = queue
+        .read_batch::<MyMessage>(&test_queue, vt, 1)
+        .await
+        .unwrap();
+    assert!(msgs_read.is_empty());
+
+    let msgs_sent = [
+        MyMessage::default(),
+        MyMessage::default(),
+        MyMessage::default(),
+    ];
+    let msg_ids = queue.send_batch(&test_queue, &msgs_sent).await.unwrap();
+    assert_eq!(3, msg_ids.len());
+
+    let msgs_read = queue
+        .read_batch::<MyMessage>(&test_queue, vt, (msgs_sent.len() as i32) - 1)
+        .await
+        .expect("Should successfully read a batch of messages");
+    assert_eq!(msgs_sent.len() - 1, msgs_read.len());
+
+    let msgs_read = queue
+        .read_batch::<MyMessage>(&test_queue, vt, 1)
+        .await
+        .unwrap();
+    assert_eq!(1, msgs_read.len());
+
+    let msgs_read = queue
+        .read_batch::<MyMessage>(&test_queue, vt, 1)
+        .await
+        .unwrap();
+    assert!(msgs_read.is_empty());
+}
+
 async fn test_ext_send_batch_delay_core(delay: impl Copy + Into<VisibilityTimeoutOffset>) {
     let test_queue = format!(
         "test_ext_send_batch_delay_{}",


### PR DESCRIPTION
This PR adds support for reading batches of messages from `PGMQueueExt` rust client. This PR also updates the existing single-message read functions to use the batch method with a `qty` of one.

Relates to https://github.com/pgmq/pgmq/issues/494