### PR TITLE
chore: Check that upgrade scripts do not diverge from a fresh install

### DIFF
--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -144,3 +144,106 @@ jobs:
         if: failure()
         working-directory: ./pgmq-extension
         run: cat regression.diffs
+
+  upgrade_scripts_do_not_diverge:
+    name: Confirm upgrade scripts do not diverge from fresh install (pg ${{ matrix.pg }})
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: [ 14, 15, 16, 17, 18 ]
+    env:
+      DATABASE_URL: postgresql://postgres@localhost:5432/postgres
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get current branch
+        id: current-version
+        run: echo "CI_BRANCH=$(git name-rev --name-only HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Start PostgreSQL ${{ matrix.pg }}
+        run: pg-start ${{ matrix.pg }}
+
+      - name: Checkout old version (v1.5.0)
+        run: git checkout tags/v1.5.0
+
+      - name: Install pgmq v1.5.0 as an extension
+        working-directory: ./pgmq-extension
+        run: |
+          make clean || true
+          make
+          make install
+          psql -c "CREATE EXTENSION pgmq;"
+
+      - name: Checkout CI branch
+        env:
+          CI_BRANCH: ${{ steps.current-version.outputs.CI_BRANCH }}
+        run: git checkout $CI_BRANCH
+
+      - name: Install and upgrade pgmq extension to CI branch version
+        working-directory: ./pgmq-extension
+        run: |
+          make clean || true
+          make
+          make install
+          psql -c "ALTER EXTENSION pgmq UPDATE;"
+
+      - name: Dump the extension schema (upgrade path)
+        run: |
+          file_name=/tmp/pg_dump_upgrade.txt
+          echo "--- pgmq extension version ---" >> $file_name
+          psql "$DATABASE_URL" -A -t -c "SELECT extversion FROM pg_extension where extname = 'pgmq';" >> $file_name
+          echo "--- pg_dump ---" >> $file_name
+          pg_dump -n pgmq -e pgmq "$DATABASE_URL" >> $file_name
+          # `pg_dump` does not dump all data, so we need to manually dump the other data we care about
+          echo "--- pgmq functions ---" >> $file_name
+          psql "$DATABASE_URL" -A -t -c "SELECT pg_get_functiondef(f.oid) FROM pg_catalog.pg_proc f INNER JOIN pg_catalog.pg_namespace n ON (f.pronamespace = n.oid) WHERE n.nspname = 'pgmq' ORDER BY pg_get_functiondef(f.oid);" >> $file_name
+          echo "--- pgmq tables ---" >> $file_name
+          psql "$DATABASE_URL" -A -c "SELECT table_name, column_name, ordinal_position, column_default, is_nullable, data_type FROM information_schema.columns WHERE table_schema = 'pgmq' ORDER BY table_name, ordinal_position;" >> $file_name
+          echo "--- pgmq types ---" >> $file_name
+          psql "$DATABASE_URL" -A -c "SELECT udt_name, attribute_name, ordinal_position, attribute_default, is_nullable, data_type FROM information_schema.attributes where udt_schema = 'pgmq' ORDER BY udt_name, ordinal_position;" >> $file_name
+
+      - name: Drop the extension and perform a fresh installation
+        run: |
+          psql "$DATABASE_URL" -c "DROP EXTENSION pgmq;"
+          psql "$DATABASE_URL" -c "CREATE EXTENSION pgmq;"
+
+      - name: Dump the extension schema (fresh install)
+        run: |
+          file_name=/tmp/pg_dump_fresh.txt
+          echo "--- pgmq extension version ---" >> $file_name
+          psql "$DATABASE_URL" -A -t -c "SELECT extversion FROM pg_extension where extname = 'pgmq';" >> $file_name
+          echo "--- pg_dump ---" >> $file_name
+          pg_dump -n pgmq -e pgmq "$DATABASE_URL" >> $file_name
+          # `pg_dump` does not dump all data, so we need to manually dump the other data we care about
+          echo "--- pgmq functions ---" >> $file_name
+          psql "$DATABASE_URL" -A -t -c "SELECT pg_get_functiondef(f.oid) FROM pg_catalog.pg_proc f INNER JOIN pg_catalog.pg_namespace n ON (f.pronamespace = n.oid) WHERE n.nspname = 'pgmq' ORDER BY pg_get_functiondef(f.oid);" >> $file_name
+          echo "--- pgmq tables ---" >> $file_name
+          psql "$DATABASE_URL" -A -c "SELECT table_name, column_name, ordinal_position, column_default, is_nullable, data_type FROM information_schema.columns WHERE table_schema = 'pgmq' ORDER BY table_name, ordinal_position;" >> $file_name
+          echo "--- pgmq types ---" >> $file_name
+          psql "$DATABASE_URL" -A -c "SELECT udt_name, attribute_name, ordinal_position, attribute_default, is_nullable, data_type FROM information_schema.attributes where udt_schema = 'pgmq' ORDER BY udt_name, ordinal_position;" >> $file_name
+
+      - name: Compare output
+        run: |
+          # `pg_dump` outputs two random lines that will always be different for every output. They look something like this:
+          #
+          # ```
+          # \restrict JHbd1xebXKAq2dfkAGAXWi7b1B3ifORyKWdIrTcwerJibjA54EsYymeEFrIQNmc
+          # \unrestrict JHbd1xebXKAq2dfkAGAXWi7b1B3ifORyKWdIrTcwerJibjA54EsYymeEFrIQNmc
+          # ```
+          num_lines_different=$(! diff -y --suppress-common-lines --ignore-all-space /tmp/pg_dump_upgrade.txt /tmp/pg_dump_fresh.txt | wc -l)
+          if [[ $num_lines_different -gt 2 ]]; then
+            echo "PGMQ upgrade diverges from a fresh installation. Diff:"
+            ! diff --suppress-common-lines --ignore-all-space /tmp/pg_dump_upgrade.txt /tmp/pg_dump_fresh.txt
+
+            echo "Upgrade path:"
+            cat /tmp/pg_dump_upgrade.txt
+
+            echo "Fresh install:"
+            cat /tmp/pg_dump_fresh.txt
+
+            exit 1
+          fi

--- a/.github/workflows/extension_upgrade.yml
+++ b/.github/workflows/extension_upgrade.yml
@@ -192,19 +192,9 @@ jobs:
           psql -c "ALTER EXTENSION pgmq UPDATE;"
 
       - name: Dump the extension schema (upgrade path)
+        working-directory: ./pgmq-extension
         run: |
-          file_name=/tmp/pg_dump_upgrade.txt
-          echo "--- pgmq extension version ---" >> $file_name
-          psql "$DATABASE_URL" -A -t -c "SELECT extversion FROM pg_extension where extname = 'pgmq';" >> $file_name
-          echo "--- pg_dump ---" >> $file_name
-          pg_dump -n pgmq -e pgmq "$DATABASE_URL" >> $file_name
-          # `pg_dump` does not dump all data, so we need to manually dump the other data we care about
-          echo "--- pgmq functions ---" >> $file_name
-          psql "$DATABASE_URL" -A -t -c "SELECT pg_get_functiondef(f.oid) FROM pg_catalog.pg_proc f INNER JOIN pg_catalog.pg_namespace n ON (f.pronamespace = n.oid) WHERE n.nspname = 'pgmq' ORDER BY pg_get_functiondef(f.oid);" >> $file_name
-          echo "--- pgmq tables ---" >> $file_name
-          psql "$DATABASE_URL" -A -c "SELECT table_name, column_name, ordinal_position, column_default, is_nullable, data_type FROM information_schema.columns WHERE table_schema = 'pgmq' ORDER BY table_name, ordinal_position;" >> $file_name
-          echo "--- pgmq types ---" >> $file_name
-          psql "$DATABASE_URL" -A -c "SELECT udt_name, attribute_name, ordinal_position, attribute_default, is_nullable, data_type FROM information_schema.attributes where udt_schema = 'pgmq' ORDER BY udt_name, ordinal_position;" >> $file_name
+          make dump.extension-schema FILE_PATH=/tmp/pg_dump_upgrade.txt
 
       - name: Drop the extension and perform a fresh installation
         run: |
@@ -212,19 +202,9 @@ jobs:
           psql "$DATABASE_URL" -c "CREATE EXTENSION pgmq;"
 
       - name: Dump the extension schema (fresh install)
+        working-directory: ./pgmq-extension
         run: |
-          file_name=/tmp/pg_dump_fresh.txt
-          echo "--- pgmq extension version ---" >> $file_name
-          psql "$DATABASE_URL" -A -t -c "SELECT extversion FROM pg_extension where extname = 'pgmq';" >> $file_name
-          echo "--- pg_dump ---" >> $file_name
-          pg_dump -n pgmq -e pgmq "$DATABASE_URL" >> $file_name
-          # `pg_dump` does not dump all data, so we need to manually dump the other data we care about
-          echo "--- pgmq functions ---" >> $file_name
-          psql "$DATABASE_URL" -A -t -c "SELECT pg_get_functiondef(f.oid) FROM pg_catalog.pg_proc f INNER JOIN pg_catalog.pg_namespace n ON (f.pronamespace = n.oid) WHERE n.nspname = 'pgmq' ORDER BY pg_get_functiondef(f.oid);" >> $file_name
-          echo "--- pgmq tables ---" >> $file_name
-          psql "$DATABASE_URL" -A -c "SELECT table_name, column_name, ordinal_position, column_default, is_nullable, data_type FROM information_schema.columns WHERE table_schema = 'pgmq' ORDER BY table_name, ordinal_position;" >> $file_name
-          echo "--- pgmq types ---" >> $file_name
-          psql "$DATABASE_URL" -A -c "SELECT udt_name, attribute_name, ordinal_position, attribute_default, is_nullable, data_type FROM information_schema.attributes where udt_schema = 'pgmq' ORDER BY udt_name, ordinal_position;" >> $file_name
+          make dump.extension-schema FILE_PATH=/tmp/pg_dump_fresh.txt
 
       - name: Compare output
         run: |

--- a/pgmq-extension/Makefile
+++ b/pgmq-extension/Makefile
@@ -40,3 +40,16 @@ install-pg-partman:
 	make && \
 	make install PG_CONFIG=$(PG_CONFIG) && \
 	cd ../ && rm -rf pg_partman
+
+dump.extension-schema:
+	echo "--- pgmq extension version ---" > $(FILE_PATH)
+	psql $(DATABASE_URL) -A -t -c "SELECT extversion FROM pg_extension where extname = 'pgmq';" >> $(FILE_PATH)
+	echo "--- pg_dump ---" >> $(FILE_PATH)
+	pg_dump -n pgmq -e pgmq $(DATABASE_URL) >> $(FILE_PATH)
+	# `pg_dump` does not dump all data, so we need to manually dump the other data we care about
+	echo "--- pgmq functions ---" >> $(FILE_PATH)
+	psql $(DATABASE_URL) -A -t -c "SELECT pg_get_functiondef(f.oid) FROM pg_catalog.pg_proc f INNER JOIN pg_catalog.pg_namespace n ON (f.pronamespace = n.oid) WHERE n.nspname = 'pgmq' ORDER BY pg_get_functiondef(f.oid);" >> $(FILE_PATH)
+	echo "--- pgmq tables ---" >> $(FILE_PATH)
+	psql $(DATABASE_URL) -A -c "SELECT table_name, column_name, ordinal_position, column_default, is_nullable, data_type FROM information_schema.columns WHERE table_schema = 'pgmq' ORDER BY table_name, ordinal_position;" >> $(FILE_PATH)
+	echo "--- pgmq types ---" >> $(FILE_PATH)
+	psql $(DATABASE_URL) -A -c "SELECT udt_name, attribute_name, ordinal_position, attribute_default, is_nullable, data_type FROM information_schema.attributes where udt_schema = 'pgmq' ORDER BY udt_name, ordinal_position;" >> $(FILE_PATH)

--- a/pgmq-extension/pgmq.control
+++ b/pgmq-extension/pgmq.control
@@ -1,5 +1,5 @@
 comment = 'A lightweight message queue. Like AWS SQS and RSMQ but on Postgres.'
-default_version = '1.11.0'
+default_version = '1.11.1'
 module_pathname = '$libdir/pgmq'
 schema = 'pgmq'
 relocatable = false

--- a/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
+++ b/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
@@ -1,0 +1,71 @@
+-- Allow `pgmq.notify_insert_throttle` and `pgmq.topic_bindings` to be dumped by `pg_dump` when pgmq is installed as an extension
+DO
+$$
+BEGIN
+    IF EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pgmq') THEN
+        PERFORM pg_catalog.pg_extension_config_dump('pgmq.notify_insert_throttle', '');
+        PERFORM pg_catalog.pg_extension_config_dump('pgmq.topic_bindings', '');
+    END IF;
+END
+$$;
+
+
+-- read_grouped_head:  read the head of N different FIFO groups in a single operation.
+-- This supports horizontal scaling by processing groups in parallel while ensuring message ordering is preserved per group.
+CREATE OR REPLACE FUNCTION pgmq.read_grouped_head(
+    queue_name TEXT,
+    vt INTEGER,
+    qty INTEGER
+)
+RETURNS SETOF pgmq.message_record AS $$
+DECLARE
+    sql TEXT;
+    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+BEGIN
+    sql := FORMAT(
+        $QUERY$
+        WITH fifo_groups AS (
+            -- Determine the absolute head (oldest) message id per FIFO group, regardless of visibility
+            SELECT
+                COALESCE(headers->>'x-pgmq-group', '_default_fifo_group') AS fifo_key,
+                MIN(msg_id) AS head_msg_id
+            FROM pgmq.%1$I
+            GROUP BY COALESCE(headers->>'x-pgmq-group', '_default_fifo_group')
+        ),
+        selected_messages AS (
+            -- Take at most 1 message per group
+            SELECT g.head_msg_id msg_id
+            FROM fifo_groups g
+            JOIN pgmq.%1$I q ON q.msg_id = g.head_msg_id
+	        WHERE q.vt <= clock_timestamp()
+            ORDER BY q.msg_id
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+        )
+        UPDATE pgmq.%1$I m
+        SET
+            vt = clock_timestamp() + %2$L,
+            read_ct = read_ct + 1,
+            last_read_at = clock_timestamp()
+        FROM selected_messages sm
+        WHERE m.msg_id = sm.msg_id
+        RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.last_read_at, m.vt, m.message, m.headers;
+        $QUERY$,
+        qtable, make_interval(secs => vt)
+    );
+    RETURN QUERY EXECUTE sql USING qty;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION pgmq._ensure_pg_partman_installed()
+RETURNS void AS $$
+BEGIN
+  IF NOT pgmq._extension_exists('pg_partman') THEN
+    RAISE EXCEPTION 'pg_partman is required for partitioned queues';
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+
+DROP FUNCTION IF EXISTS pgmq.enable_notify_insert(queue_name text);

--- a/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
+++ b/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
@@ -3,7 +3,6 @@ DO
 $$
 BEGIN
     IF EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pgmq') THEN
-        PERFORM pg_catalog.pg_extension_config_dump('pgmq.notify_insert_throttle', '');
         PERFORM pg_catalog.pg_extension_config_dump('pgmq.topic_bindings', '');
     END IF;
 END

--- a/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
+++ b/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
@@ -1,4 +1,4 @@
--- Allow `pgmq.notify_insert_throttle` and `pgmq.topic_bindings` to be dumped by `pg_dump` when pgmq is installed as an extension
+-- Allow `pgmq.topic_bindings` to be dumped by `pg_dump` when pgmq is installed as an extension
 DO
 $$
 BEGIN

--- a/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
+++ b/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
@@ -1,71 +1,71 @@
 -- Allow `pgmq.notify_insert_throttle` and `pgmq.topic_bindings` to be dumped by `pg_dump` when pgmq is installed as an extension
-DO
-$$
-BEGIN
-    IF EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pgmq') THEN
-        PERFORM pg_catalog.pg_extension_config_dump('pgmq.notify_insert_throttle', '');
-        PERFORM pg_catalog.pg_extension_config_dump('pgmq.topic_bindings', '');
-    END IF;
-END
-$$;
+-- DO
+-- $$
+-- BEGIN
+--     IF EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pgmq') THEN
+--         PERFORM pg_catalog.pg_extension_config_dump('pgmq.notify_insert_throttle', '');
+--         PERFORM pg_catalog.pg_extension_config_dump('pgmq.topic_bindings', '');
+--     END IF;
+-- END
+-- $$;
+--
+--
+-- -- read_grouped_head:  read the head of N different FIFO groups in a single operation.
+-- -- This supports horizontal scaling by processing groups in parallel while ensuring message ordering is preserved per group.
+-- CREATE OR REPLACE FUNCTION pgmq.read_grouped_head(
+--     queue_name TEXT,
+--     vt INTEGER,
+--     qty INTEGER
+-- )
+-- RETURNS SETOF pgmq.message_record AS $$
+-- DECLARE
+--     sql TEXT;
+--     qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+-- BEGIN
+--     sql := FORMAT(
+--         $QUERY$
+--         WITH fifo_groups AS (
+--             -- Determine the absolute head (oldest) message id per FIFO group, regardless of visibility
+--             SELECT
+--                 COALESCE(headers->>'x-pgmq-group', '_default_fifo_group') AS fifo_key,
+--                 MIN(msg_id) AS head_msg_id
+--             FROM pgmq.%1$I
+--             GROUP BY COALESCE(headers->>'x-pgmq-group', '_default_fifo_group')
+--         ),
+--         selected_messages AS (
+--             -- Take at most 1 message per group
+--             SELECT g.head_msg_id msg_id
+--             FROM fifo_groups g
+--             JOIN pgmq.%1$I q ON q.msg_id = g.head_msg_id
+-- 	        WHERE q.vt <= clock_timestamp()
+--             ORDER BY q.msg_id
+--             LIMIT $1
+--             FOR UPDATE SKIP LOCKED
+--         )
+--         UPDATE pgmq.%1$I m
+--         SET
+--             vt = clock_timestamp() + %2$L,
+--             read_ct = read_ct + 1,
+--             last_read_at = clock_timestamp()
+--         FROM selected_messages sm
+--         WHERE m.msg_id = sm.msg_id
+--         RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.last_read_at, m.vt, m.message, m.headers;
+--         $QUERY$,
+--         qtable, make_interval(secs => vt)
+--     );
+--     RETURN QUERY EXECUTE sql USING qty;
+-- END;
+-- $$ LANGUAGE plpgsql;
+--
+--
+-- CREATE OR REPLACE FUNCTION pgmq._ensure_pg_partman_installed()
+-- RETURNS void AS $$
+-- BEGIN
+--   IF NOT pgmq._extension_exists('pg_partman') THEN
+--     RAISE EXCEPTION 'pg_partman is required for partitioned queues';
+--   END IF;
+-- END;
+-- $$ LANGUAGE plpgsql;
 
 
--- read_grouped_head:  read the head of N different FIFO groups in a single operation.
--- This supports horizontal scaling by processing groups in parallel while ensuring message ordering is preserved per group.
-CREATE OR REPLACE FUNCTION pgmq.read_grouped_head(
-    queue_name TEXT,
-    vt INTEGER,
-    qty INTEGER
-)
-RETURNS SETOF pgmq.message_record AS $$
-DECLARE
-    sql TEXT;
-    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
-BEGIN
-    sql := FORMAT(
-        $QUERY$
-        WITH fifo_groups AS (
-            -- Determine the absolute head (oldest) message id per FIFO group, regardless of visibility
-            SELECT
-                COALESCE(headers->>'x-pgmq-group', '_default_fifo_group') AS fifo_key,
-                MIN(msg_id) AS head_msg_id
-            FROM pgmq.%1$I
-            GROUP BY COALESCE(headers->>'x-pgmq-group', '_default_fifo_group')
-        ),
-        selected_messages AS (
-            -- Take at most 1 message per group
-            SELECT g.head_msg_id msg_id
-            FROM fifo_groups g
-            JOIN pgmq.%1$I q ON q.msg_id = g.head_msg_id
-	        WHERE q.vt <= clock_timestamp()
-            ORDER BY q.msg_id
-            LIMIT $1
-            FOR UPDATE SKIP LOCKED
-        )
-        UPDATE pgmq.%1$I m
-        SET
-            vt = clock_timestamp() + %2$L,
-            read_ct = read_ct + 1,
-            last_read_at = clock_timestamp()
-        FROM selected_messages sm
-        WHERE m.msg_id = sm.msg_id
-        RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.last_read_at, m.vt, m.message, m.headers;
-        $QUERY$,
-        qtable, make_interval(secs => vt)
-    );
-    RETURN QUERY EXECUTE sql USING qty;
-END;
-$$ LANGUAGE plpgsql;
-
-
-CREATE OR REPLACE FUNCTION pgmq._ensure_pg_partman_installed()
-RETURNS void AS $$
-BEGIN
-  IF NOT pgmq._extension_exists('pg_partman') THEN
-    RAISE EXCEPTION 'pg_partman is required for partitioned queues';
-  END IF;
-END;
-$$ LANGUAGE plpgsql;
-
-
-DROP FUNCTION IF EXISTS pgmq.enable_notify_insert(queue_name text);
+-- DROP FUNCTION IF EXISTS pgmq.enable_notify_insert(queue_name text);

--- a/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
+++ b/pgmq-extension/sql/pgmq--1.11.0--1.11.1.sql
@@ -1,71 +1,71 @@
 -- Allow `pgmq.notify_insert_throttle` and `pgmq.topic_bindings` to be dumped by `pg_dump` when pgmq is installed as an extension
--- DO
--- $$
--- BEGIN
---     IF EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pgmq') THEN
---         PERFORM pg_catalog.pg_extension_config_dump('pgmq.notify_insert_throttle', '');
---         PERFORM pg_catalog.pg_extension_config_dump('pgmq.topic_bindings', '');
---     END IF;
--- END
--- $$;
---
---
--- -- read_grouped_head:  read the head of N different FIFO groups in a single operation.
--- -- This supports horizontal scaling by processing groups in parallel while ensuring message ordering is preserved per group.
--- CREATE OR REPLACE FUNCTION pgmq.read_grouped_head(
---     queue_name TEXT,
---     vt INTEGER,
---     qty INTEGER
--- )
--- RETURNS SETOF pgmq.message_record AS $$
--- DECLARE
---     sql TEXT;
---     qtable TEXT := pgmq.format_table_name(queue_name, 'q');
--- BEGIN
---     sql := FORMAT(
---         $QUERY$
---         WITH fifo_groups AS (
---             -- Determine the absolute head (oldest) message id per FIFO group, regardless of visibility
---             SELECT
---                 COALESCE(headers->>'x-pgmq-group', '_default_fifo_group') AS fifo_key,
---                 MIN(msg_id) AS head_msg_id
---             FROM pgmq.%1$I
---             GROUP BY COALESCE(headers->>'x-pgmq-group', '_default_fifo_group')
---         ),
---         selected_messages AS (
---             -- Take at most 1 message per group
---             SELECT g.head_msg_id msg_id
---             FROM fifo_groups g
---             JOIN pgmq.%1$I q ON q.msg_id = g.head_msg_id
--- 	        WHERE q.vt <= clock_timestamp()
---             ORDER BY q.msg_id
---             LIMIT $1
---             FOR UPDATE SKIP LOCKED
---         )
---         UPDATE pgmq.%1$I m
---         SET
---             vt = clock_timestamp() + %2$L,
---             read_ct = read_ct + 1,
---             last_read_at = clock_timestamp()
---         FROM selected_messages sm
---         WHERE m.msg_id = sm.msg_id
---         RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.last_read_at, m.vt, m.message, m.headers;
---         $QUERY$,
---         qtable, make_interval(secs => vt)
---     );
---     RETURN QUERY EXECUTE sql USING qty;
--- END;
--- $$ LANGUAGE plpgsql;
---
---
--- CREATE OR REPLACE FUNCTION pgmq._ensure_pg_partman_installed()
--- RETURNS void AS $$
--- BEGIN
---   IF NOT pgmq._extension_exists('pg_partman') THEN
---     RAISE EXCEPTION 'pg_partman is required for partitioned queues';
---   END IF;
--- END;
--- $$ LANGUAGE plpgsql;
+DO
+$$
+BEGIN
+    IF EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pgmq') THEN
+        PERFORM pg_catalog.pg_extension_config_dump('pgmq.notify_insert_throttle', '');
+        PERFORM pg_catalog.pg_extension_config_dump('pgmq.topic_bindings', '');
+    END IF;
+END
+$$;
 
 
--- DROP FUNCTION IF EXISTS pgmq.enable_notify_insert(queue_name text);
+-- read_grouped_head:  read the head of N different FIFO groups in a single operation.
+-- This supports horizontal scaling by processing groups in parallel while ensuring message ordering is preserved per group.
+CREATE OR REPLACE FUNCTION pgmq.read_grouped_head(
+    queue_name TEXT,
+    vt INTEGER,
+    qty INTEGER
+)
+RETURNS SETOF pgmq.message_record AS $$
+DECLARE
+    sql TEXT;
+    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
+BEGIN
+    sql := FORMAT(
+        $QUERY$
+        WITH fifo_groups AS (
+            -- Determine the absolute head (oldest) message id per FIFO group, regardless of visibility
+            SELECT
+                COALESCE(headers->>'x-pgmq-group', '_default_fifo_group') AS fifo_key,
+                MIN(msg_id) AS head_msg_id
+            FROM pgmq.%1$I
+            GROUP BY COALESCE(headers->>'x-pgmq-group', '_default_fifo_group')
+        ),
+        selected_messages AS (
+            -- Take at most 1 message per group
+            SELECT g.head_msg_id msg_id
+            FROM fifo_groups g
+            JOIN pgmq.%1$I q ON q.msg_id = g.head_msg_id
+	        WHERE q.vt <= clock_timestamp()
+            ORDER BY q.msg_id
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+        )
+        UPDATE pgmq.%1$I m
+        SET
+            vt = clock_timestamp() + %2$L,
+            read_ct = read_ct + 1,
+            last_read_at = clock_timestamp()
+        FROM selected_messages sm
+        WHERE m.msg_id = sm.msg_id
+        RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.last_read_at, m.vt, m.message, m.headers;
+        $QUERY$,
+        qtable, make_interval(secs => vt)
+    );
+    RETURN QUERY EXECUTE sql USING qty;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION pgmq._ensure_pg_partman_installed()
+RETURNS void AS $$
+BEGIN
+  IF NOT pgmq._extension_exists('pg_partman') THEN
+    RAISE EXCEPTION 'pg_partman is required for partitioned queues';
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+
+DROP FUNCTION IF EXISTS pgmq.enable_notify_insert(queue_name text);

--- a/pgmq-extension/sql/pgmq.sql
+++ b/pgmq-extension/sql/pgmq.sql
@@ -21,6 +21,16 @@ CREATE TABLE IF NOT EXISTS pgmq.meta (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL
 );
 
+-- Grant permission to pg_monitor to all tables and sequences
+-- These grants are intentionally placed here (after creating `pgmq.meta` but before creating other tables). This
+-- allows the `pg_dump` output for a fresh installation to match the output for an installation that followed the
+-- upgrade path.
+GRANT USAGE ON SCHEMA pgmq TO pg_monitor;
+GRANT SELECT ON ALL TABLES IN SCHEMA pgmq TO pg_monitor;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA pgmq TO pg_monitor;
+ALTER DEFAULT PRIVILEGES IN SCHEMA pgmq GRANT SELECT ON TABLES TO pg_monitor;
+ALTER DEFAULT PRIVILEGES IN SCHEMA pgmq GRANT SELECT ON SEQUENCES TO pg_monitor;
+
 -- Table to track notification throttling for queues
 CREATE UNLOGGED TABLE IF NOT EXISTS pgmq.notify_insert_throttle (
     queue_name           VARCHAR UNIQUE NOT NULL -- Queue name (without 'q_' prefix)
@@ -62,7 +72,7 @@ CREATE TABLE IF NOT EXISTS pgmq.topic_bindings
 -- Includes queue_name and compiled_regex to allow index-only scans (no table access needed)
 CREATE INDEX IF NOT EXISTS idx_topic_bindings_covering ON pgmq.topic_bindings (pattern) INCLUDE (queue_name, compiled_regex);
 
--- Allow pgmq.meta to be dumped by `pg_dump` when pgmq is installed as an extension
+-- Allow the following `pgmq` tables to be dumped by `pg_dump` when pgmq is installed as an extension
 DO
 $$
 BEGIN
@@ -73,13 +83,6 @@ BEGIN
     END IF;
 END
 $$;
-
--- Grant permission to pg_monitor to all tables and sequences
-GRANT USAGE ON SCHEMA pgmq TO pg_monitor;
-GRANT SELECT ON ALL TABLES IN SCHEMA pgmq TO pg_monitor;
-GRANT SELECT ON ALL SEQUENCES IN SCHEMA pgmq TO pg_monitor;
-ALTER DEFAULT PRIVILEGES IN SCHEMA pgmq GRANT SELECT ON TABLES TO pg_monitor;
-ALTER DEFAULT PRIVILEGES IN SCHEMA pgmq GRANT SELECT ON SEQUENCES TO pg_monitor;
 
 -- This type has the shape of a message in a queue, and is often returned by
 -- pgmq functions that return messages


### PR DESCRIPTION
## Problem
As seen in https://github.com/pgmq/pgmq/issues/521, it's easy for the upgrade scripts to diverge from a fresh installation.

## Solution
This PR adds a check to verify that the upgrade scripts do not diverge from a fresh installation. The check uses the output of `pg_dump` as well as a manual query of the extensions functions (these are not included in `pg_dump`).

This PR also adds a new migration script (`pgmq--1.11.0--1.11.1.sql`) to resolve the existing differences between the upgrade scripts and a fresh installation.

### Summary of differences and how they were resolved
#### `pgmq.read_grouped_head`

This function only existed in the fresh install (`pgmq.sql`), so this PR adds it via a migration file as well.

#### `pgmq._ensure_pg_partman_installed`
This method exists for both fresh installs and upgrades, but the implementations are different. This PR updates the version in the upgrade path to match the fresh installation.

#### `enable_notify_insert`

This function ([added here](https://github.com/pgmq/pgmq/blob/66349cfee14ab75827eb541d36b2c84cbbb68dab/pgmq-extension/sql/pgmq--1.6.1--1.7.0.sql#L9)) originally had a single parameter but was [updated to have two parameters](https://github.com/pgmq/pgmq/blob/66349cfee14ab75827eb541d36b2c84cbbb68dab/pgmq-extension/sql/pgmq--1.7.1--1.8.0.sql#L45) -- the single-parameter version does not exist in fresh installs. I'm guessing that the upgrade script was intending to replace the single-parameter version with the two-parameter version, but `CREATE OR REPLACE FUNCTION` does not replace an existing function if the parameter types are different, even if the function names match, so the single-parameter version was not removed. 

This PR removes the single parameter version. This should not be a breaking change as the two-parameter version has a default value for the second parameter, so it can be called in the same way as the old single-parameter version.

#### `pg_dump` output
First, there was a missing `PERFORM pg_catalog.pg_extension_config_dump('pgmq.topic_bindings', '');` call for the migration path. This PR adds the missing call.

Second, in the migration path, the `pgmq.notify_insert_throttle` and `pgmq.topic_bindings` tables are created after the blanket `GRANT`s from the fresh installation script, so they each have an extra `GRANT SELECT ON TABLE ... TO pg_monitor;` line in the `pg_dump` output. The fresh installation script was updated to move the blanket `GRANT`s to be before the creation of these tables as well.

Closes https://github.com/pgmq/pgmq/issues/521