### PR TITLE
feat: Add `PGMQueueExt#read_with_poll` method

### DIFF
--- a/pgmq-rs/src/install/embedded/mod.rs
+++ b/pgmq-rs/src/install/embedded/mod.rs
@@ -134,7 +134,6 @@ mod tests {
 
     mod parsed_script_name {
         use crate::install::embedded::{list_all_scripts_in_dir, MIGRATION_SCRIPTS};
-        use crate::install::script::ParsedScriptName;
         use itertools::Itertools;
 
         #[test]
@@ -169,7 +168,7 @@ mod tests {
     mod migrations_script {
         use super::TEST_MIGRATION_SCRIPTS;
         use crate::install::embedded::{get_migration_scripts_from_dir, get_script_from_dir};
-        use crate::install::script::{MigrationScript, ParsedScriptName};
+        use crate::install::script::ParsedScriptName;
         use crate::install::version::Version;
         use insta::assert_debug_snapshot;
         use itertools::Itertools;

--- a/pgmq-rs/src/install/script.rs
+++ b/pgmq-rs/src/install/script.rs
@@ -122,11 +122,6 @@ impl PartialOrd for MigrationScript {
 
 #[cfg(test)]
 mod tests {
-    use include_dir::{include_dir, Dir};
-
-    static TEST_MIGRATION_SCRIPTS: Dir<'static> =
-        include_dir!("$CARGO_MANIFEST_DIR/src/install/embedded/test_migrations/");
-
     mod parsed_script_name {
         use crate::install::script::ParsedScriptName;
         use crate::install::version::Version;

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -531,6 +531,40 @@ impl PGMQueueExt {
             .await
     }
 
+    pub async fn read_with_poll_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+        executor: E,
+    ) -> Result<Option<Message<T>>, PgmqError> {
+        self.read_batch_with_poll_with_cxn(queue_name, vt, 1, poll_timeout, poll_interval, executor)
+            .await
+            .map(|result| result.and_then(|result| result.into_iter().next()))
+    }
+
+    pub async fn read_with_poll<'c, T: for<'de> Deserialize<'de>>(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+    ) -> Result<Option<Message<T>>, PgmqError> {
+        self.read_with_poll_with_cxn(
+            queue_name,
+            vt,
+            poll_timeout,
+            poll_interval,
+            &self.connection,
+        )
+        .await
+    }
+
     // Todo: In a future SemVer-breaking release, we can update this to return
     //  `Result<Vec<Message<T>>, PgmqError>` to match `read_batch`/`read_batch_with_cxn`.
     pub async fn read_batch_with_poll_with_cxn<

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -393,9 +393,42 @@ async fn test_ext_send_batch_read_batch() {
 }
 
 #[tokio::test]
+async fn test_ext_read_with_poll() {
+    let test_queue = format!(
+        "test_ext_read_with_poll_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let vt = 4;
+    let msg = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    assert!(msg.is_none());
+
+    let msgs_sent = [
+        MyMessage::default(),
+        MyMessage::default(),
+        MyMessage::default(),
+    ];
+    let msg_ids = queue.send_batch(&test_queue, &msgs_sent).await.unwrap();
+    assert_eq!(3, msg_ids.len());
+
+    let msg = queue
+        .read_with_poll::<MyMessage>(&test_queue, vt, Some(Duration::from_secs(1)), None)
+        .await
+        .unwrap();
+    assert!(msg.is_some());
+
+    let msgs_read = queue
+        .read_batch::<MyMessage>(&test_queue, vt, msgs_sent.len() as i32)
+        .await
+        .unwrap();
+    assert_eq!(msgs_sent.len() - 1, msgs_read.len());
+}
+
+#[tokio::test]
 async fn test_ext_read_batch_with_poll_empty_queue() {
     let test_queue = format!(
-        "test_ext_read_batch_with_poll_{}",
+        "test_ext_read_batch_with_poll_empty_queue_{}",
         rand::thread_rng().gen_range(0..100000)
     );
     let queue = init_queue_ext(&test_queue).await;
@@ -410,6 +443,23 @@ async fn test_ext_read_batch_with_poll_empty_queue() {
         .unwrap();
     assert!(msg_read.is_some());
     assert!(msg_read.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_ext_read_with_poll_empty_queue() {
+    let test_queue = format!(
+        "test_ext_read_with_poll_empty_queue_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let vt = 4;
+
+    let msg = queue
+        .read_with_poll::<MyMessage>(&test_queue, vt, Some(Duration::from_secs(1)), None)
+        .await
+        .unwrap();
+    assert!(msg.is_none());
 }
 
 async fn test_ext_send_batch_delay_core(delay: impl Copy + Into<VisibilityTimeoutOffset>) {


### PR DESCRIPTION
This PR adds the `PGMQueueExt#read_with_poll` method, which is simply a specialization of the `read_batch_with_poll` method with a batch size of `1`.

This PR also removes a few unused imports in tests.