### PR TITLE
chore: Enable building all features' docs on docs.rs

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -70,3 +70,7 @@ sqlx = { version = "0.8.1", features = ["time"] }
 name = "install"
 path = "examples/install.rs"
 required-features = ["cli"]
+
+[package.metadata.docs.rs]
+# Have docs.rs pass `--all-features` to ensure all features have their documentation built.
+all-features = true


### PR DESCRIPTION
Not all of the crate's features currently have their documentation built on docs.rs. This can be resolved by setting the
`package.metadata.docs.rs.all-features` flag to `true`.