### PR TITLE
feat: Add methods to create FIFO indexes

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -768,4 +768,41 @@ impl PGMQueueExt {
         self.delete_batch_with_cxn(queue_name, msg_id, &self.connection)
             .await
     }
+
+    pub async fn create_fifo_index_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(
+        &self,
+        queue_name: &str,
+        executor: E,
+    ) -> Result<(), PgmqError> {
+        sqlx::query("SELECT * from pgmq.create_fifo_index(queue_name=>$1::text);")
+            .bind(queue_name)
+            .execute(executor)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn create_fifo_index(&self, queue_name: &str) -> Result<(), PgmqError> {
+        self.create_fifo_index_with_cxn(queue_name, &self.connection)
+            .await
+    }
+
+    pub async fn create_fifo_indexes_all_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+    >(
+        &self,
+        executor: E,
+    ) -> Result<(), PgmqError> {
+        sqlx::query("SELECT * from pgmq.create_fifo_indexes_all();")
+            .execute(executor)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn create_fifo_indexes_all(&self) -> Result<(), PgmqError> {
+        self.create_fifo_indexes_all_with_cxn(&self.connection)
+            .await
+    }
 }

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -3,7 +3,7 @@ use pgmq::types::{ARCHIVE_PREFIX, PGMQ_SCHEMA, QUEUE_PREFIX};
 use pgmq::util::connect;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use sqlx::{Pool, Postgres, Row};
+use sqlx::{Acquire, Pool, Postgres, Row};
 use std::env;
 use std::time::Duration;
 
@@ -837,4 +837,59 @@ async fn test_create_queue_race_condition() {
     // If there's a race condition in `PGMQueueExt#create`, both results could be `true` (this
     // may not always occur due to the non-deterministic nature of race conditions).
     assert_ne!(result1, result2);
+}
+
+#[tokio::test]
+async fn test_create_fifo_index() {
+    let test_queue = format!(
+        "test_create_fifo_index_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+
+    let queue = init_queue_ext(&test_queue).await;
+    queue.create_fifo_index(&test_queue).await.unwrap();
+
+    let index_name = format!("q_{test_queue}_fifo_idx");
+    let index_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM pg_indexes WHERE schemaname = 'pgmq' AND indexname = $1;",
+    )
+    .bind(&index_name)
+    .fetch_one(&queue.connection)
+    .await
+    .unwrap();
+
+    assert_eq!(1, index_count, "FIFO index does not exist");
+}
+
+#[tokio::test]
+async fn test_create_fifo_indexes_all() {
+    let test_queue_prefix = format!(
+        "test_create_fifo_indexes_all_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue_prefix).await;
+    queue.drop_queue(&test_queue_prefix).await.unwrap();
+
+    let queue_names: Vec<String> = (0..5).map(|i| format!("{test_queue_prefix}_{i}")).collect();
+
+    for queue_name in queue_names.iter() {
+        queue.create(queue_name).await.unwrap();
+    }
+
+    let indexes_to_create: Vec<String> = queue_names
+        .iter()
+        .map(|queue_name| format!("q_{queue_name}_fifo_idx"))
+        .collect();
+
+    queue.create_fifo_indexes_all().await.unwrap();
+
+    let indexes = sqlx::query_scalar::<_, String>(
+        "SELECT indexname FROM pg_indexes WHERE schemaname = 'pgmq' AND starts_with(indexname, $1) AND indexname LIKE '%_fifo_idx' ORDER BY indexname;",
+    )
+    .bind(format!("q_{test_queue_prefix}"))
+    .fetch_all(&queue.connection)
+    .await
+    .unwrap();
+
+    assert_eq!(indexes_to_create, indexes);
 }


### PR DESCRIPTION
This PR adds methods to `PGMQueueExt` for the `pgmq.create_fifo_index` and `pgmq.create_fifo_indexes_all` SQL methods, including tests in `pg_ext_integration_test.rs`.

Relates to https://github.com/pgmq/pgmq/issues/494