### PR TITLE
feat: Add `PGMQueueExt#acquire_queue_lock*` methods

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.33.3"
+version = "0.33.4"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/src/install/applied.rs
+++ b/pgmq-rs/src/install/applied.rs
@@ -19,21 +19,21 @@ pub struct AppliedMigration {
 
 impl AppliedMigration {
     /// Create the DB table used to keep track of which migration scripts have been applied.
-    pub async fn create_table(tx: &mut Transaction<'static, Postgres>) -> Result<(), PgmqError> {
-        init_lock(tx).await?;
+    pub async fn create_table(txn: &mut Transaction<'static, Postgres>) -> Result<(), PgmqError> {
+        init_lock(txn).await?;
 
         /*
         The `pgmq` schema will not exist yet if we're currently performing a fresh installation
         of `pgmq`, so we first need to make sure the schema exists.
          */
         sqlx::query("CREATE SCHEMA IF NOT EXISTS pgmq;")
-            .execute(tx.acquire().await?)
+            .execute(&mut **txn)
             .await?;
 
         sqlx::query(
         "CREATE TABLE IF NOT EXISTS pgmq.__pgmq_migrations ( name TEXT PRIMARY KEY NOT NULL, version TEXT NOT NULL, run_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp());",
         )
-        .execute(tx.acquire().await?)
+        .execute(&mut **txn)
         .await?;
 
         /*
@@ -42,7 +42,7 @@ impl AppliedMigration {
         list of applied migrations at once.
          */
         sqlx::query("LOCK TABLE pgmq.__pgmq_migrations IN ACCESS EXCLUSIVE MODE;")
-            .execute(tx.acquire().await?)
+            .execute(&mut **txn)
             .await?;
 
         Ok(())

--- a/pgmq-rs/src/install/mod.rs
+++ b/pgmq-rs/src/install/mod.rs
@@ -12,7 +12,7 @@ use crate::errors::PgmqError;
 use crate::install::applied::AppliedMigration;
 use crate::install::script::{ParsedScriptName, ScriptFetcher};
 use itertools::Itertools;
-use sqlx::{Acquire, Pool, Postgres};
+use sqlx::{Pool, Postgres};
 
 #[cfg(feature = "install-sql")]
 #[doc = include_str!("init_migrations_table.md")]
@@ -20,17 +20,17 @@ pub async fn init_migrations_table(
     pool: &Pool<Postgres>,
     version: Version,
 ) -> Result<(), PgmqError> {
-    let mut tx = pool.begin().await?;
-    AppliedMigration::create_table(&mut tx).await?;
-    if !AppliedMigration::fetch_all(&mut tx).await?.is_empty() {
+    let mut txn = pool.begin().await?;
+    AppliedMigration::create_table(&mut txn).await?;
+    if !AppliedMigration::fetch_all(&mut txn).await?.is_empty() {
         // If the migration table already has items in it, it does not need to be initialized
         return Ok(());
     }
     AppliedMigration::insert_script(&ParsedScriptName::init_script(version))?
-        .execute(tx.acquire().await?)
+        .execute(&mut *txn)
         .await?;
 
-    tx.commit().await?;
+    txn.commit().await?;
     Ok(())
 }
 

--- a/pgmq-rs/src/install/script.rs
+++ b/pgmq-rs/src/install/script.rs
@@ -4,7 +4,7 @@ use crate::install::version::Version;
 use crate::PgmqError;
 use futures_util::StreamExt;
 use regex::Regex;
-use sqlx::{Acquire, Executor, Postgres, Transaction};
+use sqlx::{Executor, Postgres, Transaction};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::str::FromStr;
@@ -86,16 +86,16 @@ pub struct MigrationScript {
 
 impl MigrationScript {
     /// Run this script and mark it as applied in the DB.
-    pub async fn run(&self, tx: &mut Transaction<'static, Postgres>) -> Result<(), PgmqError> {
+    pub async fn run(&self, txn: &mut Transaction<'static, Postgres>) -> Result<(), PgmqError> {
         {
-            let mut stream = tx.fetch_many(self.content.as_ref());
+            let mut stream = txn.fetch_many(self.content.as_ref());
             while let Some(step) = stream.next().await {
                 let _ = step?;
             }
         }
 
         AppliedMigration::insert_script(&self.name)?
-            .execute(tx.acquire().await?)
+            .execute(&mut **txn)
             .await?;
 
         Ok(())

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -7,7 +7,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
 use sqlx::types::chrono::Utc;
-use sqlx::{Acquire, FromRow, Pool, Postgres, Row};
+use sqlx::{FromRow, Pool, Postgres, Row};
 pub use visibility_timeout_offest::VisibilityTimeoutOffset;
 
 const DEFAULT_POLL_TIMEOUT_S: i32 = 5;
@@ -139,18 +139,70 @@ impl PGMQueueExt {
         &self,
         executor: E,
     ) -> Result<bool, PgmqError> {
-        let mut tx = executor.begin().await?;
-        crate::util::init_lock(&mut tx).await?;
+        let mut txn = executor.begin().await?;
+        crate::util::init_lock(&mut txn).await?;
         sqlx::query("CREATE EXTENSION IF NOT EXISTS pgmq CASCADE;")
-            .execute(tx.acquire().await?)
+            .execute(&mut *txn)
             .await
             .map(|_| true)?;
-        tx.commit().await?;
+        txn.commit().await?;
         Ok(true)
     }
 
     pub async fn init(&self) -> Result<bool, PgmqError> {
         self.init_with_cxn(&self.connection).await
+    }
+
+    /// Acquire a transaction-level advisory lock specific to the provided queue. Useful to prevent
+    /// race conditions when performing queue/table-level operations, such as creating an index
+    /// for the queue (e.g., with [`Self::create_fifo_index`].
+    pub async fn acquire_queue_lock_with_txn<'c>(
+        &self,
+        queue_name: &str,
+        txn: &mut sqlx::Transaction<'c, Postgres>,
+    ) -> Result<(), PgmqError> {
+        sqlx::query("SELECT * from pgmq.acquire_queue_lock(queue_name=>$1::text);")
+            .bind(queue_name)
+            .execute(&mut **txn)
+            .await?;
+        Ok(())
+    }
+
+    /// Acquire a transaction-level advisory lock specific to the provided queue. Useful to prevent
+    /// race conditions when performing queue/table-level operations, such as creating an index
+    /// for the queue (e.g., with [`Self::create_fifo_index`].
+    ///
+    /// Returns the [`sqlx::Transaction`] that should be used to perform the queue/table-level
+    /// operations. Remember to call [`sqlx::Transaction::commit`] after performing the desired
+    /// operations.
+    pub async fn acquire_queue_lock_with_cxn<'c, E: sqlx::Acquire<'c, Database = Postgres>>(
+        &self,
+        queue_name: &str,
+        executor: E,
+    ) -> Result<sqlx::Transaction<'c, Postgres>, PgmqError> {
+        let mut txn = executor.begin().await?;
+
+        self.acquire_queue_lock_with_txn(queue_name, &mut txn)
+            .await?;
+
+        Ok(txn)
+    }
+
+    /// Acquire a transaction-level advisory lock specific to the provided queue. Useful to prevent
+    /// race conditions when performing queue/table-level operations, such as creating an index
+    /// for the queue (e.g., with [`Self::create_fifo_index_with_cxn`]).
+    ///
+    /// Returns the [`sqlx::Transaction`] that should be used to perform the queue/table-level
+    /// operations. Remember to call [`sqlx::Transaction::commit`] after performing the desired
+    /// operations.
+    pub async fn acquire_queue_lock<'c>(
+        &self,
+        queue_name: &str,
+    ) -> Result<sqlx::Transaction<'c, Postgres>, PgmqError> {
+        let txn = self
+            .acquire_queue_lock_with_cxn(queue_name, &self.connection)
+            .await?;
+        Ok(txn)
     }
 
     pub async fn create_with_cxn<'c, E>(
@@ -162,18 +214,15 @@ impl PGMQueueExt {
         E: sqlx::Acquire<'c, Database = Postgres>,
     {
         check_input(queue_name)?;
-        let mut tx = executor.begin().await?;
-
-        sqlx::query("SELECT * from pgmq.acquire_queue_lock(queue_name=>$1::text);")
-            .bind(queue_name)
-            .execute(tx.acquire().await?)
+        let mut txn = self
+            .acquire_queue_lock_with_cxn(queue_name, executor)
             .await?;
 
         let exists = sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS(SELECT 1 FROM pgmq.meta WHERE queue_name = $1::text);",
         )
         .bind(queue_name)
-        .fetch_one(tx.acquire().await?)
+        .fetch_one(&mut *txn)
         .await?;
 
         if exists {
@@ -182,10 +231,10 @@ impl PGMQueueExt {
 
         sqlx::query("SELECT * from pgmq.create(queue_name=>$1::text);")
             .bind(queue_name)
-            .execute(tx.acquire().await?)
+            .execute(&mut *txn)
             .await?;
 
-        tx.commit().await?;
+        txn.commit().await?;
 
         Ok(true)
     }

--- a/pgmq-rs/src/util.rs
+++ b/pgmq-rs/src/util.rs
@@ -5,7 +5,7 @@ use crate::{errors::PgmqError, types::Message};
 use log::LevelFilter;
 use serde::Deserialize;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
-use sqlx::{Acquire, FromRow};
+use sqlx::FromRow;
 use sqlx::{ConnectOptions, Transaction};
 use sqlx::{Pool, Postgres};
 use url::{ParseError, Url};
@@ -138,10 +138,10 @@ const ADVISORY_LOCK_KEY: i64 = -9223372036854775808 + 4149;
 /// to attempt to perform the `pgmq` SQL installation/upgrade process at the same time, and they
 /// may conflict when creating the `pgmq` schema and/or `pgmq.__pgmq_migrations` table. This is
 /// the case even with `IF NOT EXISTS` in the SQL query.
-pub(crate) async fn init_lock<'c>(tx: &mut Transaction<'c, Postgres>) -> Result<(), PgmqError> {
+pub(crate) async fn init_lock<'c>(txn: &mut Transaction<'c, Postgres>) -> Result<(), PgmqError> {
     sqlx::query("SELECT pg_advisory_xact_lock($1);")
         .bind(ADVISORY_LOCK_KEY)
-        .execute(tx.acquire().await?)
+        .execute(&mut **txn)
         .await?;
     Ok(())
 }

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -847,7 +847,12 @@ async fn test_create_fifo_index() {
     );
 
     let queue = init_queue_ext(&test_queue).await;
-    queue.create_fifo_index(&test_queue).await.unwrap();
+    let mut txn = queue.acquire_queue_lock(&test_queue).await.unwrap();
+    queue
+        .create_fifo_index_with_cxn(&test_queue, &mut *txn)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
 
     let index_name = format!("q_{test_queue}_fifo_idx");
     let index_count = sqlx::query_scalar::<_, i64>(


### PR DESCRIPTION
Also:
- Switch how we get a sqlx executor from a transaction from `tx.acquire().await?` to a simple dereference of the transaction (e.g. `&mut *tx`).
- Bump the crate version

Relates to https://github.com/pgmq/pgmq/issues/494