### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 *       @ChuckHend @theory @v0idpwn
-/pgmq-rs @ChuckHend @spencewenski
+/pgmq-rs/ @ChuckHend @spencewenski

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 *       @ChuckHend @theory @v0idpwn
-/tembo-pgmq-python/ @tavallaie @ChuckHend
+/pgmq-rs @ChuckHend @spencewenski


### PR DESCRIPTION
- pgmq-py was moved to https://github.com/pgmq/pgmq-py
- welcoming @spencewenski as codeowner on the Rust client