### PR TITLE
feat: Add `read_grouped*` & `send*with_headers` methods to `PGMQueueExt`

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.33.4"
+version = "0.33.5"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -437,18 +437,14 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<i64, PgmqError> {
-        check_input(queue_name)?;
-        let delay: VisibilityTimeoutOffset = delay.into();
-        let msg = serde_json::to_value(message)?;
-        let msg_id: i64 = sqlx::query_scalar(
-            "SELECT * from pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, delay=>$3::int);",
+        self.send_delay_with_headers_with_cxn(
+            queue_name,
+            message,
+            Option::<&()>::None,
+            delay,
+            executor,
         )
-        .bind(queue_name)
-        .bind(msg)
-        .bind(delay)
-        .fetch_one(executor)
-        .await?;
-        Ok(msg_id)
+        .await
     }
 
     pub async fn send_delay<T: Serialize>(
@@ -458,6 +454,46 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
     ) -> Result<i64, PgmqError> {
         self.send_delay_with_cxn(queue_name, message, delay, &self.connection)
+            .await
+    }
+
+    pub async fn send_delay_with_headers_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: Serialize,
+        H: Serialize,
+    >(
+        &self,
+        queue_name: &str,
+        message: &T,
+        headers: Option<&H>,
+        delay: impl Into<VisibilityTimeoutOffset>,
+        executor: E,
+    ) -> Result<i64, PgmqError> {
+        check_input(queue_name)?;
+        let delay: VisibilityTimeoutOffset = delay.into();
+        let message = serde_json::to_value(message)?;
+        let headers = serde_json::to_value(headers)?;
+        let msg_id: i64 = sqlx::query_scalar(
+            "SELECT * from pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, headers=>$3::jsonb, delay=>$4::int);",
+        )
+        .bind(queue_name)
+        .bind(message)
+        .bind(headers)
+        .bind(delay)
+        .fetch_one(executor)
+        .await?;
+        Ok(msg_id)
+    }
+
+    pub async fn send_delay_with_headers<T: Serialize, H: Serialize>(
+        &self,
+        queue_name: &str,
+        message: &T,
+        headers: Option<&H>,
+        delay: impl Into<VisibilityTimeoutOffset>,
+    ) -> Result<i64, PgmqError> {
+        self.send_delay_with_headers_with_cxn(queue_name, message, headers, delay, &self.connection)
             .await
     }
 
@@ -495,21 +531,14 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<Vec<i64>, PgmqError> {
-        check_input(queue_name)?;
-        let delay: VisibilityTimeoutOffset = delay.into();
-        let msgs = messages
-            .iter()
-            .map(serde_json::to_value)
-            .collect::<Result<Vec<serde_json::Value>, _>>()?;
-        let sent: Vec<i64> = sqlx::query_scalar(
-            "SELECT * from pgmq.send_batch(queue_name=>$1::text, msgs=>$2::jsonb[], delay=>$3::integer);",
+        self.send_batch_with_delay_with_headers_with_cxn(
+            queue_name,
+            messages,
+            Option::<&[()]>::None,
+            delay,
+            executor,
         )
-            .bind(queue_name)
-            .bind(msgs)
-            .bind(delay)
-            .fetch_all(executor)
-            .await?;
-        Ok(sent)
+        .await
     }
 
     pub async fn send_batch_with_delay<T: Serialize>(
@@ -520,6 +549,64 @@ impl PGMQueueExt {
     ) -> Result<Vec<i64>, PgmqError> {
         self.send_batch_with_delay_with_cxn(queue_name, messages, delay, &self.connection)
             .await
+    }
+
+    pub async fn send_batch_with_delay_with_headers_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: Serialize,
+        H: Serialize,
+    >(
+        &self,
+        queue_name: &str,
+        messages: &[T],
+        headers: Option<&[H]>,
+        delay: impl Into<VisibilityTimeoutOffset>,
+        executor: E,
+    ) -> Result<Vec<i64>, PgmqError> {
+        check_input(queue_name)?;
+        let delay: VisibilityTimeoutOffset = delay.into();
+        let messages = messages
+            .iter()
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<serde_json::Value>, _>>()?;
+        let headers = if let Some(headers) = headers {
+            Some(
+                headers
+                    .iter()
+                    .map(serde_json::to_value)
+                    .collect::<Result<Vec<serde_json::Value>, _>>()?,
+            )
+        } else {
+            None
+        };
+        let sent: Vec<i64> = sqlx::query_scalar(
+            "SELECT * from pgmq.send_batch(queue_name=>$1::text, msgs=>$2::jsonb[], headers=>$3::jsonb[], delay=>$4::integer);",
+        )
+            .bind(queue_name)
+            .bind(messages)
+            .bind(headers)
+            .bind(delay)
+            .fetch_all(executor)
+            .await?;
+        Ok(sent)
+    }
+
+    pub async fn send_batch_with_delay_with_headers<T: Serialize, H: Serialize>(
+        &self,
+        queue_name: &str,
+        messages: &[T],
+        headers: Option<&[H]>,
+        delay: impl Into<VisibilityTimeoutOffset>,
+    ) -> Result<Vec<i64>, PgmqError> {
+        self.send_batch_with_delay_with_headers_with_cxn(
+            queue_name,
+            messages,
+            headers,
+            delay,
+            &self.connection,
+        )
+        .await
     }
 
     pub async fn read_with_cxn<
@@ -556,18 +643,11 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
-        check_input(queue_name)?;
-        let vt: VisibilityTimeoutOffset = vt.into();
-        let rows = sqlx::query(
+        let query = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)"#,
-        )
-            .bind(queue_name)
-            .bind(vt)
-            .bind(qty)
-            .fetch_all(executor)
-            .await?;
+        );
 
-        Self::handle_read_batch_result(rows)
+        Self::read_batch_common(query, queue_name, vt, qty, executor).await
     }
 
     pub async fn read_batch<T: for<'de> Deserialize<'de>>(
@@ -629,12 +709,7 @@ impl PGMQueueExt {
         poll_interval: Option<std::time::Duration>,
         executor: E,
     ) -> Result<Option<Vec<Message<T>>>, PgmqError> {
-        check_input(queue_name)?;
-        let vt: VisibilityTimeoutOffset = vt.into();
-        let poll_timeout_s = poll_timeout.map_or(DEFAULT_POLL_TIMEOUT_S, |t| t.as_secs() as i32);
-        let poll_interval_ms =
-            poll_interval.map_or(DEFAULT_POLL_INTERVAL_MS, |i| i.as_millis() as i32);
-        let rows = sqlx::query(
+        let query = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_with_poll(
                 queue_name=>$1::text,
                 vt=>$2::integer,
@@ -642,16 +717,19 @@ impl PGMQueueExt {
                 max_poll_seconds=>$4::integer,
                 poll_interval_ms=>$5::integer
             )"#,
-        )
-        .bind(queue_name)
-        .bind(vt)
-        .bind(max_batch_size)
-        .bind(poll_timeout_s)
-        .bind(poll_interval_ms)
-        .fetch_all(executor)
-        .await?;
+        );
 
-        Self::handle_read_batch_result(rows).map(Some)
+        Self::read_batch_with_poll_common(
+            query,
+            queue_name,
+            vt,
+            max_batch_size,
+            poll_timeout,
+            poll_interval,
+            executor,
+        )
+        .await
+        .map(Some)
     }
 
     pub async fn read_batch_with_poll<T: for<'de> Deserialize<'de>>(
@@ -671,6 +749,247 @@ impl PGMQueueExt {
             &self.connection,
         )
         .await
+    }
+
+    pub async fn read_grouped_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        executor: E,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
+
+        Self::read_batch_common(query, queue_name, vt, qty, executor).await
+    }
+
+    pub async fn read_grouped<T: for<'de> Deserialize<'de>>(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        self.read_grouped_with_cxn(queue_name, vt, qty, &self.connection)
+            .await
+    }
+
+    pub async fn read_grouped_with_poll_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+        executor: E,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        let query = sqlx::query(
+            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped_with_poll(
+                queue_name=>$1::text,
+                vt=>$2::integer,
+                qty=>$3::integer,
+                max_poll_seconds=>$4::integer,
+                poll_interval_ms=>$5::integer
+            )"#,
+        );
+
+        Self::read_batch_with_poll_common(
+            query,
+            queue_name,
+            vt,
+            qty,
+            poll_timeout,
+            poll_interval,
+            executor,
+        )
+        .await
+    }
+
+    pub async fn read_grouped_with_poll<T: for<'de> Deserialize<'de>>(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        self.read_grouped_with_poll_with_cxn(
+            queue_name,
+            vt,
+            qty,
+            poll_timeout,
+            poll_interval,
+            &self.connection,
+        )
+        .await
+    }
+
+    pub async fn read_grouped_head_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        executor: E,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped_head(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
+
+        Self::read_batch_common(query, queue_name, vt, qty, executor).await
+    }
+
+    pub async fn read_grouped_head<T: for<'de> Deserialize<'de>>(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        self.read_grouped_head_with_cxn(queue_name, vt, qty, &self.connection)
+            .await
+    }
+
+    pub async fn read_grouped_rr_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        executor: E,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped_rr(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
+
+        Self::read_batch_common(query, queue_name, vt, qty, executor).await
+    }
+
+    pub async fn read_grouped_rr<T: for<'de> Deserialize<'de>>(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        self.read_grouped_rr_with_cxn(queue_name, vt, qty, &self.connection)
+            .await
+    }
+
+    pub async fn read_grouped_rr_with_poll_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+        executor: E,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        let query = sqlx::query(
+            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped_rr_with_poll(
+                queue_name=>$1::text,
+                vt=>$2::integer,
+                qty=>$3::integer,
+                max_poll_seconds=>$4::integer,
+                poll_interval_ms=>$5::integer
+            )"#,
+        );
+
+        Self::read_batch_with_poll_common(
+            query,
+            queue_name,
+            vt,
+            qty,
+            poll_timeout,
+            poll_interval,
+            executor,
+        )
+        .await
+    }
+
+    pub async fn read_grouped_rr_with_poll<T: for<'de> Deserialize<'de>>(
+        &self,
+        queue_name: &str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        self.read_grouped_rr_with_poll_with_cxn(
+            queue_name,
+            vt,
+            qty,
+            poll_timeout,
+            poll_interval,
+            &self.connection,
+        )
+        .await
+    }
+
+    async fn read_batch_common<
+        'c,
+        'q,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        query: sqlx::query::Query<'q, Postgres, <Postgres as sqlx::Database>::Arguments<'q>>,
+        queue_name: &'q str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        qty: i32,
+        executor: E,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        check_input(queue_name)?;
+        let vt: VisibilityTimeoutOffset = vt.into();
+        let rows = query
+            .bind(queue_name)
+            .bind(vt)
+            .bind(qty)
+            .fetch_all(executor)
+            .await?;
+
+        Self::handle_read_batch_result(rows)
+    }
+
+    async fn read_batch_with_poll_common<
+        'c,
+        'q,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: for<'de> Deserialize<'de>,
+    >(
+        query: sqlx::query::Query<'q, Postgres, <Postgres as sqlx::Database>::Arguments<'q>>,
+        queue_name: &'q str,
+        vt: impl Into<VisibilityTimeoutOffset>,
+        max_batch_size: i32,
+        poll_timeout: Option<std::time::Duration>,
+        poll_interval: Option<std::time::Duration>,
+        executor: E,
+    ) -> Result<Vec<Message<T>>, PgmqError> {
+        check_input(queue_name)?;
+        let vt: VisibilityTimeoutOffset = vt.into();
+        let poll_timeout_s = poll_timeout.map_or(DEFAULT_POLL_TIMEOUT_S, |t| t.as_secs() as i32);
+        let poll_interval_ms =
+            poll_interval.map_or(DEFAULT_POLL_INTERVAL_MS, |i| i.as_millis() as i32);
+        let rows = query
+            .bind(queue_name)
+            .bind(vt)
+            .bind(max_batch_size)
+            .bind(poll_timeout_s)
+            .bind(poll_interval_ms)
+            .fetch_all(executor)
+            .await?;
+
+        Self::handle_read_batch_result(rows)
     }
 
     /// Helper method to convert [`PgRow`] to [`Message`] for the `read*`/`read_batch*` methods.

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -898,3 +898,373 @@ async fn test_create_fifo_indexes_all() {
 
     assert_eq!(indexes_to_create, indexes);
 }
+
+#[tokio::test]
+async fn test_read_grouped_default_group() {
+    let test_queue = format!(
+        "test_read_grouped_default_group_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let msg1 = MyMessage::default();
+    let id1 = queue.send(&test_queue, &msg1).await.unwrap();
+    let msg2 = MyMessage::default();
+    let _ = queue.send(&test_queue, &msg2).await.unwrap();
+
+    {
+        let read_msg1 = queue
+            .read_grouped::<MyMessage>(&test_queue, 100, 1)
+            .await
+            .unwrap()
+            .into_iter()
+            .next();
+        let read_msg2 = queue
+            .read_grouped::<MyMessage>(&test_queue, 100, 1)
+            .await
+            .unwrap()
+            .into_iter()
+            .next();
+        assert!(read_msg1.is_some());
+        assert!(read_msg2.is_none(), "The second message should not become available until the first message has been processed");
+    }
+
+    {
+        queue.archive(&test_queue, id1).await.unwrap();
+        let read_msg2 = queue
+            .read_grouped::<MyMessage>(&test_queue, 100, 1)
+            .await
+            .unwrap()
+            .into_iter()
+            .next();
+        assert!(read_msg2.is_some());
+    }
+}
+
+#[tokio::test]
+async fn test_read_grouped_default_group_many() {
+    let test_queue = format!(
+        "read_grouped_default_group_many_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let msg1 = MyMessage::default();
+    queue.send(&test_queue, &msg1).await.unwrap();
+    let msg2 = MyMessage::default();
+    queue.send(&test_queue, &msg2).await.unwrap();
+
+    let read_msgs = queue
+        .read_grouped::<MyMessage>(&test_queue, 100, 2)
+        .await
+        .unwrap();
+    assert_eq!(2, read_msgs.len());
+}
+
+#[tokio::test]
+async fn test_read_grouped_custom_group() {
+    let test_queue = format!(
+        "test_read_grouped_custom_group_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let msg1 = MyMessage {
+        foo: "a".to_string(),
+        num: 1,
+    };
+    let headers1 = serde_json::json!({
+        "x-pgmq-group": msg1.num
+    });
+    let msg2 = MyMessage {
+        foo: "b".to_string(),
+        num: 2,
+    };
+    let headers2 = serde_json::json!({
+        "x-pgmq-group": msg2.num
+    });
+    queue
+        .send_batch_with_delay_with_headers(
+            &test_queue,
+            &[msg1, msg2],
+            Some(&[headers1, headers2]),
+            0,
+        )
+        .await
+        .unwrap();
+
+    let read_msg1 = queue
+        .read_grouped::<MyMessage>(&test_queue, 100, 1)
+        .await
+        .unwrap()
+        .into_iter()
+        .next();
+    let read_msg2 = queue
+        .read_grouped::<MyMessage>(&test_queue, 100, 1)
+        .await
+        .unwrap()
+        .into_iter()
+        .next();
+    assert!(read_msg1.is_some());
+    assert!(read_msg2.is_some());
+}
+
+#[tokio::test]
+async fn test_read_grouped_rr_diff_groups() {
+    let test_queue = format!(
+        "test_read_grouped_rr_diff_groups_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let msg1 = MyMessage {
+        foo: "a".to_string(),
+        num: 1,
+    };
+    let headers1 = serde_json::json!({
+        "x-pgmq-group": msg1.num
+    });
+    let msg2 = MyMessage {
+        foo: "b".to_string(),
+        num: 1,
+    };
+    let headers2 = serde_json::json!({
+        "x-pgmq-group": msg2.num
+    });
+    let msg3 = MyMessage {
+        foo: "c".to_string(),
+        num: 2,
+    };
+    let headers3 = serde_json::json!({
+        "x-pgmq-group": msg3.num
+    });
+    let msg4 = MyMessage {
+        foo: "d".to_string(),
+        num: 2,
+    };
+    let headers4 = serde_json::json!({
+        "x-pgmq-group": msg4.num
+    });
+    queue
+        .send_batch_with_delay_with_headers(
+            &test_queue,
+            &[msg1, msg2, msg3, msg4],
+            Some(&[headers1, headers2, headers3, headers4]),
+            0,
+        )
+        .await
+        .unwrap();
+
+    let read_msgs = queue
+        .read_grouped_rr::<MyMessage>(&test_queue, 100, 2)
+        .await
+        .unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.num,
+        read_msgs.get(1).unwrap().message.num
+    );
+
+    let read_msgs2 = queue
+        .read_grouped_rr::<MyMessage>(&test_queue, 100, 2)
+        .await
+        .unwrap();
+    assert!(read_msgs2.is_empty(), "The second message in each group should not become available until the first message has been processed");
+
+    queue
+        .archive_batch(
+            &test_queue,
+            &read_msgs.iter().map(|msg| msg.msg_id).collect::<Vec<_>>(),
+        )
+        .await
+        .unwrap();
+
+    let read_msgs = queue
+        .read_grouped_rr::<MyMessage>(&test_queue, 100, 2)
+        .await
+        .unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.num,
+        read_msgs.get(1).unwrap().message.num
+    );
+}
+
+#[tokio::test]
+async fn test_read_grouped_head_diff_groups() {
+    let test_queue = format!(
+        "test_read_grouped_head_diff_groups_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let msg1 = MyMessage {
+        foo: "a".to_string(),
+        num: 1,
+    };
+    let headers1 = serde_json::json!({
+        "x-pgmq-group": msg1.num
+    });
+    let msg2 = MyMessage {
+        foo: "b".to_string(),
+        num: 1,
+    };
+    let headers2 = serde_json::json!({
+        "x-pgmq-group": msg2.num
+    });
+    let msg3 = MyMessage {
+        foo: "c".to_string(),
+        num: 2,
+    };
+    let headers3 = serde_json::json!({
+        "x-pgmq-group": msg3.num
+    });
+    let msg4 = MyMessage {
+        foo: "d".to_string(),
+        num: 2,
+    };
+    let headers4 = serde_json::json!({
+        "x-pgmq-group": msg4.num
+    });
+    queue
+        .send_batch_with_delay_with_headers(
+            &test_queue,
+            &[msg1, msg2, msg3, msg4],
+            Some(&[headers1, headers2, headers3, headers4]),
+            0,
+        )
+        .await
+        .unwrap();
+
+    let read_msgs = queue
+        .read_grouped_head::<MyMessage>(&test_queue, 100, 2)
+        .await
+        .unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.num,
+        read_msgs.get(1).unwrap().message.num
+    );
+
+    let read_msgs2 = queue
+        .read_grouped_head::<MyMessage>(&test_queue, 100, 2)
+        .await
+        .unwrap();
+    assert!(read_msgs2.is_empty(), "The second message in each group should not become available until the first message has been processed");
+
+    queue
+        .archive_batch(
+            &test_queue,
+            &read_msgs.iter().map(|msg| msg.msg_id).collect::<Vec<_>>(),
+        )
+        .await
+        .unwrap();
+
+    let read_msgs = queue
+        .read_grouped_head::<MyMessage>(&test_queue, 100, 2)
+        .await
+        .unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.num,
+        read_msgs.get(1).unwrap().message.num
+    );
+}
+
+#[tokio::test]
+async fn test_read_grouped_with_poll() {
+    let test_queue = format!(
+        "test_read_grouped_with_poll_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let msg1 = MyMessage {
+        foo: "a".to_string(),
+        num: 1,
+    };
+    let headers1 = serde_json::json!({
+        "x-pgmq-group": msg1.num
+    });
+    let msg2 = MyMessage {
+        foo: "b".to_string(),
+        num: 2,
+    };
+    let headers2 = serde_json::json!({
+        "x-pgmq-group": msg2.num
+    });
+    queue
+        .send_batch_with_delay_with_headers(
+            &test_queue,
+            &[msg1, msg2],
+            Some(&[headers1, headers2]),
+            5,
+        )
+        .await
+        .unwrap();
+
+    let read_msgs = queue
+        .read_grouped_with_poll::<MyMessage>(
+            &test_queue,
+            100,
+            2,
+            Some(Duration::from_secs(10)),
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.num,
+        read_msgs.get(1).unwrap().message.num
+    );
+}
+
+#[tokio::test]
+async fn test_read_grouped_rr_with_poll() {
+    let test_queue = format!(
+        "test_read_grouped_rr_with_poll_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+
+    let msg1 = MyMessage {
+        foo: "a".to_string(),
+        num: 1,
+    };
+    let headers1 = serde_json::json!({
+        "x-pgmq-group": msg1.num
+    });
+    let msg2 = MyMessage {
+        foo: "b".to_string(),
+        num: 2,
+    };
+    let headers2 = serde_json::json!({
+        "x-pgmq-group": msg2.num
+    });
+    queue
+        .send_batch_with_delay_with_headers(
+            &test_queue,
+            &[msg1, msg2],
+            Some(&[headers1, headers2]),
+            5,
+        )
+        .await
+        .unwrap();
+
+    let read_msgs = queue
+        .read_grouped_rr_with_poll::<MyMessage>(
+            &test_queue,
+            100,
+            2,
+            Some(Duration::from_secs(10)),
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(2, read_msgs.len());
+    assert_ne!(
+        read_msgs.first().unwrap().message.num,
+        read_msgs.get(1).unwrap().message.num
+    );
+}


### PR DESCRIPTION
This PR adds the following `read_grouped*` (FIFO) methods to `PGMQueueExt`:

- `read_grouped_with_cxn`
- `read_grouped`
- `read_grouped_with_poll_with_cxn`
- `read_grouped_with_poll`
- `read_grouped_head_with_cxn`
- `read_grouped_head`
- `read_grouped_rr_with_cxn`
- `read_grouped_rr`
- `read_grouped_rr_with_poll_with_cxn`
- `read_grouped_rr_with_poll`

Also, in for these methods to be useful (and in order to test them), we need to be able to set the `x-pgmq-group` header on the messages, so I added the following methods to allow setting headers when enqueuing messages:

- `send_delay_with_headers_cxn`
- `send_delay_with_headers`
- `send_batch_with_delay_with_headers_with_cxn`
- `send_batch_with_delay_with_headers`

Also, when writing all of these new `read*` messages, I noticed they were all duplicates of each other except for the query, so I added two new helper methods to contain the common logic:

- `read_batch_common`
- `read_batch_with_poll_common`

Relates to https://github.com/pgmq/pgmq/issues/494