### PR TITLE
feat: Add support for topic-based routing

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1,7 +1,7 @@
 mod visibility_timeout_offest;
 
 use crate::errors::PgmqError;
-use crate::types::{Message, QUEUE_PREFIX};
+use crate::types::{ListTopicBindingsRow, Message, SendBatchTopicRow, QUEUE_PREFIX};
 use crate::util::{check_input, connect};
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -566,20 +566,8 @@ impl PGMQueueExt {
     ) -> Result<Vec<i64>, PgmqError> {
         check_input(queue_name)?;
         let delay: VisibilityTimeoutOffset = delay.into();
-        let messages = messages
-            .iter()
-            .map(serde_json::to_value)
-            .collect::<Result<Vec<serde_json::Value>, _>>()?;
-        let headers = if let Some(headers) = headers {
-            Some(
-                headers
-                    .iter()
-                    .map(serde_json::to_value)
-                    .collect::<Result<Vec<serde_json::Value>, _>>()?,
-            )
-        } else {
-            None
-        };
+        let messages = Self::serialize_list(messages)?;
+        let headers = Self::serialize_optional_list(headers)?;
         let sent: Vec<i64> = sqlx::query_scalar(
             "SELECT * from pgmq.send_batch(queue_name=>$1::text, msgs=>$2::jsonb[], headers=>$3::jsonb[], delay=>$4::integer);",
         )
@@ -1172,5 +1160,205 @@ impl PGMQueueExt {
     pub async fn create_fifo_indexes_all(&self) -> Result<(), PgmqError> {
         self.create_fifo_indexes_all_with_cxn(&self.connection)
             .await
+    }
+
+    pub async fn bind_topic_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(
+        &self,
+        pattern: &str,
+        queue_name: &str,
+        executor: E,
+    ) -> Result<(), PgmqError> {
+        check_input(queue_name)?;
+        sqlx::query("SELECT * from pgmq.bind_topic(pattern=>$1::text, queue_name=>$2::text)")
+            .bind(pattern)
+            .bind(queue_name)
+            .execute(executor)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn bind_topic(&self, pattern: &str, queue_name: &str) -> Result<(), PgmqError> {
+        self.bind_topic_with_cxn(pattern, queue_name, &self.connection)
+            .await
+    }
+
+    pub async fn unbind_topic_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(
+        &self,
+        pattern: &str,
+        queue_name: &str,
+        executor: E,
+    ) -> Result<(), PgmqError> {
+        check_input(queue_name)?;
+        sqlx::query("SELECT * from pgmq.unbind_topic(pattern=>$1::text, queue_name=>$2::text)")
+            .bind(pattern)
+            .bind(queue_name)
+            .execute(executor)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn unbind_topic(&self, pattern: &str, queue_name: &str) -> Result<(), PgmqError> {
+        self.unbind_topic_with_cxn(pattern, queue_name, &self.connection)
+            .await
+    }
+
+    pub async fn list_topic_bindings_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(
+        &self,
+        queue_name: &str,
+        executor: E,
+    ) -> Result<Vec<ListTopicBindingsRow>, PgmqError> {
+        let rows = sqlx::query(
+            "SELECT pattern, queue_name, bound_at, compiled_regex from pgmq.list_topic_bindings(queue_name=>$1::text);",
+        )
+            .bind(queue_name)
+            .fetch_all(executor)
+            .await?;
+
+        let rows = rows
+            .into_iter()
+            .map(|row| ListTopicBindingsRow::from_row(&row))
+            .collect::<Result<Vec<ListTopicBindingsRow>, _>>()?;
+        Ok(rows)
+    }
+
+    pub async fn list_topic_bindings(
+        &self,
+        queue_name: &str,
+    ) -> Result<Vec<ListTopicBindingsRow>, PgmqError> {
+        self.list_topic_bindings_with_cxn(queue_name, &self.connection)
+            .await
+    }
+
+    pub async fn list_topic_bindings_all_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+    >(
+        &self,
+        executor: E,
+    ) -> Result<Vec<ListTopicBindingsRow>, PgmqError> {
+        let rows = sqlx::query(
+            "SELECT pattern, queue_name, bound_at, compiled_regex from pgmq.list_topic_bindings();",
+        )
+        .fetch_all(executor)
+        .await?;
+
+        let rows = rows
+            .into_iter()
+            .map(|row| ListTopicBindingsRow::from_row(&row))
+            .collect::<Result<Vec<ListTopicBindingsRow>, _>>()?;
+        Ok(rows)
+    }
+
+    pub async fn list_topic_bindings_all(&self) -> Result<Vec<ListTopicBindingsRow>, PgmqError> {
+        self.list_topic_bindings_all_with_cxn(&self.connection)
+            .await
+    }
+
+    /// Send a message using topic-based routing. Will send the message to every queue that has
+    /// a topic binding that matches the given `routing_key`. Returns the number of queues that
+    /// the message was sent to.
+    pub async fn send_topic_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: Serialize,
+        H: Serialize,
+    >(
+        &self,
+        routing_key: &str,
+        message: &T,
+        headers: Option<&H>,
+        delay: impl Into<VisibilityTimeoutOffset>,
+        executor: E,
+    ) -> Result<i32, PgmqError> {
+        let delay: VisibilityTimeoutOffset = delay.into();
+        let message = serde_json::to_value(message)?;
+        let headers = serde_json::to_value(headers)?;
+        let matched_queue_count = sqlx::query_scalar("SELECT * from pgmq.send_topic(routing_key=>$1::text, msg=>$2::jsonb, headers=>$3::jsonb, delay=>$4::int)")
+            .bind(routing_key)
+            .bind(message)
+            .bind(headers)
+            .bind(delay)
+            .fetch_one(executor)
+            .await?;
+
+        Ok(matched_queue_count)
+    }
+
+    pub async fn send_topic<T: Serialize, H: Serialize>(
+        &self,
+        routing_key: &str,
+        message: &T,
+        headers: Option<&H>,
+        delay: impl Into<VisibilityTimeoutOffset>,
+    ) -> Result<i32, PgmqError> {
+        self.send_topic_with_cxn(routing_key, message, headers, delay, &self.connection)
+            .await
+    }
+
+    /// Send messages using topic-based routing. Will send the messages to every queue that has
+    /// a topic binding that matches the given `routing_key`.
+    pub async fn send_batch_topic_with_cxn<
+        'c,
+        E: sqlx::Executor<'c, Database = Postgres>,
+        T: Serialize,
+        H: Serialize,
+    >(
+        &self,
+        routing_key: &str,
+        messages: &[T],
+        headers: Option<&[H]>,
+        delay: impl Into<VisibilityTimeoutOffset>,
+        executor: E,
+    ) -> Result<Vec<SendBatchTopicRow>, PgmqError> {
+        let delay: VisibilityTimeoutOffset = delay.into();
+        let messages = Self::serialize_list(messages)?;
+        let headers = Self::serialize_optional_list(headers)?;
+        let sent = sqlx::query(
+            "SELECT queue_name, msg_id from pgmq.send_batch_topic(routing_key=>$1::text, msgs=>$2::jsonb[], headers=>$3::jsonb[], delay=>$4::integer);",
+        )
+            .bind(routing_key)
+            .bind(messages)
+            .bind(headers)
+            .bind(delay)
+            .fetch_all(executor)
+            .await?;
+
+        let sent = sent
+            .into_iter()
+            .map(|row| SendBatchTopicRow::from_row(&row))
+            .collect::<Result<Vec<SendBatchTopicRow>, _>>()?;
+        Ok(sent)
+    }
+
+    pub async fn send_batch_topic<T: Serialize, H: Serialize>(
+        &self,
+        routing_key: &str,
+        messages: &[T],
+        headers: Option<&[H]>,
+        delay: impl Into<VisibilityTimeoutOffset>,
+    ) -> Result<Vec<SendBatchTopicRow>, PgmqError> {
+        self.send_batch_topic_with_cxn(routing_key, messages, headers, delay, &self.connection)
+            .await
+    }
+
+    fn serialize_list<T: serde::Serialize>(
+        list: &[T],
+    ) -> Result<Vec<serde_json::Value>, serde_json::Error> {
+        list.iter()
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<serde_json::Value>, _>>()
+    }
+
+    fn serialize_optional_list<H: serde::Serialize>(
+        list: Option<&[H]>,
+    ) -> Result<Option<Vec<serde_json::Value>>, serde_json::Error> {
+        let headers = if let Some(list) = list {
+            Some(Self::serialize_list(list)?)
+        } else {
+            None
+        };
+        Ok(headers)
     }
 }

--- a/pgmq-rs/src/types.rs
+++ b/pgmq-rs/src/types.rs
@@ -38,3 +38,21 @@ pub struct Message<T = serde_json::Value> {
     #[sqlx(json)]
     pub message: T,
 }
+
+/// A row returned by the `pgmq.send_batch_topic` SQL function(s).
+#[derive(Clone, Debug, Deserialize, FromRow)]
+#[non_exhaustive]
+pub struct SendBatchTopicRow {
+    pub queue_name: String,
+    pub msg_id: i64,
+}
+
+/// A row returned by the `pgmq.list_topic_bindings` SQL function(s).
+#[derive(Clone, Debug, Deserialize, FromRow)]
+#[non_exhaustive]
+pub struct ListTopicBindingsRow {
+    pub pattern: String,
+    pub queue_name: String,
+    pub bound_at: chrono::DateTime<Utc>,
+    pub compiled_regex: String,
+}

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -3,7 +3,7 @@ use pgmq::types::{ARCHIVE_PREFIX, PGMQ_SCHEMA, QUEUE_PREFIX};
 use pgmq::util::connect;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use sqlx::{Acquire, Pool, Postgres, Row};
+use sqlx::{Pool, Postgres, Row};
 use std::env;
 use std::time::Duration;
 
@@ -1267,4 +1267,125 @@ async fn test_read_grouped_rr_with_poll() {
         read_msgs.first().unwrap().message.num,
         read_msgs.get(1).unwrap().message.num
     );
+}
+
+#[tokio::test]
+async fn test_bind_list_topics() {
+    let test_queue = format!(
+        "test_bind_list_topics_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+    let pattern = format!("{test_queue}.*");
+
+    queue.bind_topic(&pattern, &test_queue).await.unwrap();
+    let topic_binding = queue
+        .list_topic_bindings(&test_queue)
+        .await
+        .unwrap()
+        .into_iter()
+        .next();
+    assert!(topic_binding.is_some());
+    let topic_binding = topic_binding.unwrap();
+    assert_eq!(topic_binding.queue_name, test_queue);
+    assert_eq!(topic_binding.pattern, pattern);
+    assert_eq!(
+        topic_binding.compiled_regex,
+        format!("^{test_queue}\\.[^.]+$")
+    );
+}
+
+#[tokio::test]
+async fn test_list_topics_all() {
+    let test_queue = format!(
+        "test_list_topics_all_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+    let pattern = format!("{test_queue}.*");
+
+    queue.bind_topic(&pattern, &test_queue).await.unwrap();
+    let topic_bindings = queue.list_topic_bindings_all().await.unwrap();
+    let topic_binding = topic_bindings
+        .into_iter()
+        .find(|binding| binding.queue_name == test_queue)
+        .unwrap();
+    assert_eq!(topic_binding.queue_name, test_queue);
+    assert_eq!(topic_binding.pattern, pattern);
+    assert_eq!(
+        topic_binding.compiled_regex,
+        format!("^{test_queue}\\.[^.]+$")
+    );
+}
+
+#[tokio::test]
+async fn test_unbind_topic() {
+    let test_queue = format!(
+        "test_unbind_topic_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+    let pattern = format!("{test_queue}.*");
+
+    queue.bind_topic(&pattern, &test_queue).await.unwrap();
+    queue.unbind_topic(&pattern, &test_queue).await.unwrap();
+    let topic_binding = queue
+        .list_topic_bindings(&test_queue)
+        .await
+        .unwrap()
+        .into_iter()
+        .next();
+    assert!(topic_binding.is_none());
+}
+
+#[tokio::test]
+async fn test_send_topic() {
+    let test_queue = format!(
+        "test_send_topic_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+    let pattern = format!("{test_queue}.*");
+
+    queue.bind_topic(&pattern, &test_queue).await.unwrap();
+
+    let msg = MyMessage::default();
+    let matched_queues = queue
+        .send_topic(&format!("{test_queue}.foo"), &msg, Option::<&()>::None, 0)
+        .await
+        .unwrap();
+    assert_eq!(1, matched_queues);
+
+    let read_msg = queue.read::<MyMessage>(&test_queue, 100).await.unwrap();
+    assert!(read_msg.is_some());
+}
+
+#[tokio::test]
+async fn test_send_batch_topic() {
+    let test_queue = format!(
+        "test_send_batch_topic_{}",
+        rand::thread_rng().gen_range(0..100000)
+    );
+    let queue = init_queue_ext(&test_queue).await;
+    let pattern = format!("{test_queue}.*");
+
+    queue.bind_topic(&pattern, &test_queue).await.unwrap();
+
+    let msgs = [MyMessage::default(), MyMessage::default()];
+    let send_batch_rows = queue
+        .send_batch_topic(
+            &format!("{test_queue}.foo"),
+            &msgs,
+            Option::<&[()]>::None,
+            0,
+        )
+        .await
+        .unwrap();
+    assert_eq!(msgs.len(), send_batch_rows.len());
+
+    let read_msgs = queue
+        .read_batch::<MyMessage>(&test_queue, 100, 2)
+        .await
+        .unwrap();
+    assert_eq!(msgs.len(), read_msgs.len());
 }


### PR DESCRIPTION
Adds support for the following extension methods to `PGMQueueExt`:

- `pgmq.bind_topic`
- `pgmq.unbind_topic`
- `pgmq.list_topic_bindings`
- `pgmq.send_topic`
- `pgmq.send_batch_topic`