### PR TITLE
feat!: Initial `Queue` trait and `sqlx` implementation

### DIFF
--- a/.github/workflows/crate_ci.yml
+++ b/.github/workflows/crate_ci.yml
@@ -191,6 +191,38 @@ jobs:
       - name: Run SQL installation test
         run: cargo test test_sql_lifecycle --release --features install-sql-embedded -- --ignored
 
+  test_queue_trait:
+    name: Queue Trait Tests
+    runs-on: ubuntu-22.04
+    needs: lint
+    services:
+      postgres:
+        image: ghcr.io/pgmq/pg17-pgmq:latest
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: "postgresql://postgres:postgres@0.0.0.0:5432/postgres"
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Rust stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run Queue trait tests
+        run: make test.queue
+      # The `queue` integration tests create a separate temporary DB for each test, so we can safely run the tests
+      # with the sql-only installation directly after the extension installation tests
+      - name: Run Queue trait tests with sql-only installation
+        run: make test.queue_sql
+
   publish:
     name: Publish or validate crate
     runs-on: ubuntu-latest

--- a/.github/workflows/crate_ci.yml
+++ b/.github/workflows/crate_ci.yml
@@ -30,7 +30,7 @@ jobs:
           components: rustfmt, clippy
       - uses: taiki-e/install-action@9adcff13829681f1e2f4a678b775043ab5c7fc2c
         with:
-          tool: cargo-readme
+          tool: cargo-readme,cargo-hack
       - uses: Swatinem/rust-cache@v2
       - name: Cargo format
         run: make check.fmt
@@ -45,6 +45,8 @@ jobs:
             echo "README.md is out of sync with the crate's main 'lib.rs' doc comment. Run 'make update.readme' to sync."
             exit 1
           fi
+      - name: Check each feature builds independently
+        run: make check.each_feature
 
   semver:
     name: Check SemVer compatibility

--- a/pgmq-rs/Cargo.lock
+++ b/pgmq-rs/Cargo.lock
@@ -1457,7 +1457,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pgmq"
-version = "0.34.0-alpha.3"
+version = "0.34.0-alpha.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/pgmq-rs/Cargo.lock
+++ b/pgmq-rs/Cargo.lock
@@ -1474,6 +1474,7 @@ dependencies = [
  "reqwest",
  "rstest",
  "serde",
+ "serde_derive",
  "serde_json",
  "sqlx",
  "thiserror",

--- a/pgmq-rs/Cargo.lock
+++ b/pgmq-rs/Cargo.lock
@@ -83,6 +83,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1459,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 name = "pgmq"
 version = "0.34.0-alpha.3"
 dependencies = [
+ "async-trait",
  "chrono",
  "clap",
  "env_logger",
@@ -1456,6 +1468,7 @@ dependencies = [
  "insta",
  "itertools",
  "log",
+ "pgmq_test_macro",
  "rand 0.10.1",
  "regex",
  "reqwest",
@@ -1466,6 +1479,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "pgmq_test_macro"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -20,9 +20,9 @@ required-features = ["cli"]
 
 [features]
 default = ["sqlx"]
-cli = ["clap", "url/serde", "install-sql-github", "install-sql-embedded", "env_logger"]
-install-sql = ["futures-util", "regex", "itertools"]
-install-sql-github = ["install-sql", "reqwest"]
+cli = ["sqlx", "clap", "install-sql-github", "install-sql-embedded", "env_logger"]
+install-sql = ["sqlx", "futures-util", "regex", "itertools"]
+install-sql-github = ["install-sql", "reqwest", "url/serde"]
 install-sql-embedded = ["install-sql", "include_dir"]
 queue-experimental = []
 # Enables the `PGMQueueExt` client and the `sqlx` implementation of the experimental `Queue` trait if
@@ -31,6 +31,7 @@ sqlx = ["dep:sqlx"]
 
 [dependencies]
 chrono = { version = "0.4.34", features = ["serde"] }
+serde_derive = { version = "1.0.219" }
 serde = { version = "1.0.219" }
 serde_json = { version = "1.0.142", features = ["raw_value"] }
 sqlx = { version = "0.9.0", features = ["runtime-tokio", "postgres", "chrono", "json"], optional = true }

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.34.0-alpha.3"
+version = "0.34.0-alpha.4"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -19,21 +19,26 @@ path = "src/bin/pgmq-cli.rs"
 required-features = ["cli"]
 
 [features]
-default = []
+default = ["sqlx"]
 cli = ["clap", "url/serde", "install-sql-github", "install-sql-embedded", "env_logger"]
 install-sql = ["futures-util", "regex", "itertools"]
 install-sql-github = ["install-sql", "reqwest"]
 install-sql-embedded = ["install-sql", "include_dir"]
+queue-experimental = []
+# Enables the `PGMQueueExt` client and the `sqlx` implementation of the experimental `Queue` trait if
+# the `queue-experimental` feature is also enabled.
+sqlx = ["dep:sqlx"]
 
 [dependencies]
 chrono = { version = "0.4.34", features = ["serde"] }
 serde = { version = "1.0.219" }
 serde_json = { version = "1.0.142", features = ["raw_value"] }
-sqlx = { version = "0.9.0", features = ["runtime-tokio", "postgres", "chrono", "json"] }
+sqlx = { version = "0.9.0", features = ["runtime-tokio", "postgres", "chrono", "json"], optional = true }
 thiserror = "2.0.18"
 tokio = { version = "1.38.0", default-features = false, features = ["macros", "time"] }
 log = "0.4.18"
 url = "2.4.0"
+async-trait = { version = "0.1.89" }
 
 # Optional dependencies for the `cli` feature
 clap = { version = "4.1", features = ["derive"], optional = true }
@@ -65,6 +70,8 @@ rstest = "0.26.1"
 # both the `time` and `chrono` features enabled. If a query that would see the conflict is added, `pgmq` will fail to
 # compile when running tests/examples.
 sqlx = { version = "0.9.0", features = ["time"] }
+
+pgmq_test_macro = { path = "pgmq_test_macro" }
 
 [[example]]
 name = "install"

--- a/pgmq-rs/Makefile
+++ b/pgmq-rs/Makefile
@@ -66,3 +66,6 @@ check.minimal-versions:
 
 check.msrv:
 	cargo msrv verify --all-features
+
+check.each_feature:
+	cargo hack build --each-feature

--- a/pgmq-rs/Makefile
+++ b/pgmq-rs/Makefile
@@ -27,6 +27,14 @@ test:
 test.pgmqext_sql:
 	cargo test --features install-sql-embedded --test pg_ext_integration_test
 
+# Run the tests for the all of the supported `Queue` trait implementations
+test.queue:
+	cargo test --test queue --features queue-experimental,sqlx
+
+# Run the tests for the all of the supported `Queue` trait implementations using the SQL-only installation approach
+test.queue_sql:
+	cargo test --test queue --features install-sql-embedded,queue-experimental,sqlx
+
 setup.env:
 	sqlx migrate run --database-url ${DATABASE_URL}
 

--- a/pgmq-rs/README.md
+++ b/pgmq-rs/README.md
@@ -214,7 +214,7 @@ Below is a minimal example of how to use the crate. More advanced examples can b
 
 ```rust
 use pgmq::{PgmqError, Message, PGMQueueExt};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[tokio::main]

--- a/pgmq-rs/examples/basic.rs
+++ b/pgmq-rs/examples/basic.rs
@@ -1,5 +1,5 @@
 use pgmq::{errors::PgmqError, Message, PGMQueueExt};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[tokio::main]

--- a/pgmq-rs/examples/install.rs
+++ b/pgmq-rs/examples/install.rs
@@ -1,5 +1,5 @@
 use pgmq::Message;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Debug, Deserialize, Eq, PartialEq)]
 struct MyMessage {

--- a/pgmq-rs/examples/transactions.rs
+++ b/pgmq-rs/examples/transactions.rs
@@ -1,5 +1,5 @@
 use pgmq::{Message, PGMQueueExt};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use sqlx::{PgPool, Row};
 
 #[derive(Serialize, Debug, Deserialize, Eq, PartialEq)]

--- a/pgmq-rs/pgmq_test_macro/Cargo.toml
+++ b/pgmq-rs/pgmq_test_macro/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pgmq_test_macro"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+proc-macro = true
+
+[features]
+
+[dependencies]
+quote = "1.0.45"
+proc-macro2 = "1.0.106"
+syn = { version = "2.0.118", features = ["full"] }
+

--- a/pgmq-rs/pgmq_test_macro/src/lib.rs
+++ b/pgmq-rs/pgmq_test_macro/src/lib.rs
@@ -1,0 +1,139 @@
+//! Private macro(s) used by the `pgmq` crate in tests.
+
+use quote::quote;
+use syn::{Item, parse_macro_input};
+
+/// This attribute macro is only intended to be used to help generate tests for each implementation
+/// of the `pgmq::Queue` trait.
+///
+/// The macro can be placed on a method that takes `conn_details: ConnDetails` and
+/// `queue: impl Queue` parameters. Since this macro is only intended to be used in the `Queue`
+/// trait integration tests, it makes some assumptions about utility types/functions that it needs
+/// to be in scope. For example, it expects the `ConnDetails` struct to be in scope, as well as
+/// functions to create connections and/or connection pools for each client that implements `Queue`,
+/// and `before`/`after` functions to perform setup/teardown logic that's shared between all tests.
+///
+/// # Examples
+///
+/// ```ignore
+/// #[pgmq_test_macro::queue_test]
+/// async fn create(conn_details: ConnDetails, queue: impl Queue) {
+///     queue.create("queue").await.unwrap();
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn queue_test(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let item = match parse_macro_input!(item as Item) {
+        Item::Fn(item) => item,
+        _ => panic!("This macro only supports functions"),
+    };
+
+    /*
+    Because the `Queue` trait's methods all take `self`, only a single method can be called in a
+    method that takes `impl Queue`. Example:
+
+    ```
+    async fn test(queue: impl Queue) {
+        queue.create(QUEUE).await.unwrap();
+        // This second call is not allowed because the `queue.create` call moves ownership of the
+        // `queue` variable.
+        queue.send(QUEUE, serde_json::json!({}), serde_json::json!({}), 0).await.unwrap();
+    }
+    ```
+
+    However, in practice, each type we're testing is a reference type, so we can get around this
+    by simply copying the `block` (e.g., body) of the original test method into the individual test
+    methods, and the block will compile with multiple method calls because the `queue` variable
+    is a reference.
+     */
+    let original_block = &item.block;
+
+    let test_details = [
+        (
+            // The `pgmq` crate feature that needs to be enabled in order for this test to run.
+            "sqlx",
+            // String describing the type of the client implementation. Will be appended to the
+            // original test name, so must be a valid rust function name.
+            "ext_deref",
+            // Details of how to create an instance of the client and how to invoke the original
+            // test method with it.
+            quote! {
+                use std::ops::Deref;
+                let queue_ext = initialization::pgmq_ext(&conn_details.test_db_url).await;
+                let queue = queue_ext.deref();
+                #original_block
+            },
+        ),
+        (
+            "sqlx",
+            "ext_ref",
+            quote! {
+                let queue_ext = initialization::pgmq_ext(&conn_details.test_db_url).await;
+                let queue = queue_ext.as_ref();
+                #original_block
+            },
+        ),
+        (
+            "sqlx",
+            "sqlx_cxn",
+            quote! {
+                let mut conn = initialization::sqlx_conn(&conn_details.test_db_url).await;
+                let queue = &mut conn;
+                #original_block
+            },
+        ),
+        (
+            "sqlx",
+            "sqlx_txn",
+            quote! {
+                use sqlx::Connection;
+                let mut conn = initialization::sqlx_conn(&conn_details.test_db_url).await;
+                let mut transaction = conn.begin().await.unwrap();
+                let queue = &mut transaction;
+
+                #original_block
+
+                transaction.commit().await.unwrap();
+            },
+        ),
+        (
+            "sqlx",
+            "sqlx_pool",
+            quote! {
+                let pool = pgmq::util::connect(conn_details.test_db_url.as_str(), 2)
+                    .await
+                    .unwrap();
+                let queue = &pool;
+                #original_block
+            },
+        ),
+    ];
+
+    // Create individual test functions using the test details for each client implementation.
+    let test_functions = test_details
+        .into_iter()
+        .map(|(feature, impl_type, invoke)| {
+            let test_name = syn::Ident::new(
+                &format!("{}_{}", item.sig.ident, impl_type),
+                proc_macro2::Span::call_site(),
+            );
+            quote! {
+                #[cfg(all(feature = "queue-experimental", feature = #feature))]
+                #[tokio::test]
+                async fn #test_name() {
+                    let conn_details = ConnDetails::new();
+                    initialization::before(&conn_details).await;
+
+                    #invoke
+
+                    initialization::after(&conn_details).await;
+                }
+            }
+        });
+
+    // Collect all the test functions into a single token stream.
+    test_functions.collect::<proc_macro2::TokenStream>().into()
+}

--- a/pgmq-rs/src/errors.rs
+++ b/pgmq-rs/src/errors.rs
@@ -15,6 +15,7 @@ pub enum PgmqError {
     UrlParsingError(#[from] ParseError),
 
     /// a database error
+    #[cfg(feature = "sqlx")]
     #[error("database error {0}")]
     DatabaseError(#[from] sqlx::Error),
 

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -214,7 +214,7 @@
 //!
 //! ```rust,no_run
 //! use pgmq::{PgmqError, Message, PGMQueueExt};
-//! use serde::{Deserialize, Serialize};
+//! use serde_derive::{Deserialize, Serialize};
 //! use serde_json::Value;
 //!
 //! #[tokio::main]
@@ -278,5 +278,6 @@ pub mod types;
 pub mod util;
 
 pub use errors::PgmqError;
+#[cfg(feature = "sqlx")]
 pub use pg_ext::PGMQueueExt;
 pub use types::Message;

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -267,7 +267,13 @@
 pub mod errors;
 #[cfg(feature = "install-sql")]
 pub mod install;
+#[cfg(feature = "sqlx")]
 pub mod pg_ext;
+pub(crate) mod private;
+#[cfg(feature = "queue-experimental")]
+pub mod queue;
+#[cfg(not(feature = "queue-experimental"))]
+pub(crate) mod queue;
 pub mod types;
 pub mod util;
 

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1,17 +1,17 @@
-mod visibility_timeout_offest;
-
 use crate::errors::PgmqError;
-use crate::types::queue_name::check_queue_name;
+use crate::private::util::handle_read_batch_result;
+use crate::queue::Queue;
+use crate::types::queue_name::{check_queue_name, QueueNameError};
 use crate::types::{
     ListNotifyInsertThrottlesRow, ListTopicBindingsRow, Message, PGMQueueMeta, QueueMetrics,
     SendBatchTopicRow, QUEUE_PREFIX,
 };
+use crate::types::{QueueName, VisibilityTimeoutOffset};
 use crate::util::connect;
 use log::info;
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Pool, Postgres, Row};
-pub use visibility_timeout_offest::VisibilityTimeoutOffset;
+use std::ops::Deref;
 
 const DEFAULT_POLL_TIMEOUT_S: i32 = 5;
 const DEFAULT_POLL_INTERVAL_MS: i32 = 250;
@@ -22,6 +22,20 @@ const DEFAULT_POLL_INTERVAL_MS: i32 = 250;
 pub struct PGMQueueExt {
     pub url: String,
     pub connection: Pool<Postgres>,
+}
+
+impl AsRef<Pool<Postgres>> for PGMQueueExt {
+    fn as_ref(&self) -> &Pool<Postgres> {
+        &self.connection
+    }
+}
+
+impl Deref for PGMQueueExt {
+    type Target = Pool<Postgres>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
 }
 
 impl PGMQueueExt {
@@ -212,15 +226,15 @@ impl PGMQueueExt {
     where
         E: sqlx::Acquire<'c, Database = Postgres>,
     {
-        check_queue_name(queue_name)?;
+        let queue_name: QueueName = queue_name.try_into().map_err(QueueNameError::other)?;
         let mut txn = self
-            .acquire_queue_lock_with_cxn(queue_name, executor)
+            .acquire_queue_lock_with_cxn(*queue_name, executor)
             .await?;
 
         let exists = sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS(SELECT 1 FROM pgmq.meta WHERE queue_name = $1::text);",
         )
-        .bind(queue_name)
+        .bind(*queue_name)
         .fetch_one(&mut *txn)
         .await?;
 
@@ -228,10 +242,7 @@ impl PGMQueueExt {
             return Ok(false);
         }
 
-        sqlx::query("SELECT pgmq.create(queue_name=>$1::text);")
-            .bind(queue_name)
-            .execute(&mut *txn)
-            .await?;
+        txn.create(queue_name).await?;
 
         txn.commit().await?;
 
@@ -509,20 +520,11 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<i64, PgmqError> {
-        check_queue_name(queue_name)?;
+        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
         let delay: VisibilityTimeoutOffset = delay.into();
         let message = serde_json::to_value(message)?;
         let headers = serde_json::to_value(headers)?;
-        let msg_id: i64 = sqlx::query_scalar(
-            "SELECT * from pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, headers=>$3::jsonb, delay=>$4::int);",
-        )
-        .bind(queue_name)
-        .bind(message)
-        .bind(headers)
-        .bind(delay)
-        .fetch_one(executor)
-        .await?;
-        Ok(msg_id)
+        crate::queue::sqlx::send(executor, queue_name, message, headers, delay).await
     }
 
     pub async fn send_delay_with_headers<T: Serialize, H: Serialize>(
@@ -982,7 +984,7 @@ impl PGMQueueExt {
             .fetch_all(executor)
             .await?;
 
-        Self::handle_read_batch_result(rows)
+        handle_read_batch_result(rows)
     }
 
     async fn read_batch_with_poll_common<
@@ -1013,24 +1015,7 @@ impl PGMQueueExt {
             .fetch_all(executor)
             .await?;
 
-        Self::handle_read_batch_result(rows)
-    }
-
-    /// Helper method to convert [`PgRow`] to [`Message`] for the `read*`/`read_batch*` methods.
-    /// This is needed, vs using [`sqlx::query_as`] to directly convert the result to
-    /// [`Message`], because in order to use [`sqlx::query_as`] we need to add trait constraints
-    /// to the `T` type parameter used in the `read*`/`read_batch*` methods, which
-    /// would be a breaking change.
-    // Todo: In a future SemVer-breaking release, replace this method using `query_as`
-    //  to directly parse the SQL query rows to `Vec<Message<T>`.
-    fn handle_read_batch_result<T: for<'de> Deserialize<'de>>(
-        rows: Vec<PgRow>,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
-        let messages = rows
-            .into_iter()
-            .map(|row| Message::<T>::from_row(&row))
-            .collect::<Result<Vec<Message<T>>, _>>()?;
-        Ok(messages)
+        handle_read_batch_result(rows)
     }
 
     pub async fn archive_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(

--- a/pgmq-rs/src/private/mod.rs
+++ b/pgmq-rs/src/private/mod.rs
@@ -1,0 +1,6 @@
+pub mod util;
+
+/// Private marker trait that can be used to mark another trait as "sealed", which prevents external
+/// consumers from implementing the trait. This allows adding new methods to the sealed trait
+/// in a semver compatible way. See: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
+pub(crate) trait Sealed {}

--- a/pgmq-rs/src/private/util.rs
+++ b/pgmq-rs/src/private/util.rs
@@ -1,0 +1,12 @@
+/// Helper method to convert [`PgRow`] to [`Message`] for the `read*`/`read_batch*` methods.
+#[cfg(feature = "sqlx")]
+pub fn handle_read_batch_result<T: for<'de> serde::Deserialize<'de>>(
+    rows: Vec<sqlx::postgres::PgRow>,
+) -> Result<Vec<crate::types::Message<T>>, crate::errors::PgmqError> {
+    use sqlx::FromRow;
+    let messages = rows
+        .into_iter()
+        .map(|row| crate::types::Message::<T>::from_row(&row))
+        .collect::<Result<Vec<crate::types::Message<T>>, _>>()?;
+    Ok(messages)
+}

--- a/pgmq-rs/src/private/util.rs
+++ b/pgmq-rs/src/private/util.rs
@@ -1,12 +1,16 @@
 /// Helper method to convert [`PgRow`] to [`Message`] for the `read*`/`read_batch*` methods.
 #[cfg(feature = "sqlx")]
-pub fn handle_read_batch_result<T: for<'de> serde::Deserialize<'de>>(
+pub fn handle_read_batch_result<T, H>(
     rows: Vec<sqlx::postgres::PgRow>,
-) -> Result<Vec<crate::types::Message<T>>, crate::errors::PgmqError> {
+) -> Result<Vec<crate::types::Message<T, H>>, crate::errors::PgmqError>
+where
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
     use sqlx::FromRow;
     let messages = rows
         .into_iter()
-        .map(|row| crate::types::Message::<T>::from_row(&row))
-        .collect::<Result<Vec<crate::types::Message<T>>, _>>()?;
+        .map(|row| crate::types::Message::<T, H>::from_row(&row))
+        .collect::<Result<Vec<crate::types::Message<T, H>>, _>>()?;
     Ok(messages)
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -1,0 +1,124 @@
+//! Macros to help with implementing the [`crate::queue::Queue`] trait.
+
+/// "Identity" transformation macro -- simply returns the provided input.
+macro_rules! identity_macro {
+    ($input:tt) => {
+        $input
+    };
+}
+// Re-export the macro for use within this crate
+pub(crate) use identity_macro;
+
+/// Helper macro to implement the [`crate::queue::Queue`] trait for a type. Assumes that async
+/// functions exist in scope with the same names as the trait's methods. The functions' parameters
+/// should match the trait's parameters as well, with the following exceptions:
+///
+/// 1. Concrete [`crate::types::queue_name::QueueName`] and
+///    [`crate::types::visibility_timeout_offset::VisibilityTimeoutOffset`] instances are passed
+///    instead of a generic parameter (the generic parameter has already been converted)
+/// 2. Serializable parameters (e.g., message and headers) are passed as pre-serialized
+///    [`serde_json::Value`] instances.
+/*
+Note: Ideally we would be able to implement `Queue` using blanket implementations, e.g.:
+
+```rust
+impl<T> Queue for T where T: for<'c> sqlx::Executor<'c, Database = sqlx::Postgres> {
+    ...
+}
+
+impl<T> Queue for T where T: diesel_async::AsyncConnection<Backend = diesel::pg::Pg> {
+    ...
+}
+```
+
+This works if we only have a single blanket implementation. However, since we want to support
+multiple external traits' executor types, we would need multiple blanket implementations, which
+results in a "conflicting implementations" compilation error. This is the case even if we add a
+"sealed" trait for each external crate's blanket implementation, e.g., something like this:
+
+```rust
+mod sqlx_impl {
+    trait SqlxSealed {}
+    impl SqlxSealed for &mut sqlx::PgConnection {}
+    impl<T> Queue for T where T: SqlxSealed + for<'c> sqlx::Executor<'c, Database = sqlx::Postgres> {
+        ...
+    }
+}
+
+mod diesel_impl {
+    trait DieselSealed {}
+    impl DieselSealed for &mut diesel::PgConnection {}
+    impl<T> Queue for T where
+        T: DieselSealed + diesel::connection::LoadConnection<Backend = diesel::pg::Pg>
+    {
+        ...
+    }
+}
+```
+
+So, instead of using a blanket implementation, the `impl_queue` macro can be used to reduce the
+boilerplate / code duplication required to implement the `Queue` trait for all the external
+types we want to support.
+ */
+macro_rules! impl_queue {
+    (
+        /// The type to implement the `Queue` trait for.
+        $for_type:ty,
+        /// Expression used to transform `self` into an implementation-specific executor type.
+        $transform_self:tt
+    ) => {
+        impl crate::private::Sealed for $for_type {}
+
+        #[async_trait::async_trait]
+        impl crate::queue::Queue for $for_type {
+            async fn create<'q, Q, QE>(self, queue_name: Q) -> Result<(), crate::errors::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::queue_name::QueueName<'q>, Error = QE>,
+                QE: ToString,
+            {
+                let queue_name = queue_name.try_into().map_err(crate::types::queue_name::QueueNameError::other)?;
+                create($transform_self!(self), queue_name).await
+            }
+
+            async fn send<'q,T, H, Q, QE,  D>(
+                self,
+                queue_name: Q,
+                message: T,
+                headers: H,
+                delay: D,
+            ) -> Result<i64, crate::errors::PgmqError>
+            where
+                T: Send + serde::Serialize,
+                H: Send + serde::Serialize,
+                Q: Send + TryInto<crate::types::queue_name::QueueName<'q>, Error = QE>,
+                QE: ToString,
+                D: Send + Into<crate::types::visibility_timeout_offset::VisibilityTimeoutOffset>,
+            {
+                let queue_name = queue_name.try_into().map_err(crate::types::queue_name::QueueNameError::other)?;
+                let delay: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset = delay.into();
+                let message = serde_json::to_value(message)?;
+                let headers = serde_json::to_value(headers)?;
+                send($transform_self!(self), queue_name, message, headers, delay).await
+            }
+
+            async fn read<'q, T, Q, QE, VT>(
+                self,
+                queue_name: Q,
+                visibility_timeout: VT,
+                quantity: i32,
+            ) -> Result<Vec<crate::types::Message<T>>, crate::errors::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::queue_name::QueueName<'q>, Error = QE>,
+                QE: ToString,
+                VT: Send + Into<crate::types::visibility_timeout_offset::VisibilityTimeoutOffset>,
+            {
+                let queue_name = queue_name.try_into().map_err(crate::types::queue_name::QueueNameError::other)?;
+                let visibility_timeout: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset = visibility_timeout.into();
+                read($transform_self!(self), queue_name, visibility_timeout, quantity).await
+            }
+        }
+    };
+}
+// Re-export the macro for use within this crate
+pub(crate) use impl_queue;

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -13,8 +13,8 @@ pub(crate) use identity_macro;
 /// functions exist in scope with the same names as the trait's methods. The functions' parameters
 /// should match the trait's parameters as well, with the following exceptions:
 ///
-/// 1. Concrete [`crate::types::queue_name::QueueName`] and
-///    [`crate::types::visibility_timeout_offset::VisibilityTimeoutOffset`] instances are passed
+/// 1. Concrete [`crate::types::QueueName`] and
+///    [`crate::types::VisibilityTimeoutOffset`] instances are passed
 ///    instead of a generic parameter (the generic parameter has already been converted)
 /// 2. Serializable parameters (e.g., message and headers) are passed as pre-serialized
 ///    [`serde_json::Value`] instances.
@@ -73,14 +73,16 @@ macro_rules! impl_queue {
         impl crate::queue::Queue for $for_type {
             async fn create<'q, Q, QE>(self, queue_name: Q) -> Result<(), crate::errors::PgmqError>
             where
-                Q: Send + TryInto<crate::types::queue_name::QueueName<'q>, Error = QE>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
                 QE: ToString,
             {
-                let queue_name = queue_name.try_into().map_err(crate::types::queue_name::QueueNameError::other)?;
+                let queue_name = queue_name
+                    .try_into()
+                    .map_err(crate::types::queue_name::QueueNameError::other)?;
                 create($transform_self!(self), queue_name).await
             }
 
-            async fn send<'q,T, H, Q, QE,  D>(
+            async fn send<'q, T, H, Q, QE, D>(
                 self,
                 queue_name: Q,
                 message: T,
@@ -90,12 +92,14 @@ macro_rules! impl_queue {
             where
                 T: Send + serde::Serialize,
                 H: Send + serde::Serialize,
-                Q: Send + TryInto<crate::types::queue_name::QueueName<'q>, Error = QE>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
                 QE: ToString,
-                D: Send + Into<crate::types::visibility_timeout_offset::VisibilityTimeoutOffset>,
+                D: Send + Into<crate::types::VisibilityTimeoutOffset>,
             {
-                let queue_name = queue_name.try_into().map_err(crate::types::queue_name::QueueNameError::other)?;
-                let delay: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset = delay.into();
+                let queue_name = queue_name
+                    .try_into()
+                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let delay: crate::types::VisibilityTimeoutOffset = delay.into();
                 let message = serde_json::to_value(message)?;
                 let headers = serde_json::to_value(headers)?;
                 send($transform_self!(self), queue_name, message, headers, delay).await
@@ -109,13 +113,22 @@ macro_rules! impl_queue {
             ) -> Result<Vec<crate::types::Message<T>>, crate::errors::PgmqError>
             where
                 T: 'static + Send + for<'de> serde::Deserialize<'de>,
-                Q: Send + TryInto<crate::types::queue_name::QueueName<'q>, Error = QE>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
                 QE: ToString,
-                VT: Send + Into<crate::types::visibility_timeout_offset::VisibilityTimeoutOffset>,
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
             {
-                let queue_name = queue_name.try_into().map_err(crate::types::queue_name::QueueNameError::other)?;
-                let visibility_timeout: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset = visibility_timeout.into();
-                read($transform_self!(self), queue_name, visibility_timeout, quantity).await
+                let queue_name = queue_name
+                    .try_into()
+                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                read(
+                    $transform_self!(self),
+                    queue_name,
+                    visibility_timeout,
+                    quantity,
+                )
+                .await
             }
         }
     };

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -6,8 +6,7 @@ mod macros;
 #[cfg(feature = "sqlx")]
 pub mod sqlx;
 
-use crate::types::visibility_timeout_offset::VisibilityTimeoutOffset;
-use crate::types::QueueName;
+use crate::types::{QueueName, VisibilityTimeoutOffset};
 use crate::PgmqError;
 
 /// Sealed so we can add methods without breaking semver compatibility.

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -1,0 +1,48 @@
+//! (Unstable) Common interface shared between various SQL client implementations (sqlx, diesel, rust-postgres).
+//! This interface is considered unstable -- breaking changes may be released without a corresponding
+//! SemVer bump.
+
+mod macros;
+#[cfg(feature = "sqlx")]
+pub mod sqlx;
+
+use crate::types::visibility_timeout_offset::VisibilityTimeoutOffset;
+use crate::types::QueueName;
+use crate::PgmqError;
+
+/// Sealed so we can add methods without breaking semver compatibility.
+/// See: <https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed>
+#[async_trait::async_trait]
+#[allow(private_bounds)]
+pub trait Queue: crate::private::Sealed {
+    async fn create<'q, Q, QE>(self, queue_name: Q) -> Result<(), PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: ToString;
+
+    async fn send<'q, T, H, Q, QE, D>(
+        self,
+        queue_name: Q,
+        message: T,
+        headers: H,
+        delay: D,
+    ) -> Result<i64, PgmqError>
+    where
+        T: Send + serde::Serialize,
+        H: Send + serde::Serialize,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: ToString,
+        D: Send + Into<VisibilityTimeoutOffset>;
+
+    async fn read<'q, T, Q, QE, VT>(
+        self,
+        queue_name: Q,
+        visibility_timeout: VT,
+        quantity: i32,
+    ) -> Result<Vec<crate::types::Message<T>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: ToString,
+        VT: Send + Into<VisibilityTimeoutOffset>;
+}

--- a/pgmq-rs/src/queue/sqlx.rs
+++ b/pgmq-rs/src/queue/sqlx.rs
@@ -1,0 +1,78 @@
+use crate::private::util::handle_read_batch_result;
+use crate::queue::macros::{identity_macro, impl_queue};
+use crate::types::QueueName;
+use crate::types::VisibilityTimeoutOffset;
+use crate::{Message, PgmqError};
+use sqlx::{Executor, Postgres};
+
+/// Transforms a `sqlx::Transaction<'_, Postgres>` identifier by dereferencing it so that it can be
+/// used as an [`Executor`].
+macro_rules! transform_input_dereference_transaction {
+    ($input:ident) => {
+        &mut **$input
+    };
+}
+
+impl_queue!(
+    &mut sqlx::Transaction<'_, Postgres>,
+    transform_input_dereference_transaction
+);
+impl_queue!(&mut sqlx::PgConnection, identity_macro);
+impl_queue!(&sqlx::PgPool, identity_macro);
+
+async fn create<'c, C>(executor: C, queue_name: QueueName<'_>) -> Result<(), PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    sqlx::query("SELECT pgmq.create(queue_name=>$1::text);")
+        .bind(*queue_name)
+        .execute(executor)
+        .await?;
+
+    Ok(())
+}
+
+pub(crate) async fn send<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    message: serde_json::Value,
+    headers: serde_json::Value,
+    delay: VisibilityTimeoutOffset,
+) -> Result<i64, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let msg_id: i64 = sqlx::query_scalar(
+        "SELECT * from pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, headers=>$3::jsonb, delay=>$4::int);",
+    )
+    .bind(*queue_name)
+    .bind(message)
+    .bind(headers)
+    .bind(delay)
+    .fetch_one(executor)
+    .await?;
+    Ok(msg_id)
+}
+
+async fn read<'c, C, T>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    visibility_timeout: VisibilityTimeoutOffset,
+    quantity: i32,
+) -> Result<Vec<Message<T>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: Send + for<'de> serde::Deserialize<'de>,
+{
+    let query = sqlx::query(
+        r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)"#,
+    );
+    let rows = query
+        .bind(*queue_name)
+        .bind(visibility_timeout)
+        .bind(quantity)
+        .fetch_all(executor)
+        .await?;
+
+    handle_read_batch_result(rows)
+}

--- a/pgmq-rs/src/types/mod.rs
+++ b/pgmq-rs/src/types/mod.rs
@@ -1,4 +1,8 @@
 pub mod queue_name;
+pub mod visibility_timeout_offset;
+
+pub use queue_name::QueueName;
+pub use visibility_timeout_offset::VisibilityTimeoutOffset;
 
 use serde::Deserialize;
 use sqlx::types::chrono::{DateTime, Utc};

--- a/pgmq-rs/src/types/mod.rs
+++ b/pgmq-rs/src/types/mod.rs
@@ -4,9 +4,8 @@ pub mod visibility_timeout_offset;
 pub use queue_name::QueueName;
 pub use visibility_timeout_offset::VisibilityTimeoutOffset;
 
-use serde::Deserialize;
-use sqlx::types::chrono::{DateTime, Utc};
-use sqlx::FromRow;
+use chrono::{DateTime, Utc};
+use serde_derive::Deserialize;
 use std::time::Duration;
 
 pub const VT_DEFAULT: i32 = 30;
@@ -18,7 +17,8 @@ pub const QUEUE_PREFIX: &str = r#"q"#;
 pub const ARCHIVE_PREFIX: &str = r#"a"#;
 pub const PGMQ_SCHEMA: &str = "pgmq";
 
-#[derive(Clone, Debug, Deserialize, FromRow)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 #[non_exhaustive]
 pub struct PGMQueueMeta {
     pub queue_name: String,
@@ -31,7 +31,8 @@ pub struct PGMQueueMeta {
 ///
 /// It is an "envelope" for the message that is stored in the queue.
 /// It contains both the message body but also metadata about the message.
-#[derive(Clone, Debug, Deserialize, FromRow)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 #[non_exhaustive]
 pub struct Message<T = serde_json::Value, H = serde_json::Value> {
     /// Unique identifier for the message.
@@ -45,15 +46,16 @@ pub struct Message<T = serde_json::Value, H = serde_json::Value> {
     /// "visibility time". The UTC timestamp at which the message will be available for reading again.
     pub vt: DateTime<Utc>,
     /// The message body.
-    #[sqlx(json)]
+    #[cfg_attr(feature = "sqlx", sqlx(json))]
     pub message: T,
     /// The message headers.
-    #[sqlx(json(nullable))]
+    #[cfg_attr(feature = "sqlx", sqlx(json(nullable)))]
     pub headers: Option<H>,
 }
 
 /// A row returned by the `pgmq.send_batch_topic` SQL function(s).
-#[derive(Clone, Debug, Deserialize, FromRow)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 #[non_exhaustive]
 pub struct SendBatchTopicRow {
     pub queue_name: String,
@@ -61,7 +63,8 @@ pub struct SendBatchTopicRow {
 }
 
 /// A row returned by the `pgmq.list_topic_bindings` SQL function(s).
-#[derive(Clone, Debug, Deserialize, FromRow)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 #[non_exhaustive]
 pub struct ListTopicBindingsRow {
     pub pattern: String,
@@ -71,7 +74,8 @@ pub struct ListTopicBindingsRow {
 }
 
 /// A row returned by the `pgmq.list_notify_insert_throttles` SQL function.
-#[derive(Clone, Debug, Deserialize, FromRow)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 #[non_exhaustive]
 pub struct ListNotifyInsertThrottlesRow {
     pub queue_name: String,
@@ -81,7 +85,8 @@ pub struct ListNotifyInsertThrottlesRow {
 
 /// Metrics for a queue. Returned for a single queue by `pgmq.metrics` and for all queues by
 /// `pgmq.metrics_all`.
-#[derive(Clone, Debug, Deserialize, FromRow)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 #[non_exhaustive]
 pub struct QueueMetrics {
     pub queue_name: String,

--- a/pgmq-rs/src/types/queue_name.rs
+++ b/pgmq-rs/src/types/queue_name.rs
@@ -110,7 +110,7 @@ pub fn check_queue_name(input: &str) -> Result<(), QueueNameError> {
 #[cfg(test)]
 mod tests {
     use super::constants::MAX_PGMQ_QUEUE_LEN;
-    use crate::types::queue_name::QueueName;
+    use crate::types::QueueName;
     use rstest::rstest;
     use std::assert_matches;
 

--- a/pgmq-rs/src/types/visibility_timeout_offset.rs
+++ b/pgmq-rs/src/types/visibility_timeout_offset.rs
@@ -1,4 +1,3 @@
-use sqlx::{Database, Encode, Type};
 use std::ops::Deref;
 
 /// Type to represent an offset that will be applied to the current timestamp in order to update
@@ -81,7 +80,8 @@ use std::ops::Deref;
 /// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(VisibilityTimeoutOffset::MAX, VisibilityTimeoutOffset::from(std::time::Duration::MAX));
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Encode)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Encode))]
 pub struct VisibilityTimeoutOffset(i32);
 
 impl VisibilityTimeoutOffset {
@@ -158,10 +158,11 @@ Manually implement `sqlx::Type` because the derive macro automatically implement
 `sqlx::Encode` and `sqlx::Decode`, but we only need `sqlx::Encode` for this type.
 However, `sqlx::Encode` is implemented via a derive macro.
 */
-impl<DB: Database> Type<DB> for VisibilityTimeoutOffset
+#[cfg(feature = "sqlx")]
+impl<DB: sqlx::Database> sqlx::Type<DB> for VisibilityTimeoutOffset
 where
-    i32: Type<DB>,
-    std::time::Duration: Type<DB>,
+    i32: sqlx::Type<DB>,
+    std::time::Duration: sqlx::Type<DB>,
 {
     fn type_info() -> DB::TypeInfo {
         <i32 as sqlx::Type<DB>>::type_info()

--- a/pgmq-rs/src/types/visibility_timeout_offset.rs
+++ b/pgmq-rs/src/types/visibility_timeout_offset.rs
@@ -18,67 +18,67 @@ use std::ops::Deref;
 ///
 /// ## Convert from `i32`
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(10i32));
 /// ```
 ///
 /// ## Convert from `u32`
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(10u32));
 /// ```
 ///
 /// ## Convert from `u32` -- capped
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(i32::MAX, *VisibilityTimeoutOffset::from(u32::MAX));
 /// ```
 ///
 /// ## Convert from `i64`
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(10i64));
 /// ```
 ///
 /// ## Convert from `i64` -- capped max
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(i32::MAX, *VisibilityTimeoutOffset::from(i64::MAX));
 /// ```
 ///
 /// ## Convert from `i64` -- capped min
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(i32::MIN, *VisibilityTimeoutOffset::from(i64::MIN));
 /// ```
 ///
 /// ## Convert from [`chrono::Duration`]
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(chrono::Duration::seconds(10)));
 /// ```
 ///
 /// ## Convert from [`chrono::Duration`] -- capped max
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(VisibilityTimeoutOffset::MAX, VisibilityTimeoutOffset::from(chrono::Duration::MAX));
 /// ```
 ///
 /// ## Convert from [`chrono::Duration`] -- capped min
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(VisibilityTimeoutOffset::MAX, VisibilityTimeoutOffset::from(chrono::Duration::MAX));
 /// ```
 ///
 /// ## Convert from [`std::time::Duration`]
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(10i32, *VisibilityTimeoutOffset::from(std::time::Duration::from_secs(10)));
 /// ```
 ///
 /// ## Convert from [`std::time::Duration`] -- capped max
 /// ```
-/// # use pgmq::pg_ext::VisibilityTimeoutOffset;
+/// # use pgmq::types::VisibilityTimeoutOffset;
 /// assert_eq!(VisibilityTimeoutOffset::MAX, VisibilityTimeoutOffset::from(std::time::Duration::MAX));
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Encode)]

--- a/pgmq-rs/src/util.rs
+++ b/pgmq-rs/src/util.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sqlx")]
+
 use crate::errors::PgmqError;
 use log::LevelFilter;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -1,5 +1,4 @@
-use pgmq::pg_ext::VisibilityTimeoutOffset;
-use pgmq::types::{ARCHIVE_PREFIX, PGMQ_SCHEMA, QUEUE_PREFIX};
+use pgmq::types::{VisibilityTimeoutOffset, ARCHIVE_PREFIX, PGMQ_SCHEMA, QUEUE_PREFIX};
 use pgmq::util::connect;
 use rand::RngExt;
 use serde::{Deserialize, Serialize};

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -1,7 +1,7 @@
 use pgmq::types::{VisibilityTimeoutOffset, ARCHIVE_PREFIX, PGMQ_SCHEMA, QUEUE_PREFIX};
 use pgmq::util::connect;
 use rand::RngExt;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use sqlx::{AssertSqlSafe, Pool, Postgres, Row};
 use std::env;
 use std::time::Duration;

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -1,0 +1,192 @@
+//! Integration tests for the [`Queue`] trait and its implementations.
+//!
+//! Tests are written with the help of the custom [`pgmq_test_macro::queue_test`] macro -- the macro
+//! generates individual tests for each type that implements the [`Queue`] trait.
+//!
+//! In order to prevent tests generating conflicting data in the DB, each test creates a temporary
+//! test DB for itself. The temporary DBs are automatically removed if the tests pass, unless the
+//! `PGMQ_KEEP_TEST_DB` env var is set to `true`.
+
+#![cfg(feature = "queue-experimental")]
+
+use initialization::ConnDetails;
+use pgmq::queue::Queue;
+use pgmq::Message;
+use rand::RngExt;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+static QUEUE: &str = "queue";
+
+mod initialization {
+    use chrono::Utc;
+    use sqlx::AssertSqlSafe;
+    use std::env;
+    use std::sync::OnceLock;
+    use url::Url;
+
+    static KEEP_TEST_DB: OnceLock<bool> = OnceLock::new();
+    static DB_URL: OnceLock<Url> = OnceLock::new();
+    static TIMESTAMP: OnceLock<String> = OnceLock::new();
+
+    const MAX_DB_NAME_LENGTH: usize = 63;
+
+    fn test_db_name(test_name: &str) -> String {
+        let timestamp = TIMESTAMP.get_or_init(|| Utc::now().timestamp().to_string());
+
+        let db_name = format!("{test_name}/{timestamp}");
+        if db_name.len() > MAX_DB_NAME_LENGTH {
+            panic!("Test DB name `{db_name}` is too long! Max length is {MAX_DB_NAME_LENGTH}");
+        }
+        db_name
+    }
+
+    fn db_url() -> &'static Url {
+        DB_URL.get_or_init(|| {
+            let url = env::var("DATABASE_URL").unwrap_or_else(|_| {
+                "postgres://postgres:postgres@localhost:5432/postgres".to_owned()
+            });
+            Url::parse(&url).unwrap()
+        })
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct ConnDetails {
+        pub original: &'static Url,
+        pub test_db_name: String,
+        pub test_db_url: Url,
+    }
+
+    impl ConnDetails {
+        pub fn new() -> Self {
+            let original = db_url();
+            let test_name = std::thread::current().name().unwrap().to_string();
+            let test_db_name = test_db_name(&test_name);
+            let mut test_db_url = original.clone();
+            test_db_url.set_path(&test_db_name);
+            Self {
+                original,
+                test_db_name,
+                test_db_url,
+            }
+        }
+
+        async fn original_conn(&self) -> sqlx::postgres::PgConnection {
+            sqlx_conn(self.original).await
+        }
+    }
+
+    pub async fn before(conn_details: &ConnDetails) {
+        let create_db_statement = format!("CREATE DATABASE \"{}\"", conn_details.test_db_name);
+        sqlx::query(AssertSqlSafe(create_db_statement))
+            .execute(&mut conn_details.original_conn().await)
+            .await
+            .unwrap();
+
+        install_pgmq(conn_details).await;
+    }
+
+    async fn install_pgmq(conn_details: &ConnDetails) {
+        // Todo: It's a little awkward to create an instance of `PGMQueueExt` just to init/install pgmq.
+        //  In a future change, we could expand the `Queue` trait to include the init/install methods,
+        //  then we could replace this method with a call to the client implementation.
+        let queue = pgmq::PGMQueueExt::new(conn_details.test_db_url.to_string(), 1)
+            .await
+            .unwrap();
+
+        #[cfg(feature = "install-sql-embedded")]
+        let result = queue.install_sql_from_embedded().await.map(|_| true);
+        #[cfg(not(feature = "install-sql"))]
+        let result = queue.init().await;
+
+        result.expect("failed to init pgmq");
+    }
+
+    pub async fn after(conn_details: &ConnDetails) {
+        let keep_db = *KEEP_TEST_DB.get_or_init(|| {
+            env::var("PGMQ_KEEP_TEST_DB")
+                .ok()
+                .and_then(|x| x.parse::<bool>().ok())
+                .unwrap_or(false)
+        });
+        if keep_db {
+            return;
+        }
+        let drop_db_statement = format!(
+            "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+            conn_details.test_db_name
+        );
+        sqlx::query(AssertSqlSafe(drop_db_statement))
+            .execute(&mut conn_details.original_conn().await)
+            .await
+            .unwrap();
+    }
+
+    pub async fn sqlx_conn(url: &Url) -> sqlx::postgres::PgConnection {
+        use sqlx::ConnectOptions;
+        sqlx::postgres::PgConnectOptions::from_url(url)
+            .unwrap()
+            .connect()
+            .await
+            .unwrap()
+    }
+
+    pub async fn pgmq_ext(url: &Url) -> pgmq::PGMQueueExt {
+        pgmq::PGMQueueExt::new(url.to_string(), 2).await.unwrap()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct TestMessage {
+    a: String,
+    b: i32,
+}
+
+impl TestMessage {
+    fn new() -> Self {
+        Self {
+            a: std::thread::current().name().unwrap().to_string(),
+            b: rand::rng().random_range(0..i32::MAX),
+        }
+    }
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let msg = TestMessage::new();
+    let msg_id = queue.send(QUEUE, &msg, json!({}), 0).await.unwrap();
+
+    // The first read should read the message
+    let read_msg: Message<TestMessage> = queue
+        .read(QUEUE, 10, 1)
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    assert_eq!(msg_id, read_msg.msg_id);
+    assert_eq!(read_msg.message, msg);
+
+    // A second read should return no messages
+    let read_msg: Vec<Message<TestMessage>> = queue.read(QUEUE, 10, 1).await.unwrap();
+    assert!(read_msg.is_empty());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn read_multiple(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let msg_id1 = queue
+        .send(QUEUE, TestMessage::new(), json!({}), 0)
+        .await
+        .unwrap();
+    let msg_id2 = queue
+        .send(QUEUE, TestMessage::new(), json!({}), 0)
+        .await
+        .unwrap();
+
+    let messages: Vec<Message<TestMessage>> = queue.read(QUEUE, 10, 2).await.unwrap();
+    assert_eq!(2, messages.len());
+    assert!(messages.iter().any(|msg| msg.msg_id == msg_id1));
+    assert!(messages.iter().any(|msg| msg.msg_id == msg_id2));
+}

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -13,7 +13,7 @@ use initialization::ConnDetails;
 use pgmq::queue::Queue;
 use pgmq::Message;
 use rand::RngExt;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
 
 static QUEUE: &str = "queue";

--- a/pgmq-rs/tests/test_sql.rs
+++ b/pgmq-rs/tests/test_sql.rs
@@ -1,5 +1,5 @@
 use rand::RngExt;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Debug, Deserialize, Eq, PartialEq)]
 struct MyMessage {


### PR DESCRIPTION
Initial commit to add a new `Queue` trait to allow supporting multiple different SQL clients (this PR only adds the `sqlx` implementation).

Some high-level details:

- The new `Queue` trait and implementations are in the `queue` mod
- Only three key methods are added initially: `create`, `send`, and `read`
- Common implementation details exist in a macro, and individual implementations are generated by invoking the macro with the relevant parameters
- Added a `sqlx` feature flag for the `PGMQueueExt` client and the `sqlx` implementation of the `Queue` trait
- Tests for all the implementations of the `Queue` trait are in the new `queue` integration test file. Each implementation has a separate test method generated for it using a new custom test macro.

Implementations for other clients (diesel/rust-postgres) will be added in a separate followup PR.

Relates to https://github.com/pgmq/pgmq/issues/425