### PR TITLE
feat!: Add `headers` and `last_read_at` fields to `Message` struct

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.34.0-alpha.0"
+version = "0.34.0-alpha.1"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/src/install/applied.rs
+++ b/pgmq-rs/src/install/applied.rs
@@ -8,6 +8,7 @@ use sqlx::{Acquire, FromRow, Postgres, Transaction};
 
 /// Struct to represent a row of the DB table that tracks which migration scripts have been applied.
 #[derive(FromRow)]
+#[non_exhaustive]
 pub struct AppliedMigration {
     /// The name of the migration script.
     pub name: String,

--- a/pgmq-rs/src/install/script.rs
+++ b/pgmq-rs/src/install/script.rs
@@ -17,6 +17,7 @@ pub static INIT_SCRIPT_NAME: &str = "pgmq.sql";
 static MIGRATION_SCRIPT_NAME_REGEX: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
 
 #[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct ParsedScriptName {
     pub original: String,
     pub from: Version,
@@ -79,6 +80,7 @@ pub trait ScriptFetcher {
 
 /// Struct to contain metadata for a pgmq extension migration script along with its content.
 #[derive(Debug, Eq)]
+#[non_exhaustive]
 pub struct MigrationScript {
     pub name: ParsedScriptName,
     pub content: Cow<'static, str>,

--- a/pgmq-rs/src/install/version.rs
+++ b/pgmq-rs/src/install/version.rs
@@ -14,6 +14,7 @@ static VERSION_REGEX: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
 
 /// Struct to represent a basic semver version, e.g. `1.2.3`.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub struct Version {
     /// The first segment of the version string, e.g., for version `1.2.3`, this would be set to `1`
     pub major: u32,

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -2,14 +2,13 @@ mod visibility_timeout_offest;
 
 use crate::errors::PgmqError;
 use crate::types::{
-    ListNotifyInsertThrottlesRow, ListTopicBindingsRow, Message, QueueMetrics, SendBatchTopicRow,
-    QUEUE_PREFIX,
+    ListNotifyInsertThrottlesRow, ListTopicBindingsRow, Message, PGMQueueMeta, QueueMetrics,
+    SendBatchTopicRow, QUEUE_PREFIX,
 };
 use crate::util::{check_input, connect};
 use log::info;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
-use sqlx::types::chrono::Utc;
 use sqlx::{FromRow, Pool, Postgres, Row};
 pub use visibility_timeout_offest::VisibilityTimeoutOffset;
 
@@ -18,17 +17,12 @@ const DEFAULT_POLL_INTERVAL_MS: i32 = 250;
 
 /// Main controller for interacting with a managed by the PGMQ Postgres extension.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct PGMQueueExt {
     pub url: String,
     pub connection: Pool<Postgres>,
 }
 
-pub struct PGMQueueMeta {
-    pub queue_name: String,
-    pub created_at: chrono::DateTime<Utc>,
-    pub is_unlogged: bool,
-    pub is_partitioned: bool,
-}
 impl PGMQueueExt {
     /// Initialize a connection to PGMQ/Postgres
     pub async fn new(url: String, max_connections: u32) -> Result<Self, PgmqError> {
@@ -404,15 +398,8 @@ impl PGMQueueExt {
             Ok(None)
         } else {
             let queues = queues
-                .into_iter()
-                .map(|q| {
-                    Ok(PGMQueueMeta {
-                        queue_name: q.try_get("queue_name")?,
-                        created_at: q.try_get("created_at")?,
-                        is_unlogged: q.try_get("is_unlogged")?,
-                        is_partitioned: q.try_get("is_partitioned")?,
-                    })
-                })
+                .iter()
+                .map(PGMQueueMeta::from_row)
                 .collect::<Result<_, sqlx::Error>>()?;
             Ok(Some(queues))
         }
@@ -438,7 +425,7 @@ impl PGMQueueExt {
         let vt: VisibilityTimeoutOffset = vt.into();
         // queue_name, created_at as "created_at: chrono::DateTime<Utc>", is_partitioned, is_unlogged
         let updated = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.set_vt(queue_name=>$1::text, msg_id=>$2::bigint, vt=>$3::integer);"#
+            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.set_vt(queue_name=>$1::text, msg_id=>$2::bigint, vt=>$3::integer);"#
         )
             .bind(queue_name)
             .bind(msg_id)
@@ -685,7 +672,7 @@ impl PGMQueueExt {
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
         let query = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)"#,
+            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)"#,
         );
 
         Self::read_batch_common(query, queue_name, vt, qty, executor).await
@@ -751,7 +738,7 @@ impl PGMQueueExt {
         executor: E,
     ) -> Result<Option<Vec<Message<T>>>, PgmqError> {
         let query = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_with_poll(
+            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_with_poll(
                 queue_name=>$1::text,
                 vt=>$2::integer,
                 qty=>$3::integer,
@@ -803,7 +790,7 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
-        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
+        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
 
         Self::read_batch_common(query, queue_name, vt, qty, executor).await
     }
@@ -832,7 +819,7 @@ impl PGMQueueExt {
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
         let query = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped_with_poll(
+            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_with_poll(
                 queue_name=>$1::text,
                 vt=>$2::integer,
                 qty=>$3::integer,
@@ -883,7 +870,7 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
-        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped_head(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
+        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_head(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
 
         Self::read_batch_common(query, queue_name, vt, qty, executor).await
     }
@@ -909,7 +896,7 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
-        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped_rr(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
+        let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_rr(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
 
         Self::read_batch_common(query, queue_name, vt, qty, executor).await
     }
@@ -938,7 +925,7 @@ impl PGMQueueExt {
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
         let query = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.read_grouped_rr_with_poll(
+            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_rr_with_poll(
                 queue_name=>$1::text,
                 vt=>$2::integer,
                 qty=>$3::integer,
@@ -1110,7 +1097,7 @@ impl PGMQueueExt {
         executor: E,
     ) -> Result<Option<Message<T>>, PgmqError> {
         check_input(queue_name)?;
-        let row = sqlx::query(r#"SELECT msg_id, read_ct, enqueued_at, vt, message from pgmq.pop(queue_name=>$1::text)"#)
+        let row = sqlx::query(r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.pop(queue_name=>$1::text)"#)
             .bind(queue_name)
             .fetch_optional(executor)
             .await?;

--- a/pgmq-rs/src/types.rs
+++ b/pgmq-rs/src/types.rs
@@ -1,4 +1,3 @@
-use chrono::serde::ts_seconds::deserialize as from_ts;
 use serde::Deserialize;
 use sqlx::types::chrono::{DateTime, Utc};
 use sqlx::FromRow;
@@ -13,9 +12,12 @@ pub const QUEUE_PREFIX: &str = r#"q"#;
 pub const ARCHIVE_PREFIX: &str = r#"a"#;
 pub const PGMQ_SCHEMA: &str = "pgmq";
 
+#[derive(Clone, Debug, Deserialize, FromRow)]
+#[non_exhaustive]
 pub struct PGMQueueMeta {
     pub queue_name: String,
     pub is_partitioned: bool,
+    pub is_unlogged: bool,
     pub created_at: DateTime<Utc>,
 }
 
@@ -24,19 +26,24 @@ pub struct PGMQueueMeta {
 /// It is an "envelope" for the message that is stored in the queue.
 /// It contains both the message body but also metadata about the message.
 #[derive(Clone, Debug, Deserialize, FromRow)]
-pub struct Message<T = serde_json::Value> {
-    /// unique identifier for the message
+#[non_exhaustive]
+pub struct Message<T = serde_json::Value, H = serde_json::Value> {
+    /// Unique identifier for the message.
     pub msg_id: i64,
-    #[serde(deserialize_with = "from_ts")]
-    /// "visibility time". The UTC timestamp at which the message will be available for reading again.
-    pub vt: chrono::DateTime<Utc>,
-    /// UTC timestamp that the message was sent to the queue
-    pub enqueued_at: chrono::DateTime<Utc>,
     /// The number of times the message has been read. Increments on read.
     pub read_ct: i32,
+    /// UTC timestamp that the message was sent to the queue.
+    pub enqueued_at: DateTime<Utc>,
+    /// UTC timestamp of the last time the message was fetched from the queue.
+    pub last_read_at: Option<DateTime<Utc>>,
+    /// "visibility time". The UTC timestamp at which the message will be available for reading again.
+    pub vt: DateTime<Utc>,
     /// The message body.
     #[sqlx(json)]
     pub message: T,
+    /// The message headers.
+    #[sqlx(json(nullable))]
+    pub headers: Option<H>,
 }
 
 /// A row returned by the `pgmq.send_batch_topic` SQL function(s).
@@ -53,7 +60,7 @@ pub struct SendBatchTopicRow {
 pub struct ListTopicBindingsRow {
     pub pattern: String,
     pub queue_name: String,
-    pub bound_at: chrono::DateTime<Utc>,
+    pub bound_at: DateTime<Utc>,
     pub compiled_regex: String,
 }
 
@@ -63,7 +70,7 @@ pub struct ListTopicBindingsRow {
 pub struct ListNotifyInsertThrottlesRow {
     pub queue_name: String,
     pub throttle_interval_ms: i32,
-    pub last_notified_at: chrono::DateTime<Utc>,
+    pub last_notified_at: DateTime<Utc>,
 }
 
 /// Metrics for a queue. Returned for a single queue by `pgmq.metrics` and for all queues by
@@ -76,6 +83,6 @@ pub struct QueueMetrics {
     pub newest_msg_age_sec: Option<i32>,
     pub oldest_msg_age_sec: Option<i32>,
     pub total_messages: i64,
-    pub scrape_time: chrono::DateTime<Utc>,
+    pub scrape_time: DateTime<Utc>,
     pub queue_visible_length: i64,
 }


### PR DESCRIPTION
Also:
- Mark `Message` and all other structs with only public fields as `#[non_exhaustive]` so additional fields can be added in the future as a non-semver breaking change
- Consolidate `PGMQMetadata` structs and add `sqlx::FromRow` derive to simplify deserializing it from a `PgRow`.

Resolves: https://github.com/pgmq/pgmq/issues/548