### PR TITLE
chore!: Resolve `TODO` comments for return type changes

### DIFF
--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.34.0-alpha.1"
+version = "0.34.0-alpha.2"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -390,23 +390,19 @@ impl PGMQueueExt {
     pub async fn list_queues_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(
         &self,
         executor: E,
-    ) -> Result<Option<Vec<PGMQueueMeta>>, PgmqError> {
+    ) -> Result<Vec<PGMQueueMeta>, PgmqError> {
         let queues = sqlx::query(r#"SELECT queue_name, is_partitioned, is_unlogged, created_at from pgmq.list_queues();"#)
             .fetch_all(executor)
             .await?;
-        if queues.is_empty() {
-            Ok(None)
-        } else {
-            let queues = queues
-                .iter()
-                .map(PGMQueueMeta::from_row)
-                .collect::<Result<_, sqlx::Error>>()?;
-            Ok(Some(queues))
-        }
+        let queues = queues
+            .iter()
+            .map(PGMQueueMeta::from_row)
+            .collect::<Result<_, _>>()?;
+        Ok(queues)
     }
 
     /// List all queues in the Postgres instance.
-    pub async fn list_queues(&self) -> Result<Option<Vec<PGMQueueMeta>>, PgmqError> {
+    pub async fn list_queues(&self) -> Result<Vec<PGMQueueMeta>, PgmqError> {
         self.list_queues_with_cxn(&self.connection).await
     }
 
@@ -702,7 +698,7 @@ impl PGMQueueExt {
     ) -> Result<Option<Message<T>>, PgmqError> {
         self.read_batch_with_poll_with_cxn(queue_name, vt, 1, poll_timeout, poll_interval, executor)
             .await
-            .map(|result| result.and_then(|result| result.into_iter().next()))
+            .map(|result| result.into_iter().next())
     }
 
     pub async fn read_with_poll<'c, T: for<'de> Deserialize<'de>>(
@@ -722,8 +718,6 @@ impl PGMQueueExt {
         .await
     }
 
-    // Todo: In a future SemVer-breaking release, we can update this to return
-    //  `Result<Vec<Message<T>>, PgmqError>` to match `read_batch`/`read_batch_with_cxn`.
     pub async fn read_batch_with_poll_with_cxn<
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
@@ -736,7 +730,7 @@ impl PGMQueueExt {
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
         executor: E,
-    ) -> Result<Option<Vec<Message<T>>>, PgmqError> {
+    ) -> Result<Vec<Message<T>>, PgmqError> {
         let query = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_with_poll(
                 queue_name=>$1::text,
@@ -757,7 +751,6 @@ impl PGMQueueExt {
             executor,
         )
         .await
-        .map(Some)
     }
 
     pub async fn read_batch_with_poll<T: for<'de> Deserialize<'de>>(
@@ -767,7 +760,7 @@ impl PGMQueueExt {
         max_batch_size: i32,
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
-    ) -> Result<Option<Vec<Message<T>>>, PgmqError> {
+    ) -> Result<Vec<Message<T>>, PgmqError> {
         self.read_batch_with_poll_with_cxn(
             queue_name,
             vt,
@@ -1144,24 +1137,27 @@ impl PGMQueueExt {
     pub async fn delete_batch_with_cxn<'c, E: sqlx::Executor<'c, Database = Postgres>>(
         &self,
         queue_name: &str,
-        msg_id: &[i64],
+        msg_ids: &[i64],
         executor: E,
-    ) -> Result<usize, PgmqError> {
-        let qty =
-            sqlx::query("SELECT * from pgmq.delete(queue_name=>$1::text, msg_ids=>$2::bigint[])")
-                .bind(queue_name)
-                .bind(msg_id)
-                .fetch_all(executor)
-                .await?
-                .len();
+    ) -> Result<Vec<i64>, PgmqError> {
+        let deleted_msg_ids = sqlx::query_scalar(
+            "SELECT * from pgmq.delete(queue_name=>$1::text, msg_ids=>$2::bigint[])",
+        )
+        .bind(queue_name)
+        .bind(msg_ids)
+        .fetch_all(executor)
+        .await?;
 
-        // FIXME: change function signature to Vec<i64> and return rows
-        Ok(qty)
+        Ok(deleted_msg_ids)
     }
 
     // Delete with a slice of message ids
-    pub async fn delete_batch(&self, queue_name: &str, msg_id: &[i64]) -> Result<usize, PgmqError> {
-        self.delete_batch_with_cxn(queue_name, msg_id, &self.connection)
+    pub async fn delete_batch(
+        &self,
+        queue_name: &str,
+        msg_ids: &[i64],
+    ) -> Result<Vec<i64>, PgmqError> {
+        self.delete_batch_with_cxn(queue_name, msg_ids, &self.connection)
             .await
     }
 

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -114,7 +114,6 @@ async fn test_ext_create_list_drop() {
         .list_queues()
         .await
         .expect("error listing queues")
-        .expect("test queue was not created")
         .iter()
         .map(|q| q.queue_name.clone())
         .collect::<Vec<String>>();
@@ -130,7 +129,6 @@ async fn test_ext_create_list_drop() {
         .list_queues()
         .await
         .expect("error listing queues")
-        .unwrap_or(vec![])
         .iter()
         .map(|q| q.queue_name.clone())
         .collect::<Vec<String>>();
@@ -185,8 +183,8 @@ async fn test_ext_send_read_delete_core<T: Into<VisibilityTimeoutOffset>>(
             None,
         )
         .await
-        .expect("error reading message")
-        .expect("no message");
+        .expect("error reading message");
+    assert!(!read_with_poll.is_empty(), "Message should have been read");
 
     let poll_duration = start_poll.elapsed();
 
@@ -447,14 +445,11 @@ async fn test_ext_read_batch_with_poll_empty_queue() {
 
     let vt = 4;
 
-    // read_batch_with_poll should return Ok(Some(<empty vec>)) if no items are available to be read.
-    // Todo: In a future SemVer breaking change, the expected return value would be Ok(<empty vec>)
     let msg_read = queue
         .read_batch_with_poll::<MyMessage>(&test_queue, vt, 1, Some(Duration::from_secs(1)), None)
         .await
         .unwrap();
-    assert!(msg_read.is_some());
-    assert!(msg_read.unwrap().is_empty());
+    assert!(msg_read.is_empty());
 }
 
 #[tokio::test]
@@ -627,7 +622,7 @@ async fn test_ext_delete_batch() {
         .expect("delete batch error");
     let post_delete_rowcount = rowcount(&test_queue, &queue.connection).await;
     assert_eq!(post_delete_rowcount, 0);
-    assert_eq!(delete_result, 3);
+    assert_eq!(delete_result.len(), 3);
 }
 
 #[tokio::test]
@@ -704,7 +699,6 @@ async fn test_create_txn() {
         .list_queues()
         .await
         .expect("error listing queues")
-        .expect("test queue was not created")
         .iter()
         .map(|q| q.queue_name.clone())
         .collect::<Vec<_>>();
@@ -728,7 +722,6 @@ async fn test_create_txn() {
         .list_queues()
         .await
         .expect("error listing queues")
-        .expect("test queue was not created")
         .iter()
         .map(|q| q.queue_name.clone())
         .collect::<Vec<_>>();


### PR DESCRIPTION
There were a few TODO comments in `PGMQueueExt` related to changing method return types. This PR resolves the comments.

- Return `Vec<_>` instead of `Option<Vec<_>>` -- `None` is redundant with an empty `Vec`, and this also makes the return type consistent with the other methods that return `Vec<_>` (e.g., `read_batch*`)
- Return `Vec<i64>` from `delete_batch` -- return the list of IDs that were deleted instead of just the number of messages that were deleted