### PR TITLE
docs: Update Rust crate `lib.rs` doc comment and synchronize `README.md`

### DIFF
--- a/.github/workflows/crate_ci.yml
+++ b/.github/workflows/crate_ci.yml
@@ -28,6 +28,9 @@ jobs:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
+      - uses: taiki-e/install-action@9adcff13829681f1e2f4a678b775043ab5c7fc2c
+        with:
+          tool: cargo-readme
       - uses: Swatinem/rust-cache@v2
       - name: Cargo format
         run: make check.fmt
@@ -35,6 +38,13 @@ jobs:
         run: make check.clippy
       - name: Check docs
         run: make check.docs
+      - name: Check readme in sync
+        run: |
+          make update.readme
+          if [ $(git diff --name-status -- README.md | wc -l) -gt 0 ]; then
+            echo "README.md is out of sync with the crate's main 'lib.rs' doc comment. Run 'make update.readme' to sync."
+            exit 1
+          fi
 
   semver:
     name: Check SemVer compatibility

--- a/pgmq-rs/Cargo.lock
+++ b/pgmq-rs/Cargo.lock
@@ -1434,7 +1434,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pgmq"
-version = "0.34.0-alpha.2"
+version = "0.34.0-alpha.3"
 dependencies = [
  "chrono",
  "clap",

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.34.0-alpha.2"
+version = "0.34.0-alpha.3"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/README.md
+++ b/pgmq-rs/README.md
@@ -1,22 +1,66 @@
 # Postgres Message Queue (PGMQ)
 
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%20%7C%2014%20%7C%2015%20%7C%2016%20%7C%2017%20%7C%2018-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+[![PGXN version](https://badge.fury.io/pg/pgmq.svg)](https://pgxn.org/dist/pgmq/)
 [![Latest Version](https://img.shields.io/crates/v/pgmq.svg)](https://crates.io/crates/pgmq)
+[![docs.rs](https://img.shields.io/docsrs/roadster?logo=docsdotrs)](https://docs.rs/roadster/latest/roadster/)
+[![Crates.io MSRV](https://img.shields.io/crates/msrv/roadster)](https://crates.io/crates/roadster)
 
-The Rust client for PGMQ. This gives you an ORM-like experience with the Postgres extension and makes managing connection pools, transactions, and serialization/deserialization much easier.
+A lightweight message queue. Like [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq) but on Postgres.
 
+## Features
+
+- Lightweight - No background worker or external dependencies, just Postgres and Rust
+- Guaranteed "exactly once" delivery of messages to a consumer within a visibility timeout
+- API parity with [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq)
+- [FIFO](docs/fifo-queues.md#overview) (First-In-First-Out) queues with message group keys for ordered processing
+- [Topic-based](docs/topics.md#topic-based-routing) routing with wildcard patterns for publish-subscribe and content-based routing
+- Messages stay in the queue until explicitly removed
+- Messages can be archived, instead of deleted, for long-term retention and replayability
+- Completely asynchronous API
+
+Supported on Postgres 14-18.
+
+Not building in Rust? Try the [PGMQ Postgres extension](https://pgt.dev/extensions/pgmq).
 
 ## Installing PGMQ
 
-PGMQ can be installed into any existing Postgres database using this Rust client. This is useful if the PGMQ extension
+PGMQ can be installed on any existing Postgres instance or installed as a Postgres Extension.
+See [INSTALLATION.md](https://github.com/pgmq/pgmq/blob/main/INSTALLATION.md) for the full
+installation guide including a [comparison](https://github.com/pgmq/pgmq/blob/main/INSTALLATION.md#considerations)
+of the Postgres Extension vs the SQL-only installation.
+
+### Postgres Extension
+
+The fastest way to get started with the extension is by running the Docker image, where PGMQ
+comes pre-installed as an extension in Postgres.
+
+```bash
+docker run -d --name pgmq-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 ghcr.io/pgmq/pg18-pgmq:v1.10.0
+```
+
+Then connect and enable PGMQ:
+
+```bash
+psql postgres://postgres:postgres@localhost:5432/postgres
+```
+
+```sql
+CREATE EXTENSION pgmq;
+```
+
+### Versioned SQL-only installation
+
+PGMQ can also be installed into any existing Postgres database using this Rust client. This is useful if the PGMQ extension
 is not supported by your PostgreSQL instance. The installation performed by the Rust client is versioned, which means
 it can be used to perform a fresh installation of PGMQ, or it can upgrade an existing installation to a newer version.
 
 Two installation methods are supported. One method uses SQL scripts embedded in the Rust crate, while the other fetches
-the SQL scripts from the PGMQ GitHub repo. The embedded approach does not require external network requests but only supports
-installing (or upgrading to) the version bundled with the crate. The GitHub approach requires several network requests to GitHub,
-but allows installing (or upgrading to) any version available in the repo.
+the SQL scripts from the PGMQ GitHub repo. The embedded approach does not require external network requests but only
+supports installing (or upgrading to) the version bundled with the crate. The GitHub approach requires several network
+requests to GitHub, but allows installing (or upgrading to) any version available in the repo.
 
-### Create the DB
+#### Create the DB
 
 Run standard Postgres using Docker:
 
@@ -24,16 +68,15 @@ Run standard Postgres using Docker:
 docker run -d -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:latest
 ```
 
-### Initialize applied migrations table
+#### Initialize applied migrations table
 
-In crate versions <= 0.32.1, the crate did not track which SQL scripts had already been run, which makes upgrading to a
-new version difficult. To switch from the old approach to the new approach, first perform the "initialize applied migrations table"
-workflow.
+In crate versions < 0.33.0, the crate did not track which SQL scripts had already been run, which makes upgrading to a
+new version difficult. To switch from the old approach to the new approach, first perform the "initialize applied
+migrations table" workflow.
 
 This method is not needed for fresh installations, or if the new SQL-only installation method was used to install PGMQ.
 
-
-#### Via the CLI
+##### Via the CLI
 
 ```shell
 # Install the PGMQ Rust CLI
@@ -42,7 +85,7 @@ cargo install pgmq --features cli --bin pgmq-cli
 pgmq-cli install -d postgres://postgres:postgres@localhost:5432/postgres init-migrations-table -v 1.9.0
 ```
 
-#### In Rust
+##### In Rust
 
 Add PGMQ to your `Cargo.toml` with the `install-sql` feature enabled:
 
@@ -59,8 +102,9 @@ async fn init_migrations_table(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), p
 }
 ```
 
-### Install using the embedded scripts
-#### Via CLI
+#### Install using the embedded scripts
+
+##### Via CLI
 
 ```bash
 # Install the PGMQ Rust CLI
@@ -69,7 +113,7 @@ cargo install pgmq --features cli --bin pgmq-cli
 pgmq-cli install -d postgres://postgres:postgres@localhost:5432/postgres install-from-embedded
 ```
 
-#### In Rust
+##### In Rust
 
 See also, the [install example](examples/install.rs)
 
@@ -87,8 +131,9 @@ async fn install_sql(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqE
 }
 ```
 
-### Install using the scripts fetched from GitHub
-#### Via CLI
+#### Install using the scripts fetched from GitHub
+
+##### Via CLI
 
 ```bash
 # Install the PGMQ Rust CLI
@@ -97,7 +142,7 @@ cargo install pgmq --features cli --bin pgmq-cli
 pgmq-cli install -d postgres://postgres:postgres@localhost:5432/postgres install-from-github -v 1.9.0
 ```
 
-#### In Rust
+##### In Rust
 
 See also, the [install example](examples/install.rs)
 
@@ -115,24 +160,101 @@ async fn install_sql(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqE
 }
 ```
 
-## Examples
+## Sending messages
 
-The project contains several [examples](./examples/). You can run these using Cargo.
+You can send one message at a time with `queue.send()` or several with `queue.send_batch()`.
+The message can be any type that implements `serde::Serialize`. This means you can prepare
+your messages as JSON with `serde_json::json!(...)` or as a dedicated struct.
 
-A basic example displaying the primary features:
-```bash
-cargo run --example basic
+## Reading messages
+
+Messages can be parsed as `serde_json::Value` or into a struct. `queue.read()` returns a
+`Result<Option<Message<T>>, PGMQError>` where `T` is the type of the message on the queue.
+It returns an error when there is an issue parsing the message ([`PgmqError::JsonParsingError`]
+or if PGMQ is unable to reach postgres ([`PgmqError::DatabaseError`]).
+
+Read a single message with `queue.read()` or as many as you want with `queue.read_batch()`.
+
+## Visibility Timeout (vt)
+
+PGMQ guarantees exactly once delivery of a message within a visibility timeout (`vt`). The
+visibility timeout is the amount of time a message is invisible to other consumers after it has
+been read by a consumer. If the message is NOT deleted or archived within the visibility timeout,
+it will become visible again and can be read by another consumer. The visibility timeout is set
+when a message is read from the queue, via `queue.read()`. It is recommended to set a `vt` value
+that is greater than the expected time it takes to process a message. After the application
+successfully processes the message, it should call `queue.delete()` to completely remove the
+message from the queue or `queue.archive()` to move it to the archive table for the queue.
+
+## Archive or Delete a message
+
+Remove the message from the queue when you are done with it. You can either completely
+delete the message using `queue.delete()`, or archive it using `queue.archive()`. Archived
+messages are deleted from the queue and inserted to the queue's archive table. Deleted messages
+are simply deleted.
+
+The Rust client does not provide a method to retrieve message from the archive. If necessary,
+they can be retrieved using plain SQL:
+
+```sql
+SELECT * FROM pgmq.a_{your_queue_name};
 ```
 
-How to install PGMQ using the Rust client from within your application:
+## Minimal example
 
-```bash
-cargo run --example install --features install-sql-github,install-sql-embedded
+Below is a minimal example of how to use the crate. More advanced examples can be found in
+[examples](https://github.com/pgmq/pgmq/tree/main/pgmq-rs/examples) and
+[tests](https://github.com/pgmq/pgmq/tree/main/pgmq-rs/tests).
+
+```rust
+use pgmq::{PgmqError, Message, PGMQueueExt};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[tokio::main]
+async fn main() -> Result<(), PgmqError> {
+
+    // Initialize a connection to Postgres
+    println!("Connecting to Postgres");
+    let queue: PGMQueueExt = PGMQueueExt::new("postgres://postgres:postgres@0.0.0.0:5432".to_owned(), 1)
+        .await
+        .expect("Failed to connect to postgres");
+
+    // Create a queue
+    println!("Creating a queue 'my_queue'");
+    let my_queue = "my_example_queue".to_string();
+    queue.create(&my_queue).await?;
+
+    // Structure a message
+    #[derive(Debug, Serialize, Deserialize)]
+    struct MyMessage {
+        foo: String,
+    }
+    let message = MyMessage {
+        foo: "bar".to_string(),
+    };
+    // Send the message
+    let message_id: i64 = queue.send(&my_queue, &message).await?;
+
+    // Use a visibility timeout of 30 seconds. Once read, the message will be unable to be read
+    // until the visibility timeout expires.
+    let visibility_timeout_seconds: i32 = 30;
+
+    // Read a message
+    let received_message: Message<MyMessage> = queue
+        .read(&my_queue, visibility_timeout_seconds)
+        .await?
+        .expect("No messages available to read from the queue");
+    println!("Received a message: {:?}", received_message);
+
+    assert_eq!(received_message.msg_id, message_id);
+
+    // archive the messages
+    queue.archive(&my_queue, received_message.msg_id).await?;
+    println!("archived the messages from the queue");
+
+    Ok(())
+}
 ```
 
-## Serialization and Deserialization
-
-Messages can be parsed as `serde_json::Value` or into a struct of your design. `queue.read()` returns an `Result<Option<Message<T>>, PgmqError>`
-where `T` is the type of the message on the queue. It returns an error when there is an issue parsing the message (`PgmqError::JsonParsingError`) or if PGMQ is unable to reach postgres (`PgmqError::DatabaseError`).
-
-License: [PostgreSQL](LICENSE)
+License: PostgreSQL

--- a/pgmq-rs/README.md
+++ b/pgmq-rs/README.md
@@ -94,6 +94,8 @@ cargo add pgmq --features install-sql
 ```
 
 ```rust
+// Requires the `install-sql` feature
+#[cfg(feature = "install-sql")]
 async fn init_migrations_table(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
     // Replace the version
@@ -124,6 +126,8 @@ cargo add pgmq --features install-sql-embedded
 ```
 
 ```rust
+// Requires the `install-sql-embedded` feature
+#[cfg(feature = "install-sql-embedded")]
 async fn install_sql(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
     queue.install_sql_from_embedded().await?;
@@ -153,6 +157,8 @@ cargo add pgmq --features install-sql-github
 ```
 
 ```rust
+// Requires the `install-sql-github` feature
+#[cfg(feature = "install-sql-github")]
 async fn install_sql(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
     queue.install_sql_from_github(Some("1.9.0")).await?;

--- a/pgmq-rs/README.md
+++ b/pgmq-rs/README.md
@@ -3,8 +3,8 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%20%7C%2014%20%7C%2015%20%7C%2016%20%7C%2017%20%7C%2018-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 [![PGXN version](https://badge.fury.io/pg/pgmq.svg)](https://pgxn.org/dist/pgmq/)
 [![Latest Version](https://img.shields.io/crates/v/pgmq.svg)](https://crates.io/crates/pgmq)
-[![docs.rs](https://img.shields.io/docsrs/roadster?logo=docsdotrs)](https://docs.rs/roadster/latest/roadster/)
-[![Crates.io MSRV](https://img.shields.io/crates/msrv/roadster)](https://crates.io/crates/roadster)
+[![docs.rs](https://img.shields.io/docsrs/pgmq?logo=docsdotrs)](https://docs.rs/pgmq/latest/pgmq/)
+[![Crates.io MSRV](https://img.shields.io/crates/msrv/pgmq)](https://crates.io/crates/pgmq)
 
 A lightweight message queue. Like [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq) but on Postgres.
 

--- a/pgmq-rs/README.md
+++ b/pgmq-rs/README.md
@@ -3,7 +3,7 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%20%7C%2014%20%7C%2015%20%7C%2016%20%7C%2017%20%7C%2018-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 [![PGXN version](https://badge.fury.io/pg/pgmq.svg)](https://pgxn.org/dist/pgmq/)
 [![Latest Version](https://img.shields.io/crates/v/pgmq.svg)](https://crates.io/crates/pgmq)
-[![docs.rs](https://img.shields.io/docsrs/pgmq?logo=docsdotrs)](https://docs.rs/pgmq/latest/pgmq/)
+[![docs.rs](https://img.shields.io/docsrs/pgmq?logo=docsdotrs)](https://docs.rs/pgmq)
 [![Crates.io MSRV](https://img.shields.io/crates/msrv/pgmq)](https://crates.io/crates/pgmq)
 
 A lightweight message queue. Like [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq) but on Postgres.

--- a/pgmq-rs/src/bin/pgmq-cli.rs
+++ b/pgmq-rs/src/bin/pgmq-cli.rs
@@ -33,12 +33,12 @@ struct InstallArgs {
 enum InstallCommands {
     /// Initialize the DB table that tracks which SQL scripts have been run for the SQL-only
     /// installation method. This is useful in order to switch from the previous SQL-only
-    /// installation approach (in crate version <= 0.32.1) to the new approach that tracks which
+    /// installation approach (in crate version < 0.33.0) to the new approach that tracks which
     /// scripts have been run. This is not needed for fresh installations, or if the new SQL-only
     /// installation method was used to install PGMQ.
     InitMigrationsTable(InitMigrationsTableArgs),
     /// Get the version of PGMQ that is currently installed. Only supports the versioned SQL-only
-    /// installation methods available in crate versions > 0.32.1.
+    /// installation methods available in crate versions >= 0.33.0.
     InstalledVersion,
     /// Install PGMQ using SQL installation scripts fetched from the PGMQ GitHub repo.
     InstallFromGithub(InstallFromGithubArgs),

--- a/pgmq-rs/src/install/embedded/install_sql_embedded.md
+++ b/pgmq-rs/src/install/embedded/install_sql_embedded.md
@@ -1,7 +1,7 @@
 Install PGMQ using the SQL-only approach. This method will perform a fresh installation if PGMQ is not installed, or
 it will upgrade PGMQ to the latest version if it was previously installed and there's a newer version available.
 
-If the previous SQL-only installation approach (in crate version <= 0.32.1) was used to install PGMQ,
+If the previous SQL-only installation approach (in crate version < 0.33.0) was used to install PGMQ,
 run [`crate::PGMQueueExt::init_migrations_table`]/[`crate::PGMQueueExt::init_migrations_table_with_cxn`]/[
 `crate::install::init_migrations_table`] before running this method.
 

--- a/pgmq-rs/src/install/github/install_sql_github.md
+++ b/pgmq-rs/src/install/github/install_sql_github.md
@@ -1,7 +1,7 @@
 Install PGMQ using the SQL-only approach. This method will perform a fresh installation if PGMQ is not installed, or
 it will upgrade PGMQ to the latest version if it was previously installed and there's a newer version available.
 
-If the previous SQL-only installation approach (in crate version <= 0.32.1) was used to install PGMQ,
+If the previous SQL-only installation approach (in crate version < 0.33.0) was used to install PGMQ,
 run [`crate::PGMQueueExt::init_migrations_table`]/[`crate::PGMQueueExt::init_migrations_table_with_cxn`]/[
 `crate::install::init_migrations_table`] before running this method.
 

--- a/pgmq-rs/src/install/init_migrations_table.md
+++ b/pgmq-rs/src/install/init_migrations_table.md
@@ -1,5 +1,5 @@
 Initialize the DB table that tracks which SQL scripts have been run for the SQL-only installation method. This is
-useful in order to switch from the previous SQL-only installation approach (in crate version <= 0.32.1) to the new
+useful in order to switch from the previous SQL-only installation approach (in crate version < 0.33.0) to the new
 approach that tracks which scripts have been run. This method is not needed for fresh installations, or if the new
 SQL-only installation method was used to install PGMQ.
 

--- a/pgmq-rs/src/install/installed_version.md
+++ b/pgmq-rs/src/install/installed_version.md
@@ -1,2 +1,2 @@
 Get the version of PGMQ that is currently installed. Only supports the versioned SQL-only installation methods
-available in crate versions > 0.32.1.
+available in crate versions >= 0.33.0.

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -1,61 +1,212 @@
 //! # Postgres Message Queue (PGMQ)
 //!
+//! [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%20%7C%2014%20%7C%2015%20%7C%2016%20%7C%2017%20%7C%2018-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+//! [![PGXN version](https://badge.fury.io/pg/pgmq.svg)](https://pgxn.org/dist/pgmq/)
 //! [![Latest Version](https://img.shields.io/crates/v/pgmq.svg)](https://crates.io/crates/pgmq)
+//! [![docs.rs](https://img.shields.io/docsrs/roadster?logo=docsdotrs)](https://docs.rs/roadster/latest/roadster/)
+//! [![Crates.io MSRV](https://img.shields.io/crates/msrv/roadster)](https://crates.io/crates/roadster)
 //!
-//! PGMQ is a lightweight, distributed message queue.
-//! It's like [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq) but native to Postgres.
-//!
-//! Message queues allow you to decouple and connect microservices.
-//! Send, store, and receive messages between components scalably, without dropping messages or
-//! needing other services to be available.
-//!
-//! PGMQ was created by Tembo. Our goal is to make the full Postgres ecosystem accessible to everyone.
-//! We're building a radically simplified Postgres platform designed to be developer-first and easily extensible.
-//! PGMQ is a part of that project.
-//!
-//! Not building in Rust? Try the [Tembo pgmq Postgres extension](https://pgt.dev/extensions/pgmq).
+//! A lightweight message queue. Like [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq) but on Postgres.
 //!
 //! ## Features
 //!
-//! - Lightweight - Rust and Postgres only
-//! - Guaranteed delivery of messages to exactly one consumer within a visibility timeout
+//! - Lightweight - No background worker or external dependencies, just Postgres and Rust
+//! - Guaranteed "exactly once" delivery of messages to a consumer within a visibility timeout
 //! - API parity with [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq)
-//! - Messages stay in the queue until deleted
+//! - [FIFO](docs/fifo-queues.md#overview) (First-In-First-Out) queues with message group keys for ordered processing
+//! - [Topic-based](docs/topics.md#topic-based-routing) routing with wildcard patterns for publish-subscribe and content-based routing
+//! - Messages stay in the queue until explicitly removed
 //! - Messages can be archived, instead of deleted, for long-term retention and replayability
 //! - Completely asynchronous API
 //!
-//! ## Quick start
+//! Supported on Postgres 14-18.
 //!
-//! - First, you will need Postgres. We use a container in this example.
+//! Not building in Rust? Try the [PGMQ Postgres extension](https://pgt.dev/extensions/pgmq).
+//!
+//! ## Installing PGMQ
+//!
+//! PGMQ can be installed on any existing Postgres instance or installed as a Postgres Extension.
+//! See [INSTALLATION.md](https://github.com/pgmq/pgmq/blob/main/INSTALLATION.md) for the full
+//! installation guide including a [comparison](https://github.com/pgmq/pgmq/blob/main/INSTALLATION.md#considerations)
+//! of the Postgres Extension vs the SQL-only installation.
+//!
+//! ### Postgres Extension
+//!
+//! The fastest way to get started with the extension is by running the Docker image, where PGMQ
+//! comes pre-installed as an extension in Postgres.
 //!
 //! ```bash
-//! docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres
+//! docker run -d --name pgmq-postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 ghcr.io/pgmq/pg18-pgmq:v1.10.0
 //! ```
 //!
-//! - If you don't have Docker installed, it can be found [here](https://docs.docker.com/get-docker/).
-//!
-//! - Make sure you have the Rust toolchain installed:
+//! Then connect and enable PGMQ:
 //!
 //! ```bash
-//! cargo --version
+//! psql postgres://postgres:postgres@localhost:5432/postgres
 //! ```
 //!
-//! - This example was written with version 1.67.0, but the latest stable should work. You can go [here](https://www.rust-lang.org/tools/install) to install Rust if you don't have it already, then run `rustup install stable` to install the latest, stable toolchain.
-//!
-//! - Change directory to the example project:
-//! ```bash
-//! cd examples/basic
-//!```
-//!
-//! - Run the project!
-//!
-//! ```bash
-//! cargo run
+//! ```sql
+//! CREATE EXTENSION pgmq;
 //! ```
 //!
-//! ## Minimal example at a glance
+//! ### Versioned SQL-only installation
 //!
-//! ```rust
+//! PGMQ can also be installed into any existing Postgres database using this Rust client. This is useful if the PGMQ extension
+//! is not supported by your PostgreSQL instance. The installation performed by the Rust client is versioned, which means
+//! it can be used to perform a fresh installation of PGMQ, or it can upgrade an existing installation to a newer version.
+//!
+//! Two installation methods are supported. One method uses SQL scripts embedded in the Rust crate, while the other fetches
+//! the SQL scripts from the PGMQ GitHub repo. The embedded approach does not require external network requests but only
+//! supports installing (or upgrading to) the version bundled with the crate. The GitHub approach requires several network
+//! requests to GitHub, but allows installing (or upgrading to) any version available in the repo.
+//!
+//! #### Create the DB
+//!
+//! Run standard Postgres using Docker:
+//!
+//! ```bash
+//! docker run -d -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:latest
+//! ```
+//!
+//! #### Initialize applied migrations table
+//!
+//! In crate versions < 0.33.0, the crate did not track which SQL scripts had already been run, which makes upgrading to a
+//! new version difficult. To switch from the old approach to the new approach, first perform the "initialize applied
+//! migrations table" workflow.
+//!
+//! This method is not needed for fresh installations, or if the new SQL-only installation method was used to install PGMQ.
+//!
+//! ##### Via the CLI
+//!
+//! ```shell
+//! # Install the PGMQ Rust CLI
+//! cargo install pgmq --features cli --bin pgmq-cli
+//! # Replace the DB url and the version
+//! pgmq-cli install -d postgres://postgres:postgres@localhost:5432/postgres init-migrations-table -v 1.9.0
+//! ```
+//!
+//! ##### In Rust
+//!
+//! Add PGMQ to your `Cargo.toml` with the `install-sql` feature enabled:
+//!
+//! ```bash
+//! cargo add pgmq --features install-sql
+//! ```
+//!
+//! ```rust,no_run
+//! async fn init_migrations_table(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
+//!     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
+//!     // Replace the version
+//!     queue.init_migrations_table("1.9.0").await?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! #### Install using the embedded scripts
+//!
+//! ##### Via CLI
+//!
+//! ```bash
+//! # Install the PGMQ Rust CLI
+//! cargo install pgmq --features cli --bin pgmq-cli
+//! # Replace the DB url
+//! pgmq-cli install -d postgres://postgres:postgres@localhost:5432/postgres install-from-embedded
+//! ```
+//!
+//! ##### In Rust
+//!
+//! See also, the [install example](examples/install.rs)
+//!
+//! Add PGMQ to your `Cargo.toml` with the `install-sql-embedded` feature enabled:
+//!
+//! ```bash
+//! cargo add pgmq --features install-sql-embedded
+//! ```
+//!
+//! ```rust,no_run
+//! async fn install_sql(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
+//!     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
+//!     queue.install_sql_from_embedded().await?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! #### Install using the scripts fetched from GitHub
+//!
+//! ##### Via CLI
+//!
+//! ```bash
+//! # Install the PGMQ Rust CLI
+//! cargo install pgmq --features cli --bin pgmq-cli
+//! # Replace the DB url and the version
+//! pgmq-cli install -d postgres://postgres:postgres@localhost:5432/postgres install-from-github -v 1.9.0
+//! ```
+//!
+//! ##### In Rust
+//!
+//! See also, the [install example](examples/install.rs)
+//!
+//! Add PGMQ to your `Cargo.toml` with the `install-sql-github` feature enabled:
+//!
+//! ```bash
+//! cargo add pgmq --features install-sql-github
+//! ```
+//!
+//! ```rust,no_run
+//! async fn install_sql(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
+//!     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
+//!     queue.install_sql_from_github(Some("1.9.0")).await?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Sending messages
+//!
+//! You can send one message at a time with `queue.send()` or several with `queue.send_batch()`.
+//! The message can be any type that implements `serde::Serialize`. This means you can prepare
+//! your messages as JSON with `serde_json::json!(...)` or as a dedicated struct.
+//!
+//! ## Reading messages
+//!
+//! Messages can be parsed as `serde_json::Value` or into a struct. `queue.read()` returns a
+//! `Result<Option<Message<T>>, PGMQError>` where `T` is the type of the message on the queue.
+//! It returns an error when there is an issue parsing the message ([`PgmqError::JsonParsingError`]
+//! or if PGMQ is unable to reach postgres ([`PgmqError::DatabaseError`]).
+//!
+//! Read a single message with `queue.read()` or as many as you want with `queue.read_batch()`.
+//!
+//! ## Visibility Timeout (vt)
+//!
+//! PGMQ guarantees exactly once delivery of a message within a visibility timeout (`vt`). The
+//! visibility timeout is the amount of time a message is invisible to other consumers after it has
+//! been read by a consumer. If the message is NOT deleted or archived within the visibility timeout,
+//! it will become visible again and can be read by another consumer. The visibility timeout is set
+//! when a message is read from the queue, via `queue.read()`. It is recommended to set a `vt` value
+//! that is greater than the expected time it takes to process a message. After the application
+//! successfully processes the message, it should call `queue.delete()` to completely remove the
+//! message from the queue or `queue.archive()` to move it to the archive table for the queue.
+//!
+//! ## Archive or Delete a message
+//!
+//! Remove the message from the queue when you are done with it. You can either completely
+//! delete the message using `queue.delete()`, or archive it using `queue.archive()`. Archived
+//! messages are deleted from the queue and inserted to the queue's archive table. Deleted messages
+//! are simply deleted.
+//!
+//! The Rust client does not provide a method to retrieve message from the archive. If necessary,
+//! they can be retrieved using plain SQL:
+//!
+//! ```sql
+//! SELECT * FROM pgmq.a_{your_queue_name};
+//! ```
+//!
+//! ## Minimal example
+//!
+//! Below is a minimal example of how to use the crate. More advanced examples can be found in
+//! [examples](https://github.com/pgmq/pgmq/tree/main/pgmq-rs/examples) and
+//! [tests](https://github.com/pgmq/pgmq/tree/main/pgmq-rs/tests).
+//!
+//! ```rust,no_run
 //! use pgmq::{PgmqError, Message, PGMQueueExt};
 //! use serde::{Deserialize, Serialize};
 //! use serde_json::Value;
@@ -71,80 +222,40 @@
 //!
 //!     // Create a queue
 //!     println!("Creating a queue 'my_queue'");
-//!     let my_queue = "my_example_queue".to_owned();
-//!     queue.create(&my_queue)
-//!         .await
-//!         .expect("Failed to create queue");
+//!     let my_queue = "my_example_queue".to_string();
+//!     queue.create(&my_queue).await?;
 //!
 //!     // Structure a message
-//!     #[derive(Serialize, Debug, Deserialize)]
+//!     #[derive(Debug, Serialize, Deserialize)]
 //!     struct MyMessage {
 //!         foo: String,
 //!     }
 //!     let message = MyMessage {
-//!         foo: "bar".to_owned(),
+//!         foo: "bar".to_string(),
 //!     };
 //!     // Send the message
-//!     let message_id: i64 = queue
-//!         .send(&my_queue, &message)
-//!         .await
-//!         .expect("Failed to enqueue message");
+//!     let message_id: i64 = queue.send(&my_queue, &message).await?;
 //!
-//!     // Use a visibility timeout of 30 seconds
-//!     // Once read, the message will be unable to be read
-//!     // until the visibility timeout expires
+//!     // Use a visibility timeout of 30 seconds. Once read, the message will be unable to be read
+//!     // until the visibility timeout expires.
 //!     let visibility_timeout_seconds: i32 = 30;
 //!
 //!     // Read a message
 //!     let received_message: Message<MyMessage> = queue
-//!         .read::<MyMessage>(&my_queue, visibility_timeout_seconds)
-//!         .await
-//!         .unwrap()
-//!         .expect("No messages in the queue");
+//!         .read(&my_queue, visibility_timeout_seconds)
+//!         .await?
+//!         .expect("No messages available to read from the queue");
 //!     println!("Received a message: {:?}", received_message);
 //!
 //!     assert_eq!(received_message.msg_id, message_id);
 //!
 //!     // archive the messages
-//!     let _ = queue.archive(&my_queue, received_message.msg_id)
-//!         .await
-//!         .expect("Failed to archive message");
+//!     queue.archive(&my_queue, received_message.msg_id).await?;
 //!     println!("archived the messages from the queue");
-//!     Ok(())
 //!
+//!     Ok(())
 //! }
 //! ```
-//!
-//! ## Sending messages
-//!
-//! You can send one message at a time with `queue.send()` or several with `queue.send_batch()`.
-//! These methods can be passed any type that implements `serde::Serialize`. This means you can prepare your messages as JSON or as a struct.
-//!
-//! ## Reading messages
-//!
-//! Reading a message will make it invisible (unavailable for consumption) for the duration of the visibility timeout (vt).
-//! No messages are returned when the queue is empty or all messages are invisible.
-//!
-//! Messages can be parsed as serde_json::Value or into a struct. `queue.read()` returns an `Result<Option<Message<T>>, PGMQError>`
-//! where `T` is the type of the message on the queue. It returns an error when there is an issue parsing the message or if PGMQ is unable to reach postgres.
-//! Note that when parsing into a `struct`, the operation will return an error if
-//! parsed as the type specified. For example, if the message expected is
-//! `MyMessage{foo: "bar"}` but `{"hello": "world"}` is received, the application will panic.
-//!
-//! Read a single message with `queue.read()` or as many as you want with `queue.read_batch()`.
-//!
-//! ## Archive or Delete a message
-//!
-//! Remove the message from the queue when you are done with it. You can either completely `.delete()`, or `.archive()` the message. Archived messages are deleted from the queue and inserted to the queue's archive table. Deleted messages are just deleted.
-//!
-//! Read messages from the queue archive with SQL:
-//!
-//! ```sql
-//! SELECT *
-//! FROM pgmq_{your_queue_name}_archive;
-//! ```
-//!
-
 #![doc(html_root_url = "https://docs.rs/pgmq/")]
 
 pub mod errors;

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -3,8 +3,8 @@
 //! [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%20%7C%2014%20%7C%2015%20%7C%2016%20%7C%2017%20%7C%2018-336791?logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 //! [![PGXN version](https://badge.fury.io/pg/pgmq.svg)](https://pgxn.org/dist/pgmq/)
 //! [![Latest Version](https://img.shields.io/crates/v/pgmq.svg)](https://crates.io/crates/pgmq)
-//! [![docs.rs](https://img.shields.io/docsrs/roadster?logo=docsdotrs)](https://docs.rs/roadster/latest/roadster/)
-//! [![Crates.io MSRV](https://img.shields.io/crates/msrv/roadster)](https://crates.io/crates/roadster)
+//! [![docs.rs](https://img.shields.io/docsrs/pgmq?logo=docsdotrs)](https://docs.rs/pgmq)
+//! [![Crates.io MSRV](https://img.shields.io/crates/msrv/pgmq)](https://crates.io/crates/pgmq)
 //!
 //! A lightweight message queue. Like [AWS SQS](https://aws.amazon.com/sqs/) and [RSMQ](https://github.com/smrchy/rsmq) but on Postgres.
 //!

--- a/pgmq-rs/src/lib.rs
+++ b/pgmq-rs/src/lib.rs
@@ -94,6 +94,8 @@
 //! ```
 //!
 //! ```rust,no_run
+//! // Requires the `install-sql` feature
+//! #[cfg(feature = "install-sql")]
 //! async fn init_migrations_table(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
 //!     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
 //!     // Replace the version
@@ -124,6 +126,8 @@
 //! ```
 //!
 //! ```rust,no_run
+//! // Requires the `install-sql-embedded` feature
+//! #[cfg(feature = "install-sql-embedded")]
 //! async fn install_sql(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
 //!     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
 //!     queue.install_sql_from_embedded().await?;
@@ -153,6 +157,8 @@
 //! ```
 //!
 //! ```rust,no_run
+//! // Requires the `install-sql-github` feature
+//! #[cfg(feature = "install-sql-github")]
 //! async fn install_sql(pool: sqlx::Pool<sqlx::Postgres>) -> Result<(), pgmq::PgmqError> {
 //!     let queue = pgmq::PGMQueueExt::new_with_pool(pool).await;
 //!     queue.install_sql_from_github(Some("1.9.0")).await?;


### PR DESCRIPTION
The Rust crate's `README.md` should be kept in sync with the `lib.rs` doc comment using `make update.readme`. However, this was not enforced by CI, so they have become out of sync.

This PR updates the crate's `lib.rs` doc comment, pulling in relevant updates from both the crate's and the repo's top-level `README.md` files, then updates the crate's `README.md` using `make update.readme`.

This PR also adds a check to CI to ensure the `README.md` stays in sync with the `lib.rs` doc comment.

Resolves: https://github.com/pgmq/pgmq/issues/516