### PR TITLE
feat!: Refactor `CheckedName`/`check_input`

### DIFF
--- a/pgmq-rs/Cargo.lock
+++ b/pgmq-rs/Cargo.lock
@@ -717,6 +717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +788,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1447,6 +1459,7 @@ dependencies = [
  "rand 0.10.1",
  "regex",
  "reqwest",
+ "rstest",
  "serde",
  "serde_json",
  "sqlx",
@@ -1514,6 +1527,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1709,6 +1731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1788,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2472,6 +2529,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,6 +3124,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -52,6 +52,7 @@ env_logger = "0.11.0"
 rand = "0.10.0"
 regex = "1.5.4"
 insta = { version = "1.46.3", features = ["json"] }
+rstest = "0.26.1"
 
 # If a consumer has both the `time` and `chrono` features of `sqlx` enabled, `sqlx` will default to using
 # `OffsetDateTime` (from `time`) for timestamp fields instead of `DateTime<Utc>` (from `chrono`), causing a compilation

--- a/pgmq-rs/src/errors.rs
+++ b/pgmq-rs/src/errors.rs
@@ -1,4 +1,5 @@
 //! Custom errors types for PGMQ
+use crate::types::queue_name::QueueNameError;
 use thiserror::Error;
 use url::ParseError;
 
@@ -17,10 +18,9 @@ pub enum PgmqError {
     #[error("database error {0}")]
     DatabaseError(#[from] sqlx::Error),
 
-    /// a queue name error
-    /// queue names must be alphanumeric and start with a letter
-    #[error("invalid queue name: '{name}'")]
-    InvalidQueueName { name: String },
+    /// the error returned when attempting to use an invalid queue name
+    #[error(transparent)]
+    QueueNameError(#[from] QueueNameError),
 
     /// a general error for installation operations
     #[cfg(feature = "install-sql")]

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1,11 +1,12 @@
 mod visibility_timeout_offest;
 
 use crate::errors::PgmqError;
+use crate::types::queue_name::check_queue_name;
 use crate::types::{
     ListNotifyInsertThrottlesRow, ListTopicBindingsRow, Message, PGMQueueMeta, QueueMetrics,
     SendBatchTopicRow, QUEUE_PREFIX,
 };
-use crate::util::{check_input, connect};
+use crate::util::connect;
 use log::info;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
@@ -158,6 +159,7 @@ impl PGMQueueExt {
         queue_name: &str,
         txn: &mut sqlx::Transaction<'c, Postgres>,
     ) -> Result<(), PgmqError> {
+        check_queue_name(queue_name)?;
         sqlx::query("SELECT pgmq.acquire_queue_lock(queue_name=>$1::text);")
             .bind(queue_name)
             .execute(&mut **txn)
@@ -210,7 +212,7 @@ impl PGMQueueExt {
     where
         E: sqlx::Acquire<'c, Database = Postgres>,
     {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let mut txn = self
             .acquire_queue_lock_with_cxn(queue_name, executor)
             .await?;
@@ -245,7 +247,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<bool, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         sqlx::query("SELECT pgmq.create_unlogged(queue_name=>$1::text);")
             .bind(queue_name)
             .execute(executor)
@@ -268,7 +270,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<bool, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let queue_table = format!("pgmq.{QUEUE_PREFIX}_{queue_name}");
         // we need to check whether the queue exists first
         // pg_partman create operations are currently unable to be idempotent
@@ -306,6 +308,7 @@ impl PGMQueueExt {
         retention_interval: Option<&str>,
         executor: E,
     ) -> Result<(), PgmqError> {
+        check_queue_name(queue_name)?;
         let mut query: sqlx::QueryBuilder<Postgres> =
             sqlx::QueryBuilder::new("SELECT pgmq.convert_archive_partitioned(");
 
@@ -353,7 +356,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         sqlx::query("SELECT pgmq.drop_queue(queue_name=>$1::text);")
             .bind(queue_name)
             .execute(executor)
@@ -373,7 +376,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<i64, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let purged = sqlx::query("SELECT * from pgmq.purge_queue(queue_name=>$1::text);")
             .bind(queue_name)
             .fetch_one(executor)
@@ -417,7 +420,7 @@ impl PGMQueueExt {
         vt: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<Message<T>, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let vt: VisibilityTimeoutOffset = vt.into();
         // queue_name, created_at as "created_at: chrono::DateTime<Utc>", is_partitioned, is_unlogged
         let updated = sqlx::query(
@@ -506,7 +509,7 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<i64, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let delay: VisibilityTimeoutOffset = delay.into();
         let message = serde_json::to_value(message)?;
         let headers = serde_json::to_value(headers)?;
@@ -600,7 +603,7 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<Vec<i64>, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let delay: VisibilityTimeoutOffset = delay.into();
         let messages = Self::serialize_list(messages)?;
         let headers = Self::serialize_optional_list(headers)?;
@@ -970,7 +973,7 @@ impl PGMQueueExt {
         qty: i32,
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let vt: VisibilityTimeoutOffset = vt.into();
         let rows = query
             .bind(queue_name)
@@ -996,7 +999,7 @@ impl PGMQueueExt {
         poll_interval: Option<std::time::Duration>,
         executor: E,
     ) -> Result<Vec<Message<T>>, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let vt: VisibilityTimeoutOffset = vt.into();
         let poll_timeout_s = poll_timeout.map_or(DEFAULT_POLL_TIMEOUT_S, |t| t.as_secs() as i32);
         let poll_interval_ms =
@@ -1036,7 +1039,7 @@ impl PGMQueueExt {
         msg_id: i64,
         executor: E,
     ) -> Result<bool, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let arch =
             sqlx::query("SELECT * from pgmq.archive(queue_name=>$1::text, msg_id=>$2::bigint)")
                 .bind(queue_name)
@@ -1058,7 +1061,7 @@ impl PGMQueueExt {
         msg_ids: &[i64],
         executor: E,
     ) -> Result<usize, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let qty =
             sqlx::query("SELECT * from pgmq.archive(queue_name=>$1::text, msg_ids=>$2::bigint[])")
                 .bind(queue_name)
@@ -1089,7 +1092,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<Option<Message<T>>, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let row = sqlx::query(r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.pop(queue_name=>$1::text)"#)
             .bind(queue_name)
             .fetch_optional(executor)
@@ -1119,6 +1122,7 @@ impl PGMQueueExt {
         msg_id: i64,
         executor: E,
     ) -> Result<bool, PgmqError> {
+        check_queue_name(queue_name)?;
         let row =
             sqlx::query("SELECT * from pgmq.delete(queue_name=>$1::text, msg_id=>$2::bigint)")
                 .bind(queue_name)
@@ -1140,6 +1144,7 @@ impl PGMQueueExt {
         msg_ids: &[i64],
         executor: E,
     ) -> Result<Vec<i64>, PgmqError> {
+        check_queue_name(queue_name)?;
         let deleted_msg_ids = sqlx::query_scalar(
             "SELECT * from pgmq.delete(queue_name=>$1::text, msg_ids=>$2::bigint[])",
         )
@@ -1166,6 +1171,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
+        check_queue_name(queue_name)?;
         sqlx::query("SELECT pgmq.create_fifo_index(queue_name=>$1::text);")
             .bind(queue_name)
             .execute(executor)
@@ -1204,7 +1210,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         sqlx::query("SELECT pgmq.bind_topic(pattern=>$1::text, queue_name=>$2::text)")
             .bind(pattern)
             .bind(queue_name)
@@ -1225,7 +1231,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         sqlx::query("SELECT pgmq.unbind_topic(pattern=>$1::text, queue_name=>$2::text)")
             .bind(pattern)
             .bind(queue_name)
@@ -1416,7 +1422,7 @@ impl PGMQueueExt {
         throttle_interval: std::time::Duration,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let throttle_interval_ms = i32::try_from(throttle_interval.as_millis()).unwrap_or(i32::MAX);
         sqlx::query("SELECT pgmq.enable_notify_insert(queue_name=>$1::text, throttle_interval_ms=>$2::integer)")
             .bind(queue_name)
@@ -1441,7 +1447,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         sqlx::query("SELECT pgmq.disable_notify_insert(queue_name=>$1::text)")
             .bind(queue_name)
             .execute(executor)
@@ -1461,7 +1467,7 @@ impl PGMQueueExt {
         throttle_interval: std::time::Duration,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let throttle_interval_ms = i32::try_from(throttle_interval.as_millis()).unwrap_or(i32::MAX);
         sqlx::query("SELECT pgmq.update_notify_insert(queue_name=>$1::text, throttle_interval_ms=>$2::integer)")
             .bind(queue_name)
@@ -1561,7 +1567,7 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<QueueMetrics, PgmqError> {
-        check_input(queue_name)?;
+        check_queue_name(queue_name)?;
         let metrics: QueueMetrics = sqlx::query_as("SELECT queue_name, queue_length, newest_msg_age_sec, oldest_msg_age_sec, total_messages, scrape_time, queue_visible_length FROM pgmq.metrics(queue_name=>$1::text)")
             .bind(queue_name)
             .fetch_one(executor)

--- a/pgmq-rs/src/types/mod.rs
+++ b/pgmq-rs/src/types/mod.rs
@@ -1,3 +1,5 @@
+pub mod queue_name;
+
 use serde::Deserialize;
 use sqlx::types::chrono::{DateTime, Utc};
 use sqlx::FromRow;

--- a/pgmq-rs/src/types/queue_name.rs
+++ b/pgmq-rs/src/types/queue_name.rs
@@ -1,0 +1,161 @@
+use constants::MAX_PGMQ_QUEUE_LEN;
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
+use thiserror::Error;
+
+/// Private module to contain constants used to calculate [`MAX_PGMQ_QUEUE_LEN`]. Intermediary
+/// constants are kept private to the module to ensure they are not referenced by accident.
+///
+/// Relevant docs: <https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS>
+mod constants {
+    /// Default value of `NAMEDATALEN`, set in `src/include/pg_config_manual.h`.
+    const NAMEDATALEN: usize = 64;
+
+    /// The maximum length of an identifier.
+    /// Longer names can be used in commands, but they'll be truncated.
+    const MAX_IDENTIFIER_LEN: usize = NAMEDATALEN - 1;
+
+    const BIGGEST_CONCAT: &str = "archived_at_idx_";
+
+    /// The max length of the name of a PGMQ queue, considering that the biggest postgres
+    /// identifier created by PGMQ is the index on archived_at.
+    pub(super) const MAX_PGMQ_QUEUE_LEN: usize = MAX_IDENTIFIER_LEN - BIGGEST_CONCAT.len();
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum QueueNameError {
+    #[error("Queue name `{0}` length must be >0 and <={MAX_PGMQ_QUEUE_LEN}")]
+    InvalidLength(String),
+
+    #[error("Queue name `{0}` contains invalid character(s)")]
+    InvalidCharacter(String),
+
+    #[error("Queue name is invalid: {0}")]
+    Other(String),
+}
+
+impl QueueNameError {
+    /// Construct [`QueueNameError::Other`] from the given error/message.
+    pub fn other(err: impl ToString) -> Self {
+        Self::Other(err.to_string())
+    }
+}
+
+/// A valid queue name.
+#[derive(Debug, Clone, Copy)]
+pub struct QueueName<'a>(&'a str);
+
+impl<'a> QueueName<'a> {
+    /// Create a new [`QueueName`], checking that the provided `queue_name` is valid.
+    pub fn new(queue_name: &'a str) -> Result<Self, QueueNameError> {
+        check_queue_name(queue_name)?;
+        Ok(Self(queue_name))
+    }
+}
+
+impl<'a> AsRef<&'a str> for QueueName<'a> {
+    fn as_ref(&self) -> &&'a str {
+        &self.0
+    }
+}
+
+impl<'a> Deref for QueueName<'a> {
+    type Target = &'a str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> TryFrom<&'a str> for QueueName<'a> {
+    type Error = QueueNameError;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        QueueName::new(value)
+    }
+}
+
+impl<'a> TryFrom<&'a String> for QueueName<'a> {
+    type Error = QueueNameError;
+
+    fn try_from(value: &'a String) -> Result<Self, Self::Error> {
+        QueueName::new(value)
+    }
+}
+
+impl<'a> Display for QueueName<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+/// Checks that the provided input is a valid queue name for usage with PGMQ.
+pub fn check_queue_name(input: &str) -> Result<(), QueueNameError> {
+    if input.is_empty() || input.len() > MAX_PGMQ_QUEUE_LEN {
+        return Err(QueueNameError::InvalidLength(input.to_string()));
+    }
+
+    let has_valid_characters = input
+        .as_bytes()
+        .iter()
+        .all(|&c| c.is_ascii_alphanumeric() || c == b'_');
+    if !has_valid_characters {
+        return Err(QueueNameError::InvalidCharacter(input.to_string()));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::constants::MAX_PGMQ_QUEUE_LEN;
+    use crate::types::queue_name::QueueName;
+    use rstest::rstest;
+    use std::assert_matches;
+
+    #[rstest]
+    #[case::single_character_alpha("a")]
+    #[case::single_character_numeric("0")]
+    #[case::single_character_underscore("_")]
+    #[case::alpha("valid")]
+    #[case::alphanumeric("valid2")]
+    #[case::alphanumeric_underscore("valid_3")]
+    #[case::max_length(std::iter::repeat_n("a", MAX_PGMQ_QUEUE_LEN).collect::<String>())]
+    fn valid_queue_name(#[case] name: impl ToString) {
+        let name = name.to_string();
+        let queue_name = QueueName::new(&name);
+        assert!(queue_name.is_ok());
+    }
+
+    #[rstest]
+    #[case::empty("")]
+    #[case::exceeds_maximum_length(std::iter::repeat_n("a", MAX_PGMQ_QUEUE_LEN + 1).collect::<String>())]
+    fn queue_name_invalid_length(#[case] name: impl ToString) {
+        let name = name.to_string();
+        let queue_name = QueueName::new(&name);
+        assert_matches!(queue_name, Err(super::QueueNameError::InvalidLength(_)));
+    }
+
+    #[rstest]
+    #[case("-")]
+    #[case(" ")]
+    #[case("&")]
+    #[case(".")]
+    #[case(",")]
+    #[case("/")]
+    #[case(";")]
+    #[case("#")]
+    #[case("(")]
+    #[case(")")]
+    #[case("`")]
+    #[case("~")]
+    #[case("\"")]
+    #[case("'")]
+    #[case("\n")]
+    fn queue_name_invalid_character(#[case] name: impl ToString) {
+        let name = name.to_string();
+        let queue_name = QueueName::new(&name);
+        assert_matches!(queue_name, Err(super::QueueNameError::InvalidCharacter(_)));
+    }
+}

--- a/pgmq-rs/src/util.rs
+++ b/pgmq-rs/src/util.rs
@@ -1,7 +1,4 @@
-use std::fmt::Display;
-
 use crate::errors::PgmqError;
-
 use log::LevelFilter;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::{ConnectOptions, Transaction};
@@ -31,62 +28,6 @@ pub async fn connect(url: &str, max_connections: u32) -> Result<Pool<Postgres>, 
         .connect_with(options)
         .await?;
     Ok(pgp)
-}
-
-/// A string that is known to be formed of only ASCII alphanumeric or an underscore;
-#[derive(Clone, Copy)]
-pub struct CheckedName<'a>(&'a str);
-
-impl<'a> CheckedName<'a> {
-    /// Accepts `input` as a CheckedName if it is a valid queue identifier
-    pub fn new(input: &'a str) -> Result<Self, PgmqError> {
-        check_input(input)?;
-
-        Ok(Self(input))
-    }
-}
-
-impl AsRef<str> for CheckedName<'_> {
-    fn as_ref(&self) -> &str {
-        self.0
-    }
-}
-
-impl Display for CheckedName<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
-}
-
-/// panics if input is invalid. otherwise does nothing.
-pub fn check_input(input: &str) -> Result<(), PgmqError> {
-    // Docs:
-    // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
-
-    // Default value of `NAMEDATALEN`, set in `src/include/pg_config_manual.h`
-    const NAMEDATALEN: usize = 64;
-
-    // The maximum length of an identifier.
-    // Longer names can be used in commands, but they'll be truncated
-    const MAX_IDENTIFIER_LEN: usize = NAMEDATALEN - 1;
-    const BIGGEST_CONCAT: &str = "archived_at_idx_";
-
-    // The max length of the name of a PGMQ queue, considering that the biggest
-    // postgres identifier created by PGMQ is the index on archived_at
-    const MAX_PGMQ_QUEUE_LEN: usize = MAX_IDENTIFIER_LEN - BIGGEST_CONCAT.len();
-
-    let is_short_enough = input.len() <= MAX_PGMQ_QUEUE_LEN;
-    let has_valid_characters = input
-        .as_bytes()
-        .iter()
-        .all(|&c| c.is_ascii_alphanumeric() || c == b'_');
-    let valid = is_short_enough && has_valid_characters;
-    match valid {
-        true => Ok(()),
-        false => Err(PgmqError::InvalidQueueName {
-            name: input.to_owned(),
-        }),
-    }
 }
 
 #[cfg(feature = "install-sql-github")]


### PR DESCRIPTION
Minor refactor of `CheckedName` struct and `check_input` function into `QueueName` struct and `check_queue_name` function.

- Place the new struct and method in the new `types/queue_name` module
- Create private sub-module to contain the `MAX_PGMQ_QUEUE_LEN` constant and the intermediary constants used to calculate its value
- Add missing calls to `check_queue_name` in `PGMQueueExt` methods
- Impl `AsRef` and `Deref` for `QueueName` to make it easy to use as a paramter in SQL commands with a simple deref (e.g., `*queue_name`)
- Define a new `QueueNameError` enum to provide more detailed error responses for invalid queue names
- Add dependency on `rstest`, a crate that provides macros to help with writing parameterized tests
- Add tests for the checks in `check_queue_name`, using `rstest` to help with testing multiple different inputs using shared test logic