### PR TITLE
feat!: Allow specifying the header type when reading a message

### DIFF
--- a/pgmq-rs/examples/basic.rs
+++ b/pgmq-rs/examples/basic.rs
@@ -51,9 +51,8 @@ async fn main() -> Result<(), PgmqError> {
 
     // Read the JSON message
     let received_json_message: Message<Value> = queue
-        .read::<Value>(&my_queue, visibility_timeout_seconds)
-        .await
-        .unwrap()
+        .read(&my_queue, visibility_timeout_seconds)
+        .await?
         .expect("No messages in the queue");
     println!("Received a message: {received_json_message:?}");
 
@@ -62,9 +61,8 @@ async fn main() -> Result<(), PgmqError> {
 
     // Read the struct message
     let received_struct_message: Message<MyMessage> = queue
-        .read::<MyMessage>(&my_queue, visibility_timeout_seconds)
-        .await
-        .unwrap()
+        .read(&my_queue, visibility_timeout_seconds)
+        .await?
         .expect("No messages in the queue");
     println!("Received a message: {received_struct_message:?}");
 
@@ -82,10 +80,8 @@ async fn main() -> Result<(), PgmqError> {
     println!("Deleted the messages from the queue");
 
     // No messages are remaining
-    let no_message: Option<Message<Value>> = queue
-        .read::<Value>(&my_queue, visibility_timeout_seconds)
-        .await
-        .unwrap();
+    let no_message: Option<Message<Value>> =
+        queue.read(&my_queue, visibility_timeout_seconds).await?;
     assert!(no_message.is_none());
 
     Ok(())

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -413,13 +413,14 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
         msg_id: i64,
         vt: impl Into<VisibilityTimeoutOffset>,
         executor: E,
-    ) -> Result<Message<T>, PgmqError> {
+    ) -> Result<Message<T, H>, PgmqError> {
         check_queue_name(queue_name)?;
         let vt: VisibilityTimeoutOffset = vt.into();
         // queue_name, created_at as "created_at: chrono::DateTime<Utc>", is_partitioned, is_unlogged
@@ -431,17 +432,17 @@ impl PGMQueueExt {
             .bind(vt)
             .fetch_one(executor)
             .await
-            .and_then(|row| Message::<T>::from_row(&row))?;
+            .and_then(|row| Message::<T, H>::from_row(&row))?;
 
         Ok(updated)
     }
     // Set the visibility time on an existing message.
-    pub async fn set_vt<T: for<'de> Deserialize<'de>>(
+    pub async fn set_vt<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
         msg_id: i64,
         vt: impl Into<VisibilityTimeoutOffset>,
-    ) -> Result<Message<T>, PgmqError> {
+    ) -> Result<Message<T, H>, PgmqError> {
         self.set_vt_with_cxn(queue_name, msg_id, vt, &self.connection)
             .await
     }
@@ -640,22 +641,23 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         executor: E,
-    ) -> Result<Option<Message<T>>, PgmqError> {
+    ) -> Result<Option<Message<T, H>>, PgmqError> {
         self.read_batch_with_cxn(queue_name, vt, 1, executor)
             .await
             .map(|result| result.into_iter().next())
     }
 
-    pub async fn read<T: for<'de> Deserialize<'de>>(
+    pub async fn read<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
-    ) -> Result<Option<Message<T>>, PgmqError> {
+    ) -> Result<Option<Message<T, H>>, PgmqError> {
         self.read_with_cxn(queue_name, vt, &self.connection).await
     }
 
@@ -663,13 +665,14 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         let query = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)"#,
         );
@@ -677,12 +680,12 @@ impl PGMQueueExt {
         Self::read_batch_common(query, queue_name, vt, qty, executor).await
     }
 
-    pub async fn read_batch<T: for<'de> Deserialize<'de>>(
+    pub async fn read_batch<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         self.read_batch_with_cxn(queue_name, vt, qty, &self.connection)
             .await
     }
@@ -691,6 +694,7 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
@@ -698,19 +702,19 @@ impl PGMQueueExt {
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
         executor: E,
-    ) -> Result<Option<Message<T>>, PgmqError> {
+    ) -> Result<Option<Message<T, H>>, PgmqError> {
         self.read_batch_with_poll_with_cxn(queue_name, vt, 1, poll_timeout, poll_interval, executor)
             .await
             .map(|result| result.into_iter().next())
     }
 
-    pub async fn read_with_poll<'c, T: for<'de> Deserialize<'de>>(
+    pub async fn read_with_poll<'c, T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
-    ) -> Result<Option<Message<T>>, PgmqError> {
+    ) -> Result<Option<Message<T, H>>, PgmqError> {
         self.read_with_poll_with_cxn(
             queue_name,
             vt,
@@ -725,6 +729,7 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
@@ -733,7 +738,7 @@ impl PGMQueueExt {
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         let query = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_with_poll(
                 queue_name=>$1::text,
@@ -756,14 +761,17 @@ impl PGMQueueExt {
         .await
     }
 
-    pub async fn read_batch_with_poll<T: for<'de> Deserialize<'de>>(
+    pub async fn read_batch_with_poll<
+        T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
+    >(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         max_batch_size: i32,
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         self.read_batch_with_poll_with_cxn(
             queue_name,
             vt,
@@ -779,24 +787,25 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
 
         Self::read_batch_common(query, queue_name, vt, qty, executor).await
     }
 
-    pub async fn read_grouped<T: for<'de> Deserialize<'de>>(
+    pub async fn read_grouped<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         self.read_grouped_with_cxn(queue_name, vt, qty, &self.connection)
             .await
     }
@@ -805,6 +814,7 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
@@ -813,7 +823,7 @@ impl PGMQueueExt {
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         let query = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_with_poll(
                 queue_name=>$1::text,
@@ -836,14 +846,17 @@ impl PGMQueueExt {
         .await
     }
 
-    pub async fn read_grouped_with_poll<T: for<'de> Deserialize<'de>>(
+    pub async fn read_grouped_with_poll<
+        T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
+    >(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         self.read_grouped_with_poll_with_cxn(
             queue_name,
             vt,
@@ -859,24 +872,25 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_head(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
 
         Self::read_batch_common(query, queue_name, vt, qty, executor).await
     }
 
-    pub async fn read_grouped_head<T: for<'de> Deserialize<'de>>(
+    pub async fn read_grouped_head<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         self.read_grouped_head_with_cxn(queue_name, vt, qty, &self.connection)
             .await
     }
@@ -885,24 +899,25 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         let query = sqlx::query("SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_rr(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer);");
 
         Self::read_batch_common(query, queue_name, vt, qty, executor).await
     }
 
-    pub async fn read_grouped_rr<T: for<'de> Deserialize<'de>>(
+    pub async fn read_grouped_rr<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         self.read_grouped_rr_with_cxn(queue_name, vt, qty, &self.connection)
             .await
     }
@@ -911,6 +926,7 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
@@ -919,7 +935,7 @@ impl PGMQueueExt {
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         let query = sqlx::query(
             r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.read_grouped_rr_with_poll(
                 queue_name=>$1::text,
@@ -942,14 +958,17 @@ impl PGMQueueExt {
         .await
     }
 
-    pub async fn read_grouped_rr_with_poll<T: for<'de> Deserialize<'de>>(
+    pub async fn read_grouped_rr_with_poll<
+        T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
+    >(
         &self,
         queue_name: &str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         self.read_grouped_rr_with_poll_with_cxn(
             queue_name,
             vt,
@@ -966,13 +985,14 @@ impl PGMQueueExt {
         'q,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         query: sqlx::query::Query<'q, Postgres, <Postgres as sqlx::Database>::Arguments>,
         queue_name: &'q str,
         vt: impl Into<VisibilityTimeoutOffset>,
         qty: i32,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         check_queue_name(queue_name)?;
         let vt: VisibilityTimeoutOffset = vt.into();
         let rows = query
@@ -990,6 +1010,7 @@ impl PGMQueueExt {
         'q,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         query: sqlx::query::Query<'q, Postgres, <Postgres as sqlx::Database>::Arguments>,
         queue_name: &'q str,
@@ -998,7 +1019,7 @@ impl PGMQueueExt {
         poll_timeout: Option<std::time::Duration>,
         poll_interval: Option<std::time::Duration>,
         executor: E,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         check_queue_name(queue_name)?;
         let vt: VisibilityTimeoutOffset = vt.into();
         let poll_timeout_s = poll_timeout.map_or(DEFAULT_POLL_TIMEOUT_S, |t| t.as_secs() as i32);
@@ -1022,14 +1043,14 @@ impl PGMQueueExt {
     /// to the `T` type parameter used in the `read*`/`read_batch*` methods, which
     /// would be a breaking change.
     // Todo: In a future SemVer-breaking release, replace this method using `query_as`
-    //  to directly parse the SQL query rows to `Vec<Message<T>`.
-    fn handle_read_batch_result<T: for<'de> Deserialize<'de>>(
+    //  to directly parse the SQL query rows to `Vec<Message<T, H>`.
+    fn handle_read_batch_result<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         rows: Vec<PgRow>,
-    ) -> Result<Vec<Message<T>>, PgmqError> {
+    ) -> Result<Vec<Message<T, H>>, PgmqError> {
         let messages = rows
             .into_iter()
-            .map(|row| Message::<T>::from_row(&row))
-            .collect::<Result<Vec<Message<T>>, _>>()?;
+            .map(|row| Message::<T, H>::from_row(&row))
+            .collect::<Result<Vec<Message<T, H>>, _>>()?;
         Ok(messages)
     }
 
@@ -1087,11 +1108,12 @@ impl PGMQueueExt {
         'c,
         E: sqlx::Executor<'c, Database = Postgres>,
         T: for<'de> Deserialize<'de>,
+        H: for<'de> Deserialize<'de>,
     >(
         &self,
         queue_name: &str,
         executor: E,
-    ) -> Result<Option<Message<T>>, PgmqError> {
+    ) -> Result<Option<Message<T, H>>, PgmqError> {
         check_queue_name(queue_name)?;
         let row = sqlx::query(r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.pop(queue_name=>$1::text)"#)
             .bind(queue_name)
@@ -1100,7 +1122,7 @@ impl PGMQueueExt {
         match row {
             Some(row) => {
                 // happy path - successfully read a message
-                Ok(Some(Message::<T>::from_row(&row)?))
+                Ok(Some(Message::<T, H>::from_row(&row)?))
             }
             None => {
                 // no message found
@@ -1109,10 +1131,10 @@ impl PGMQueueExt {
         }
     }
     // Read and message and immediately delete it.
-    pub async fn pop<T: for<'de> Deserialize<'de>>(
+    pub async fn pop<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
         &self,
         queue_name: &str,
-    ) -> Result<Option<Message<T>>, PgmqError> {
+    ) -> Result<Option<Message<T, H>>, PgmqError> {
         self.pop_with_cxn(queue_name, &self.connection).await
     }
 

--- a/pgmq-rs/tests/pg_ext_integration_test.rs
+++ b/pgmq-rs/tests/pg_ext_integration_test.rs
@@ -1,6 +1,7 @@
 use pgmq::pg_ext::VisibilityTimeoutOffset;
 use pgmq::types::{ARCHIVE_PREFIX, PGMQ_SCHEMA, QUEUE_PREFIX};
 use pgmq::util::connect;
+use pgmq::Message;
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use sqlx::{AssertSqlSafe, Pool, Postgres, Row};
@@ -156,8 +157,8 @@ async fn test_ext_send_read_delete_core<T: Into<VisibilityTimeoutOffset>>(
     let msg_id = queue.send(&test_queue, &msg).await.unwrap();
     assert!(msg_id >= 1);
 
-    let read_message = queue
-        .read::<MyMessage>(&test_queue, offset1)
+    let read_message: Option<Message<MyMessage>> = queue
+        .read(&test_queue, offset1)
         .await
         .expect("error reading message");
     assert!(read_message.is_some());
@@ -167,7 +168,7 @@ async fn test_ext_send_read_delete_core<T: Into<VisibilityTimeoutOffset>>(
 
     // read again, assert no messages visible
     let read_message = queue
-        .read::<MyMessage>(&test_queue, offset2)
+        .read::<MyMessage, ()>(&test_queue, offset2)
         .await
         .expect("error reading message");
     assert!(read_message.is_none());
@@ -175,7 +176,7 @@ async fn test_ext_send_read_delete_core<T: Into<VisibilityTimeoutOffset>>(
     // read with poll, blocks until message visible
     let start_poll = std::time::Instant::now();
     let read_with_poll = queue
-        .read_batch_with_poll::<MyMessage>(
+        .read_batch_with_poll::<MyMessage, ()>(
             &test_queue,
             offset3,
             1,
@@ -194,11 +195,11 @@ async fn test_ext_send_read_delete_core<T: Into<VisibilityTimeoutOffset>>(
 
     // change the VT to now
     let _vt_set = queue
-        .set_vt::<MyMessage>(&test_queue, msg_id, offset4)
+        .set_vt::<MyMessage, ()>(&test_queue, msg_id, offset4)
         .await
         .expect("failed to set VT");
     let read_message = queue
-        .read::<MyMessage>(&test_queue, offset5)
+        .read::<MyMessage, ()>(&test_queue, offset5)
         .await
         .expect("error reading message")
         .expect("expected a message");
@@ -288,14 +289,14 @@ async fn test_ext_send_delay_core(delay: impl Copy + Into<VisibilityTimeoutOffse
     queue.send_delay(&test_queue, &msg, delay).await.unwrap();
 
     // No messages are found due to visibility timeout
-    let no_messages = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let no_messages = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
     assert!(no_messages.is_none());
 
     // After the delay, message is found
     let duration: VisibilityTimeoutOffset = delay.into();
     tokio::time::sleep(Duration::from_secs(duration.as_seconds() as u64)).await;
 
-    let one_messages = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let one_messages = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
     assert!(one_messages.is_some());
 }
 
@@ -350,10 +351,10 @@ async fn test_ext_send_batch() {
     assert_eq!(3, msg_ids.len());
 
     let vt = 4;
-    let msg1 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
-    let msg2 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
-    let msg3 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
-    let msg4 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg1 = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
+    let msg2 = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
+    let msg3 = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
+    let msg4 = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
     assert!(msg1.is_some());
     assert!(msg2.is_some());
     assert!(msg3.is_some());
@@ -370,7 +371,7 @@ async fn test_ext_send_batch_read_batch() {
 
     let vt = 4;
     let msgs_read = queue
-        .read_batch::<MyMessage>(&test_queue, vt, 1)
+        .read_batch::<MyMessage, ()>(&test_queue, vt, 1)
         .await
         .unwrap();
     assert!(msgs_read.is_empty());
@@ -384,19 +385,19 @@ async fn test_ext_send_batch_read_batch() {
     assert_eq!(3, msg_ids.len());
 
     let msgs_read = queue
-        .read_batch::<MyMessage>(&test_queue, vt, (msgs_sent.len() as i32) - 1)
+        .read_batch::<MyMessage, ()>(&test_queue, vt, (msgs_sent.len() as i32) - 1)
         .await
         .expect("Should successfully read a batch of messages");
     assert_eq!(msgs_sent.len() - 1, msgs_read.len());
 
     let msgs_read = queue
-        .read_batch::<MyMessage>(&test_queue, vt, 1)
+        .read_batch::<MyMessage, ()>(&test_queue, vt, 1)
         .await
         .unwrap();
     assert_eq!(1, msgs_read.len());
 
     let msgs_read = queue
-        .read_batch::<MyMessage>(&test_queue, vt, 1)
+        .read_batch::<MyMessage, ()>(&test_queue, vt, 1)
         .await
         .unwrap();
     assert!(msgs_read.is_empty());
@@ -411,7 +412,7 @@ async fn test_ext_read_with_poll() {
     let queue = init_queue_ext(&test_queue).await;
 
     let vt = 4;
-    let msg = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
     assert!(msg.is_none());
 
     let msgs_sent = [
@@ -423,13 +424,13 @@ async fn test_ext_read_with_poll() {
     assert_eq!(3, msg_ids.len());
 
     let msg = queue
-        .read_with_poll::<MyMessage>(&test_queue, vt, Some(Duration::from_secs(1)), None)
+        .read_with_poll::<MyMessage, ()>(&test_queue, vt, Some(Duration::from_secs(1)), None)
         .await
         .unwrap();
     assert!(msg.is_some());
 
     let msgs_read = queue
-        .read_batch::<MyMessage>(&test_queue, vt, msgs_sent.len() as i32)
+        .read_batch::<MyMessage, ()>(&test_queue, vt, msgs_sent.len() as i32)
         .await
         .unwrap();
     assert_eq!(msgs_sent.len() - 1, msgs_read.len());
@@ -446,7 +447,13 @@ async fn test_ext_read_batch_with_poll_empty_queue() {
     let vt = 4;
 
     let msg_read = queue
-        .read_batch_with_poll::<MyMessage>(&test_queue, vt, 1, Some(Duration::from_secs(1)), None)
+        .read_batch_with_poll::<MyMessage, ()>(
+            &test_queue,
+            vt,
+            1,
+            Some(Duration::from_secs(1)),
+            None,
+        )
         .await
         .unwrap();
     assert!(msg_read.is_empty());
@@ -463,7 +470,7 @@ async fn test_ext_read_with_poll_empty_queue() {
     let vt = 4;
 
     let msg = queue
-        .read_with_poll::<MyMessage>(&test_queue, vt, Some(Duration::from_secs(1)), None)
+        .read_with_poll::<MyMessage, ()>(&test_queue, vt, Some(Duration::from_secs(1)), None)
         .await
         .unwrap();
     assert!(msg.is_none());
@@ -488,17 +495,17 @@ async fn test_ext_send_batch_delay_core(delay: impl Copy + Into<VisibilityTimeou
 
     // No messages are found due to visibility timeout
     let vt = 4;
-    let no_messages = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let no_messages = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
     assert!(no_messages.is_none());
 
     // After the delay, messages are found
     let duration: VisibilityTimeoutOffset = delay.into();
     tokio::time::sleep(Duration::from_secs(duration.as_seconds() as u64)).await;
 
-    let msg1 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
-    let msg2 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
-    let msg3 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
-    let msg4 = queue.read::<MyMessage>(&test_queue, vt).await.unwrap();
+    let msg1 = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
+    let msg2 = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
+    let msg3 = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
+    let msg4 = queue.read::<MyMessage, ()>(&test_queue, vt).await.unwrap();
     assert!(msg1.is_some());
     assert!(msg2.is_some());
     assert!(msg3.is_some());
@@ -549,7 +556,7 @@ async fn test_ext_send_pop() {
     let _ = queue.send(&test_queue, &msg).await.unwrap();
 
     let popped = queue
-        .pop::<MyMessage>(&test_queue)
+        .pop::<MyMessage, ()>(&test_queue)
         .await
         .expect("failed to pop")
         .expect("no message to pop");
@@ -904,13 +911,13 @@ async fn test_read_grouped_default_group() {
 
     {
         let read_msg1 = queue
-            .read_grouped::<MyMessage>(&test_queue, 100, 1)
+            .read_grouped::<MyMessage, ()>(&test_queue, 100, 1)
             .await
             .unwrap()
             .into_iter()
             .next();
         let read_msg2 = queue
-            .read_grouped::<MyMessage>(&test_queue, 100, 1)
+            .read_grouped::<MyMessage, ()>(&test_queue, 100, 1)
             .await
             .unwrap()
             .into_iter()
@@ -922,7 +929,7 @@ async fn test_read_grouped_default_group() {
     {
         queue.archive(&test_queue, id1).await.unwrap();
         let read_msg2 = queue
-            .read_grouped::<MyMessage>(&test_queue, 100, 1)
+            .read_grouped::<MyMessage, ()>(&test_queue, 100, 1)
             .await
             .unwrap()
             .into_iter()
@@ -945,7 +952,7 @@ async fn test_read_grouped_default_group_many() {
     queue.send(&test_queue, &msg2).await.unwrap();
 
     let read_msgs = queue
-        .read_grouped::<MyMessage>(&test_queue, 100, 2)
+        .read_grouped::<MyMessage, ()>(&test_queue, 100, 2)
         .await
         .unwrap();
     assert_eq!(2, read_msgs.len());
@@ -984,13 +991,13 @@ async fn test_read_grouped_custom_group() {
         .unwrap();
 
     let read_msg1 = queue
-        .read_grouped::<MyMessage>(&test_queue, 100, 1)
+        .read_grouped::<MyMessage, serde_json::Value>(&test_queue, 100, 1)
         .await
         .unwrap()
         .into_iter()
         .next();
     let read_msg2 = queue
-        .read_grouped::<MyMessage>(&test_queue, 100, 1)
+        .read_grouped::<MyMessage, serde_json::Value>(&test_queue, 100, 1)
         .await
         .unwrap()
         .into_iter()
@@ -1046,7 +1053,7 @@ async fn test_read_grouped_rr_diff_groups() {
         .unwrap();
 
     let read_msgs = queue
-        .read_grouped_rr::<MyMessage>(&test_queue, 100, 2)
+        .read_grouped_rr::<MyMessage, serde_json::Value>(&test_queue, 100, 2)
         .await
         .unwrap();
     assert_eq!(2, read_msgs.len());
@@ -1056,7 +1063,7 @@ async fn test_read_grouped_rr_diff_groups() {
     );
 
     let read_msgs2 = queue
-        .read_grouped_rr::<MyMessage>(&test_queue, 100, 2)
+        .read_grouped_rr::<MyMessage, serde_json::Value>(&test_queue, 100, 2)
         .await
         .unwrap();
     assert!(read_msgs2.is_empty(), "The second message in each group should not become available until the first message has been processed");
@@ -1070,7 +1077,7 @@ async fn test_read_grouped_rr_diff_groups() {
         .unwrap();
 
     let read_msgs = queue
-        .read_grouped_rr::<MyMessage>(&test_queue, 100, 2)
+        .read_grouped_rr::<MyMessage, serde_json::Value>(&test_queue, 100, 2)
         .await
         .unwrap();
     assert_eq!(2, read_msgs.len());
@@ -1127,7 +1134,7 @@ async fn test_read_grouped_head_diff_groups() {
         .unwrap();
 
     let read_msgs = queue
-        .read_grouped_head::<MyMessage>(&test_queue, 100, 2)
+        .read_grouped_head::<MyMessage, serde_json::Value>(&test_queue, 100, 2)
         .await
         .unwrap();
     assert_eq!(2, read_msgs.len());
@@ -1137,7 +1144,7 @@ async fn test_read_grouped_head_diff_groups() {
     );
 
     let read_msgs2 = queue
-        .read_grouped_head::<MyMessage>(&test_queue, 100, 2)
+        .read_grouped_head::<MyMessage, serde_json::Value>(&test_queue, 100, 2)
         .await
         .unwrap();
     assert!(read_msgs2.is_empty(), "The second message in each group should not become available until the first message has been processed");
@@ -1151,7 +1158,7 @@ async fn test_read_grouped_head_diff_groups() {
         .unwrap();
 
     let read_msgs = queue
-        .read_grouped_head::<MyMessage>(&test_queue, 100, 2)
+        .read_grouped_head::<MyMessage, serde_json::Value>(&test_queue, 100, 2)
         .await
         .unwrap();
     assert_eq!(2, read_msgs.len());
@@ -1194,7 +1201,7 @@ async fn test_read_grouped_with_poll() {
         .unwrap();
 
     let read_msgs = queue
-        .read_grouped_with_poll::<MyMessage>(
+        .read_grouped_with_poll::<MyMessage, serde_json::Value>(
             &test_queue,
             100,
             2,
@@ -1243,7 +1250,7 @@ async fn test_read_grouped_rr_with_poll() {
         .unwrap();
 
     let read_msgs = queue
-        .read_grouped_rr_with_poll::<MyMessage>(
+        .read_grouped_rr_with_poll::<MyMessage, serde_json::Value>(
             &test_queue,
             100,
             2,
@@ -1340,7 +1347,7 @@ async fn test_send_topic() {
         .unwrap();
     assert_eq!(1, matched_queues);
 
-    let read_msg = queue.read::<MyMessage>(&test_queue, 100).await.unwrap();
+    let read_msg = queue.read::<MyMessage, ()>(&test_queue, 100).await.unwrap();
     assert!(read_msg.is_some());
 }
 
@@ -1368,7 +1375,7 @@ async fn test_send_batch_topic() {
     assert_eq!(msgs.len(), send_batch_rows.len());
 
     let read_msgs = queue
-        .read_batch::<MyMessage>(&test_queue, 100, 2)
+        .read_batch::<MyMessage, ()>(&test_queue, 100, 2)
         .await
         .unwrap();
     assert_eq!(msgs.len(), read_msgs.len());
@@ -1520,7 +1527,7 @@ async fn test_metrics() {
     ];
     queue.send_batch(&test_queue, &messages).await.unwrap();
 
-    let _ = queue.read::<MyMessage>(&test_queue, 100).await.unwrap();
+    let _ = queue.read::<MyMessage, ()>(&test_queue, 100).await.unwrap();
 
     let metrics = queue.metrics(&test_queue).await.unwrap();
     assert_eq!(test_queue, metrics.queue_name);
@@ -1541,7 +1548,7 @@ async fn test_metrics_all() {
     ];
     queue.send_batch(&test_queue, &messages).await.unwrap();
 
-    let _ = queue.read::<MyMessage>(&test_queue, 100).await.unwrap();
+    let _ = queue.read::<MyMessage, ()>(&test_queue, 100).await.unwrap();
 
     let metrics = queue
         .metrics_all()

--- a/pgmq-rs/tests/test_sql.rs
+++ b/pgmq-rs/tests/test_sql.rs
@@ -1,3 +1,4 @@
+use pgmq::Message;
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
 
@@ -42,15 +43,11 @@ async fn test_sql_lifecycle() {
 
     let sent_msg = MyMessage::default();
     let msg_id = queue.send(&test_queue, &sent_msg).await.unwrap();
-    let read_msg = queue
-        .read::<MyMessage>(&test_queue, 30)
-        .await
-        .unwrap()
-        .unwrap();
+    let read_msg: Message<MyMessage> = queue.read(&test_queue, 30).await.unwrap().unwrap();
     assert_eq!(msg_id, read_msg.msg_id);
     assert_eq!(sent_msg, read_msg.message);
     queue.archive(&test_queue, msg_id).await.unwrap();
-    let read_none = queue.read::<MyMessage>(&test_queue, 30).await.unwrap();
+    let read_none: Option<Message<MyMessage>> = queue.read(&test_queue, 30).await.unwrap();
     assert!(read_none.is_none());
 }
 


### PR DESCRIPTION
We recently added the ability to fetch headers when reading a message from the queue. However, we didn't allow specifying the type to deserialize the headers as and instead just defaulted to `serde_json::Value`. This PR adds the ability to specify the header type.