### PR TITLE
feat: Add `Queue#delete` method and implement for all sql drivers

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1115,14 +1115,9 @@ impl PGMQueueExt {
         msg_id: i64,
         executor: E,
     ) -> Result<bool, PgmqError> {
-        check_queue_name(queue_name)?;
-        let row =
-            sqlx::query("SELECT * from pgmq.delete(queue_name=>$1::text, msg_id=>$2::bigint)")
-                .bind(queue_name)
-                .bind(msg_id)
-                .fetch_one(executor)
-                .await?;
-        Ok(row.try_get("delete")?)
+        self.delete_batch_with_cxn(queue_name, &[msg_id], executor)
+            .await
+            .map(|deleted| !deleted.is_empty())
     }
 
     // Delete a message by message id.
@@ -1137,16 +1132,8 @@ impl PGMQueueExt {
         msg_ids: &[i64],
         executor: E,
     ) -> Result<Vec<i64>, PgmqError> {
-        check_queue_name(queue_name)?;
-        let deleted_msg_ids = sqlx::query_scalar(
-            "SELECT * from pgmq.delete(queue_name=>$1::text, msg_ids=>$2::bigint[])",
-        )
-        .bind(queue_name)
-        .bind(msg_ids)
-        .fetch_all(executor)
-        .await?;
-
-        Ok(deleted_msg_ids)
+        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
+        crate::queue::sqlx::delete(executor, queue_name, msg_ids).await
     }
 
     // Delete with a slice of message ids

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -84,6 +84,20 @@ macro_rules! diesel_functions {
             let archived = $transform_result!(archived)?;
             Ok(archived)
         }
+
+        async fn delete<C>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            msg_ids: &[i64],
+        ) -> Result<Vec<i64>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let deleted = crate::queue::diesel::query::delete_query(queue_name, msg_ids)
+                .get_results(executor);
+            let deleted = $transform_result!(deleted)?;
+            Ok(deleted)
+        }
     };
 }
 pub(crate) use diesel_functions;

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -1,5 +1,5 @@
 //! Extracted Diesel SQL query functions. Can be used by both diesel and diesel-async.
-use crate::queue::diesel::sql::{pgmq_archive, pgmq_create, pgmq_read, pgmq_send};
+use crate::queue::diesel::sql::{pgmq_archive, pgmq_create, pgmq_delete, pgmq_read, pgmq_send};
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
 
@@ -36,4 +36,10 @@ pub fn read_query(
 pub fn archive_query<'q, 'm>(queue_name: QueueName<'q>, msg_ids: &'m [i64]) -> _ {
     let queue_name: &'q str = *queue_name;
     select(pgmq_archive(queue_name, msg_ids))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn delete_query<'q, 'm>(queue_name: QueueName<'q>, msg_ids: &'m [i64]) -> _ {
+    let queue_name: &'q str = *queue_name;
+    select(pgmq_delete(queue_name, msg_ids))
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -72,4 +72,7 @@ extern "SQL" {
 
     #[sql_name = "pgmq.archive"]
     fn pgmq_archive(queue_name: Text, msg_ids: Array<BigInt>) -> BigInt;
+
+    #[sql_name = "pgmq.delete"]
+    fn pgmq_delete(queue_name: Text, msg_ids: Array<BigInt>) -> BigInt;
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -155,6 +155,21 @@ macro_rules! impl_queue {
                     .map_err(crate::types::queue_name::QueueNameError::other)?;
                 archive($transform_self!(self), queue_name, msg_ids).await
             }
+
+            async fn delete<'q, Q, QE>(
+                self,
+                queue_name: Q,
+                msg_ids: &[i64],
+            ) -> Result<Vec<i64>, crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: ToString,
+            {
+                let queue_name = queue_name
+                    .try_into()
+                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                delete($transform_self!(self), queue_name, msg_ids).await
+            }
         }
     };
 }

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -64,4 +64,9 @@ pub trait Queue: crate::private::Sealed {
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: ToString;
+
+    async fn delete<'q, Q, QE>(self, queue_name: Q, msg_ids: &[i64]) -> Result<Vec<i64>, PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: ToString;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -126,6 +126,27 @@ macro_rules! rust_postgres_functions {
                 .collect::<Result<Vec<i64>, _>>()?;
             Ok(rows)
         }
+
+        async fn delete<C>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            msg_ids: &[i64],
+        ) -> Result<Vec<i64>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&*queue_name, postgres_types::Type::TEXT),
+                (&msg_ids, postgres_types::Type::INT8_ARRAY),
+            ];
+            let rows = executor.query_typed(crate::queue::sql::DELETE, &params);
+            let rows = $transform_result!(rows)?;
+            let rows = rows
+                .into_iter()
+                .map(|row| row.try_get(0))
+                .collect::<Result<Vec<i64>, _>>()?;
+            Ok(rows)
+        }
     };
 }
 pub(crate) use rust_postgres_functions;

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -14,3 +14,6 @@ pub const READ: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, m
 
 // language=PostgreSQL
 pub const ARCHIVE: &str = "SELECT * from pgmq.archive(queue_name=>$1::text, msg_ids=>$2::bigint[])";
+
+// language=PostgreSQL
+pub const DELETE: &str = "SELECT * from pgmq.delete(queue_name=>$1::text, msg_ids=>$2::bigint[])";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -1,5 +1,5 @@
 use crate::queue::macros::{identity_macro, impl_queue};
-use crate::queue::sql::{ARCHIVE, CREATE, READ, SEND};
+use crate::queue::sql::{ARCHIVE, CREATE, DELETE, READ, SEND};
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use crate::{Message, PgmqError};
 use sqlx::{Executor, Postgres};
@@ -90,4 +90,20 @@ where
         .fetch_all(executor)
         .await?;
     Ok(archived)
+}
+
+pub(crate) async fn delete<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    msg_ids: &[i64],
+) -> Result<Vec<i64>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let deleted: Vec<i64> = sqlx::query_scalar(DELETE)
+        .bind(*queue_name)
+        .bind(msg_ids)
+        .fetch_all(executor)
+        .await?;
+    Ok(deleted)
 }

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -270,3 +270,25 @@ async fn archive(conn_details: ConnDetails, queue: impl Queue) {
         "Attempting to read after archiving the message should return nothing"
     );
 }
+
+#[pgmq_test_macro::queue_test]
+async fn delete(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let msg_id1 = queue.send(QUEUE, TestMessage::new(), (), 0).await.unwrap();
+    let msg_id2 = queue.send(QUEUE, TestMessage::new(), (), 0).await.unwrap();
+
+    let deleted = queue.delete(QUEUE, &[msg_id1, msg_id2]).await.unwrap();
+    assert_eq!(deleted, [msg_id1, msg_id2]);
+
+    let deleted = queue.delete(QUEUE, &[msg_id1]).await.unwrap();
+    assert!(
+        deleted.is_empty(),
+        "Attempting to delete a message that was already deleted should return `false`"
+    );
+
+    let read_msg: Vec<Message<TestMessage>> = queue.read(QUEUE, 10, 1).await.unwrap();
+    assert!(
+        read_msg.is_empty(),
+        "Attempting to read after deleting the message should return nothing"
+    );
+}


### PR DESCRIPTION
This PR adds the `archive` method to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres). Use the sqlx implementation to implement `PGMQueueExt#delete_batch`.

Relates to https://github.com/pgmq/pgmq/issues/425