### PR TITLE
feat: Add `Queue#set_vt` method and implement for all sql drivers

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -432,21 +432,12 @@ impl PGMQueueExt {
         msg_id: i64,
         vt: impl Into<VisibilityTimeoutOffset>,
         executor: E,
-    ) -> Result<Message<T, H>, PgmqError> {
-        check_queue_name(queue_name)?;
+    ) -> Result<Option<Message<T, H>>, PgmqError> {
+        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
         let vt: VisibilityTimeoutOffset = vt.into();
-        // queue_name, created_at as "created_at: chrono::DateTime<Utc>", is_partitioned, is_unlogged
-        let updated = sqlx::query(
-            r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.set_vt(queue_name=>$1::text, msg_id=>$2::bigint, vt=>$3::integer);"#
-        )
-            .bind(queue_name)
-            .bind(msg_id)
-            .bind(vt)
-            .fetch_one(executor)
+        crate::queue::sqlx::set_vt(executor, queue_name, &[msg_id], vt)
             .await
-            .and_then(|row| Message::<T, H>::from_row(&row))?;
-
-        Ok(updated)
+            .map(|msgs| msgs.into_iter().next())
     }
     // Set the visibility time on an existing message.
     pub async fn set_vt<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
@@ -454,7 +445,7 @@ impl PGMQueueExt {
         queue_name: &str,
         msg_id: i64,
         vt: impl Into<VisibilityTimeoutOffset>,
-    ) -> Result<Message<T, H>, PgmqError> {
+    ) -> Result<Option<Message<T, H>>, PgmqError> {
         self.set_vt_with_cxn(queue_name, msg_id, vt, &self.connection)
             .await
     }

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -58,7 +58,7 @@ macro_rules! diesel_functions {
             queue_name: crate::types::QueueName<'_>,
             visibility_timeout: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset,
             quantity: i32,
-        ) -> Result<Vec<crate::types::Message<T, H>>, crate::PgmqError>
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
         where
             C: $executor_trait,
             T: 'static + Send + for<'de> serde::Deserialize<'de>,
@@ -97,6 +97,24 @@ macro_rules! diesel_functions {
                 .get_results(executor);
             let deleted = $transform_result!(deleted)?;
             Ok(deleted)
+        }
+
+        async fn set_vt<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            msg_ids: &'_ [i64],
+            visibility_timeout: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages =
+                crate::queue::diesel::query::set_vt_query(queue_name, msg_ids, visibility_timeout)
+                    .get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
         }
     };
 }

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -1,5 +1,7 @@
 //! Extracted Diesel SQL query functions. Can be used by both diesel and diesel-async.
-use crate::queue::diesel::sql::{pgmq_archive, pgmq_create, pgmq_delete, pgmq_read, pgmq_send};
+use crate::queue::diesel::sql::{
+    pgmq_archive, pgmq_create, pgmq_delete, pgmq_read, pgmq_send, pgmq_set_vt,
+};
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
 
@@ -42,4 +44,15 @@ pub fn archive_query<'q, 'm>(queue_name: QueueName<'q>, msg_ids: &'m [i64]) -> _
 pub fn delete_query<'q, 'm>(queue_name: QueueName<'q>, msg_ids: &'m [i64]) -> _ {
     let queue_name: &'q str = *queue_name;
     select(pgmq_delete(queue_name, msg_ids))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn set_vt_query<'q, 'm>(
+    queue_name: QueueName<'q>,
+    msg_ids: &'m [i64],
+    visibility_timeout: VisibilityTimeoutOffset,
+) -> _ {
+    let queue_name: &'q str = *queue_name;
+    let visibility_timeout: i32 = *visibility_timeout;
+    select(pgmq_set_vt(queue_name, msg_ids, visibility_timeout))
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -25,7 +25,7 @@ type PgMessage = diesel::sql_types::Record<(
     Nullable<Jsonb>,
 )>;
 
-impl<T, H> FromSql<PgMessage, Pg> for crate::types::Message<T, H>
+impl<T, H> FromSql<PgMessage, Pg> for crate::Message<T, H>
 where
     T: for<'de> serde::Deserialize<'de>,
     H: for<'de> serde::Deserialize<'de>,
@@ -75,4 +75,7 @@ extern "SQL" {
 
     #[sql_name = "pgmq.delete"]
     fn pgmq_delete(queue_name: Text, msg_ids: Array<BigInt>) -> BigInt;
+
+    #[sql_name = "pgmq.set_vt"]
+    fn pgmq_set_vt(queue_name: Text, msg_ids: Array<BigInt>, vt: Integer) -> PgMessage;
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -119,7 +119,7 @@ macro_rules! impl_queue {
                 queue_name: Q,
                 visibility_timeout: VT,
                 quantity: i32,
-            ) -> Result<Vec<crate::types::Message<T, H>>, crate::PgmqError>
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
             where
                 T: 'static + Send + for<'de> serde::Deserialize<'de>,
                 H: 'static + Send + for<'de> serde::Deserialize<'de>,
@@ -169,6 +169,33 @@ macro_rules! impl_queue {
                     .try_into()
                     .map_err(crate::types::queue_name::QueueNameError::other)?;
                 delete($transform_self!(self), queue_name, msg_ids).await
+            }
+
+            async fn set_vt<'q, T, H, Q, QE, VT>(
+                self,
+                queue_name: Q,
+                msg_ids: &[i64],
+                visibility_timeout: VT,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: ToString,
+                VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
+            {
+                let queue_name = queue_name
+                    .try_into()
+                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let visibility_timeout: crate::types::VisibilityTimeoutOffset =
+                    visibility_timeout.into();
+                set_vt(
+                    $transform_self!(self),
+                    queue_name,
+                    msg_ids,
+                    visibility_timeout,
+                )
+                .await
             }
         }
     };

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -48,7 +48,7 @@ pub trait Queue: crate::private::Sealed {
         queue_name: Q,
         visibility_timeout: VT,
         quantity: i32,
-    ) -> Result<Vec<crate::types::Message<T, H>>, PgmqError>
+    ) -> Result<Vec<crate::Message<T, H>>, PgmqError>
     where
         T: 'static + Send + for<'de> serde::Deserialize<'de>,
         H: 'static + Send + for<'de> serde::Deserialize<'de>,
@@ -69,4 +69,17 @@ pub trait Queue: crate::private::Sealed {
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: ToString;
+
+    async fn set_vt<'q, T, H, Q, QE, VT>(
+        self,
+        queue_name: Q,
+        msg_ids: &[i64],
+        visibility_timeout: VT,
+    ) -> Result<Vec<crate::Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: ToString,
+        VT: Send + Into<VisibilityTimeoutOffset>;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -3,7 +3,7 @@ pub mod postgres;
 #[cfg(feature = "tokio-postgres")]
 pub mod tokio_postgres;
 
-impl<T, H> TryFrom<::tokio_postgres::Row> for crate::types::Message<T, H>
+impl<T, H> TryFrom<::tokio_postgres::Row> for crate::Message<T, H>
 where
     T: for<'de> serde::Deserialize<'de>,
     H: for<'de> serde::Deserialize<'de>,
@@ -91,8 +91,8 @@ macro_rules! rust_postgres_functions {
         ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
         where
             C: $executor_trait,
-            T: Send + for<'de> serde::Deserialize<'de>,
-            H: Send + for<'de> serde::Deserialize<'de>,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
         {
             let params: [crate::queue::rust_postgres::SqlParam; _] = [
                 (&*queue_name, postgres_types::Type::TEXT),
@@ -146,6 +146,29 @@ macro_rules! rust_postgres_functions {
                 .map(|row| row.try_get(0))
                 .collect::<Result<Vec<i64>, _>>()?;
             Ok(rows)
+        }
+
+        async fn set_vt<'c, C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            msg_ids: &[i64],
+            visibility_timeout: crate::types::VisibilityTimeoutOffset,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&*queue_name, postgres_types::Type::TEXT),
+                (&msg_ids, postgres_types::Type::INT8_ARRAY),
+                (&*visibility_timeout, postgres_types::Type::INT4),
+            ];
+            let rows = executor.query_typed(crate::queue::sql::SET_VT, &params);
+            let rows = $transform_result!(rows)?;
+            rows.into_iter()
+                .map(|row| crate::Message::<T, H>::try_from(row))
+                .collect::<Result<Vec<crate::Message<T, H>>, crate::PgmqError>>()
         }
     };
 }

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -17,3 +17,6 @@ pub const ARCHIVE: &str = "SELECT * from pgmq.archive(queue_name=>$1::text, msg_
 
 // language=PostgreSQL
 pub const DELETE: &str = "SELECT * from pgmq.delete(queue_name=>$1::text, msg_ids=>$2::bigint[])";
+
+// language=PostgreSQL
+pub const SET_VT: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.set_vt(queue_name=>$1::text, msg_ids=>$2::bigint[], vt=>$3::integer)";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -1,5 +1,5 @@
 use crate::queue::macros::{identity_macro, impl_queue};
-use crate::queue::sql::{ARCHIVE, CREATE, DELETE, READ, SEND};
+use crate::queue::sql::{ARCHIVE, CREATE, DELETE, READ, SEND, SET_VT};
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use crate::{Message, PgmqError};
 use sqlx::{Executor, Postgres};
@@ -62,8 +62,8 @@ async fn read<'c, C, T, H>(
 ) -> Result<Vec<Message<T, H>>, PgmqError>
 where
     C: Executor<'c, Database = Postgres>,
-    T: Send + for<'de> serde::Deserialize<'de>,
-    H: Send + for<'de> serde::Deserialize<'de>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
 {
     let query = sqlx::query(READ);
     let rows = query
@@ -106,4 +106,25 @@ where
         .fetch_all(executor)
         .await?;
     Ok(deleted)
+}
+
+pub(crate) async fn set_vt<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    msg_ids: &[i64],
+    visibility_timeout: VisibilityTimeoutOffset,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    let rows = sqlx::query(SET_VT)
+        .bind(*queue_name)
+        .bind(msg_ids)
+        .bind(visibility_timeout)
+        .fetch_all(executor)
+        .await?;
+
+    handle_read_batch_result(rows)
 }

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -15,6 +15,7 @@ use pgmq::Message;
 use rand::RngExt;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
+use std::time::Duration;
 
 static QUEUE: &str = "queue";
 
@@ -290,5 +291,39 @@ async fn delete(conn_details: ConnDetails, queue: impl Queue) {
     assert!(
         read_msg.is_empty(),
         "Attempting to read after deleting the message should return nothing"
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn set_vt(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let msg_id1 = queue.send(QUEUE, TestMessage::new(), (), 0).await.unwrap();
+    let msg_id2 = queue.send(QUEUE, TestMessage::new(), (), 0).await.unwrap();
+
+    let duration = 5;
+
+    let vt_updated: Vec<Message<TestMessage>> = queue
+        .set_vt(QUEUE, &[msg_id1, msg_id2], duration)
+        .await
+        .unwrap();
+    let vt_updated = vt_updated
+        .into_iter()
+        .map(|msg| msg.msg_id)
+        .collect::<Vec<i64>>();
+    assert_eq!(vt_updated, [msg_id1, msg_id2]);
+
+    let read_msgs: Vec<Message<TestMessage>> = queue.read(QUEUE, 10, 2).await.unwrap();
+    assert!(
+        read_msgs.is_empty(),
+        "Attempting to read messages with updated vt should return nothing"
+    );
+
+    tokio::time::sleep(Duration::from_secs((duration + 1) as u64)).await;
+
+    let read_msgs: Vec<Message<TestMessage>> = queue.read(QUEUE, 10, 2).await.unwrap();
+    assert_eq!(
+        read_msgs.len(),
+        2,
+        "Attempting to read messages with updated vt after sleeping should return the messages"
     );
 }


### PR DESCRIPTION
This PR adds the `set_vt` method to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres).

This PR also updates `PGMQueueExt#set_vt` to use the sqlx implementation of `Queue`. This required changing the return type to `Option<Message<T, H>>` instead of `Message<T, H>`. If we don't want to change this return type, I can undo this part of the change.

Relates to https://github.com/pgmq/pgmq/issues/425