### PR TITLE
feat: Add `Queue#send_batch` method and implement for all sql drivers

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -8,7 +8,7 @@ use crate::types::{
     SendBatchTopicRow, QUEUE_PREFIX,
 };
 use crate::types::{QueueName, VisibilityTimeoutOffset};
-use crate::util::connect;
+use crate::util::{connect, serialize_list, serialize_optional_list};
 use log::info;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, Pool, Postgres, Row};
@@ -598,20 +598,11 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<Vec<i64>, PgmqError> {
-        check_queue_name(queue_name)?;
+        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
         let delay: VisibilityTimeoutOffset = delay.into();
-        let messages = Self::serialize_list(messages)?;
-        let headers = Self::serialize_optional_list(headers)?;
-        let sent: Vec<i64> = sqlx::query_scalar(
-            "SELECT * from pgmq.send_batch(queue_name=>$1::text, msgs=>$2::jsonb[], headers=>$3::jsonb[], delay=>$4::integer);",
-        )
-            .bind(queue_name)
-            .bind(messages)
-            .bind(headers)
-            .bind(delay)
-            .fetch_all(executor)
-            .await?;
-        Ok(sent)
+        let messages = serialize_list(messages)?;
+        let headers = serialize_optional_list(headers)?;
+        crate::queue::sqlx::send_batch(executor, queue_name, messages, headers, delay).await
     }
 
     pub async fn send_batch_with_delay_with_headers<T: Serialize, H: Serialize>(
@@ -1326,8 +1317,8 @@ impl PGMQueueExt {
         executor: E,
     ) -> Result<Vec<SendBatchTopicRow>, PgmqError> {
         let delay: VisibilityTimeoutOffset = delay.into();
-        let messages = Self::serialize_list(messages)?;
-        let headers = Self::serialize_optional_list(headers)?;
+        let messages = serialize_list(messages)?;
+        let headers = serialize_optional_list(headers)?;
         let sent = sqlx::query(
             "SELECT queue_name, msg_id from pgmq.send_batch_topic(routing_key=>$1::text, msgs=>$2::jsonb[], headers=>$3::jsonb[], delay=>$4::integer);",
         )
@@ -1354,25 +1345,6 @@ impl PGMQueueExt {
     ) -> Result<Vec<SendBatchTopicRow>, PgmqError> {
         self.send_batch_topic_with_cxn(routing_key, messages, headers, delay, &self.connection)
             .await
-    }
-
-    fn serialize_list<T: serde::Serialize>(
-        list: &[T],
-    ) -> Result<Vec<serde_json::Value>, serde_json::Error> {
-        list.iter()
-            .map(serde_json::to_value)
-            .collect::<Result<Vec<serde_json::Value>, _>>()
-    }
-
-    fn serialize_optional_list<H: serde::Serialize>(
-        list: Option<&[H]>,
-    ) -> Result<Option<Vec<serde_json::Value>>, serde_json::Error> {
-        let headers = if let Some(list) = list {
-            Some(Self::serialize_list(list)?)
-        } else {
-            None
-        };
-        Ok(headers)
     }
 
     /// Enable sending a Postgres notification when an item is inserted into the specified queue.

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -53,6 +53,23 @@ macro_rules! diesel_functions {
             Ok(message_id)
         }
 
+        async fn send_batch<C>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            messages: Vec<serde_json::Value>,
+            headers: Option<Vec<serde_json::Value>>,
+            delay: crate::types::visibility_timeout_offset::VisibilityTimeoutOffset,
+        ) -> Result<Vec<i64>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let message_ids =
+                crate::queue::diesel::query::send_batch_query(queue_name, messages, headers, delay)
+                    .get_results(executor);
+            let message_ids = $transform_result!(message_ids)?;
+            Ok(message_ids)
+        }
+
         async fn read<C, T, H>(
             executor: &mut C,
             queue_name: crate::types::QueueName<'_>,

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -1,6 +1,6 @@
 //! Extracted Diesel SQL query functions. Can be used by both diesel and diesel-async.
 use crate::queue::diesel::sql::{
-    pgmq_archive, pgmq_create, pgmq_delete, pgmq_read, pgmq_send, pgmq_set_vt,
+    pgmq_archive, pgmq_create, pgmq_delete, pgmq_read, pgmq_send, pgmq_send_batch, pgmq_set_vt,
 };
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
@@ -21,6 +21,18 @@ pub fn send_query(
     let queue_name: &str = *queue_name;
     let delay: i32 = *delay;
     select(pgmq_send(queue_name, message, headers, delay))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn send_batch_query(
+    queue_name: QueueName<'_>,
+    messages: Vec<serde_json::Value>,
+    headers: Option<Vec<serde_json::Value>>,
+    delay: VisibilityTimeoutOffset,
+) -> _ {
+    let queue_name: &str = *queue_name;
+    let delay: i32 = *delay;
+    select(pgmq_send_batch(queue_name, messages, headers, delay))
 }
 
 #[diesel::dsl::auto_type(no_type_alias)]

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -67,6 +67,14 @@ extern "SQL" {
     #[sql_name = "pgmq.send"]
     fn pgmq_send(queue_name: Text, msg: Jsonb, headers: Jsonb, delay: Integer) -> BigInt;
 
+    #[sql_name = "pgmq.send_batch"]
+    fn pgmq_send_batch(
+        queue_name: Text,
+        msgs: Array<Jsonb>,
+        headers: Nullable<Array<Jsonb>>,
+        delay: Integer,
+    ) -> BigInt;
+
     #[sql_name = "pgmq.read"]
     fn pgmq_read(queue_name: Text, vt: Integer, qty: Integer) -> PgMessage;
 

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -114,6 +114,31 @@ macro_rules! impl_queue {
                 send($transform_self!(self), queue_name, message, headers, delay).await
             }
 
+            async fn send_batch<'q, T, H, TI, HI, Q, QE, D>(
+                self,
+                queue_name: Q,
+                messages: TI,
+                headers: Option<HI>,
+                delay: D,
+            ) -> Result<Vec<i64>, crate::PgmqError>
+            where
+                T: serde::Serialize,
+                H: serde::Serialize,
+                TI: Send + IntoIterator<Item = T>,
+                HI: Send + IntoIterator<Item = H>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: ToString,
+                D: Send + Into<crate::types::VisibilityTimeoutOffset>,
+            {
+                let queue_name = queue_name
+                    .try_into()
+                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let delay: crate::types::VisibilityTimeoutOffset = delay.into();
+                let messages = crate::util::serialize_list(messages)?;
+                let headers = crate::util::serialize_optional_list(headers)?;
+                send_batch($transform_self!(self), queue_name, messages, headers, delay).await
+            }
+
             async fn read<'q, T, H, Q, QE, VT>(
                 self,
                 queue_name: Q,

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -43,6 +43,22 @@ pub trait Queue: crate::private::Sealed {
         QE: ToString,
         D: Send + Into<VisibilityTimeoutOffset>;
 
+    async fn send_batch<'q, T, H, TI, HI, Q, QE, D>(
+        self,
+        queue_name: Q,
+        messages: TI,
+        headers: Option<HI>,
+        delay: D,
+    ) -> Result<Vec<i64>, PgmqError>
+    where
+        T: serde::Serialize,
+        H: serde::Serialize,
+        TI: Send + IntoIterator<Item = T>,
+        HI: Send + IntoIterator<Item = H>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: ToString,
+        D: Send + Into<VisibilityTimeoutOffset>;
+
     async fn read<'q, T, H, Q, QE, VT>(
         self,
         queue_name: Q,

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -83,6 +83,31 @@ macro_rules! rust_postgres_functions {
             Ok(row.try_get(0)?)
         }
 
+        async fn send_batch<C>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            messages: Vec<serde_json::Value>,
+            headers: Option<Vec<serde_json::Value>>,
+            delay: crate::types::VisibilityTimeoutOffset,
+        ) -> Result<Vec<i64>, crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&*queue_name, postgres_types::Type::TEXT),
+                (&messages, postgres_types::Type::JSONB_ARRAY),
+                (&headers, postgres_types::Type::JSONB_ARRAY),
+                (&*delay, postgres_types::Type::INT4),
+            ];
+            let rows = executor.query_typed(crate::queue::sql::SEND_BATCH, &params);
+            let rows = $transform_result!(rows)?;
+            let rows = rows
+                .into_iter()
+                .map(|row| row.try_get(0))
+                .collect::<Result<Vec<i64>, _>>()?;
+            Ok(rows)
+        }
+
         async fn read<C, T, H>(
             executor: $ref_type!(C),
             queue_name: crate::types::QueueName<'_>,

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -10,6 +10,9 @@ pub const CREATE: &str = "SELECT pgmq.create(queue_name=>$1::text)";
 pub const SEND: &str = "SELECT * FROM pgmq.send(queue_name=>$1::text, msg=>$2::jsonb, headers=>$3::jsonb, delay=>$4::int)";
 
 // language=PostgreSQL
+pub const SEND_BATCH: &str = "SELECT * from pgmq.send_batch(queue_name=>$1::text, msgs=>$2::jsonb[], headers=>$3::jsonb[], delay=>$4::integer)";
+
+// language=PostgreSQL
 pub const READ: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers FROM pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)";
 
 // language=PostgreSQL

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -1,5 +1,5 @@
 use crate::queue::macros::{identity_macro, impl_queue};
-use crate::queue::sql::{ARCHIVE, CREATE, DELETE, READ, SEND, SET_VT};
+use crate::queue::sql::{ARCHIVE, CREATE, DELETE, READ, SEND, SEND_BATCH, SET_VT};
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use crate::{Message, PgmqError};
 use sqlx::{Executor, Postgres};
@@ -52,6 +52,26 @@ where
         .fetch_one(executor)
         .await?;
     Ok(msg_id)
+}
+
+pub(crate) async fn send_batch<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    messages: Vec<serde_json::Value>,
+    headers: Option<Vec<serde_json::Value>>,
+    delay: VisibilityTimeoutOffset,
+) -> Result<Vec<i64>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    let sent: Vec<i64> = sqlx::query_scalar(SEND_BATCH)
+        .bind(*queue_name)
+        .bind(messages)
+        .bind(headers)
+        .bind(delay)
+        .fetch_all(executor)
+        .await?;
+    Ok(sent)
 }
 
 async fn read<'c, C, T, H>(

--- a/pgmq-rs/src/util.rs
+++ b/pgmq-rs/src/util.rs
@@ -1,13 +1,18 @@
-#![cfg(feature = "sqlx")]
-
+#[cfg(feature = "sqlx")]
 use crate::errors::PgmqError;
+#[cfg(feature = "sqlx")]
 use log::LevelFilter;
+#[cfg(feature = "sqlx")]
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+#[cfg(feature = "sqlx")]
 use sqlx::{ConnectOptions, Transaction};
+#[cfg(feature = "sqlx")]
 use sqlx::{Pool, Postgres};
+#[cfg(feature = "sqlx")]
 use url::{ParseError, Url};
 
 // Configure connection options
+#[cfg(feature = "sqlx")]
 pub fn conn_options(url: &str) -> Result<PgConnectOptions, ParseError> {
     // Parse url
     let parsed = Url::parse(url)?;
@@ -22,6 +27,7 @@ pub fn conn_options(url: &str) -> Result<PgConnectOptions, ParseError> {
 }
 
 /// Connect to the database
+#[cfg(feature = "sqlx")]
 pub async fn connect(url: &str, max_connections: u32) -> Result<Pool<Postgres>, PgmqError> {
     let options = conn_options(url)?;
     let pgp = PgPoolOptions::new()
@@ -33,6 +39,7 @@ pub async fn connect(url: &str, max_connections: u32) -> Result<Pool<Postgres>, 
 }
 
 #[cfg(feature = "install-sql-github")]
+#[cfg(feature = "sqlx")]
 #[deprecated(
     note = "Use pgmq::install::install_sql_from_github or pgmq::install::install_sql_from_embedded instead.",
     since = "0.33.0"
@@ -53,6 +60,7 @@ pub async fn install_pgmq(
 /// Advisory lock key used to ensure only one transaction can run the `pgmq` installation process
 /// at once. Select a random large negative `bigint` value to minimize the chances of conflicting
 /// with another advisory lock used by the actual application.
+#[cfg(feature = "sqlx")]
 const ADVISORY_LOCK_KEY: i64 = -9223372036854775808 + 4149;
 
 /// Acquire an advisory lock to be sure that only one transaction can run the pgmq SQL
@@ -60,10 +68,30 @@ const ADVISORY_LOCK_KEY: i64 = -9223372036854775808 + 4149;
 /// to attempt to perform the `pgmq` SQL installation/upgrade process at the same time, and they
 /// may conflict when creating the `pgmq` schema and/or `pgmq.__pgmq_migrations` table. This is
 /// the case even with `IF NOT EXISTS` in the SQL query.
+#[cfg(feature = "sqlx")]
 pub(crate) async fn init_lock<'c>(txn: &mut Transaction<'c, Postgres>) -> Result<(), PgmqError> {
     sqlx::query("SELECT pg_advisory_xact_lock($1);")
         .bind(ADVISORY_LOCK_KEY)
         .execute(&mut **txn)
         .await?;
     Ok(())
+}
+
+pub(crate) fn serialize_list<T: serde::Serialize>(
+    list: impl IntoIterator<Item = T>,
+) -> Result<Vec<serde_json::Value>, serde_json::Error> {
+    list.into_iter()
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<serde_json::Value>, _>>()
+}
+
+pub(crate) fn serialize_optional_list<H: serde::Serialize>(
+    list: Option<impl IntoIterator<Item = H>>,
+) -> Result<Option<Vec<serde_json::Value>>, serde_json::Error> {
+    let headers = if let Some(list) = list {
+        Some(serialize_list(list)?)
+    } else {
+        None
+    };
+    Ok(headers)
 }

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -327,3 +327,63 @@ async fn set_vt(conn_details: ConnDetails, queue: impl Queue) {
         "Attempting to read messages with updated vt after sleeping should return the messages"
     );
 }
+
+#[pgmq_test_macro::queue_test]
+async fn send_batch(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let count = 5;
+    let msgs = (0..count)
+        .map(|_| TestMessage::new())
+        .collect::<Vec<TestMessage>>();
+
+    let msg_ids = queue
+        .send_batch(QUEUE, msgs, Option::<&[()]>::None, 0)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        count,
+        msg_ids.len(),
+        "send_batch should return an ID for every sent message"
+    );
+
+    let read_msgs: Vec<Message<TestMessage>> =
+        queue.read(QUEUE, 10, (count + 1) as i32).await.unwrap();
+    assert_eq!(
+        count,
+        read_msgs.len(),
+        "Read should return messages sent with send_batch"
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn send_batch_with_headers(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let count = 5;
+    let msgs = (0..count)
+        .map(|_| TestMessage::new())
+        .collect::<Vec<TestMessage>>();
+    let header_for_message = |msg: &TestMessage| json!({"a": msg.a});
+    let headers = msgs.iter().map(header_for_message);
+
+    let msg_ids = queue
+        .send_batch(QUEUE, &msgs, Some(headers), 0)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        count,
+        msg_ids.len(),
+        "send_batch should return an ID for every sent message"
+    );
+
+    let read_msgs: Vec<Message<TestMessage, serde_json::Value>> =
+        queue.read(QUEUE, 10, (count + 1) as i32).await.unwrap();
+    read_msgs.iter().for_each(|msg| {
+        assert_eq!(
+            msg.headers,
+            Some(header_for_message(&msg.message)),
+            "Read should properly deserialize headers sent with send_batch"
+        )
+    })
+}


### PR DESCRIPTION
This PR adds the `send_batch` method to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres). This PR also updates `PGMQueueExt#send_batch` to use the sqlx implementation of `Queue`.

Relates to https://github.com/pgmq/pgmq/issues/425