### PR TITLE
docs: add C++ community client

### DIFF
--- a/pgmq-extension/README.md
+++ b/pgmq-extension/README.md
@@ -92,6 +92,7 @@ To update PGMQ versions, follow the instructions in [UPDATING.md](pgmq-extension
 Community
 
 - [.NET](https://github.com/brianpursley/Npgmq)
+- [C++](https://github.com/lite-tx/pgmq-cpp)
 - [Dart](https://github.com/Ofceab-Studio/dart_pgmq)
 - [Elixir + Broadway](https://github.com/v0idpwn/off_broadway_pgmq)
 - [Elixir](https://github.com/v0idpwn/pgmq-elixir)


### PR DESCRIPTION
## Summary

Adds [pgmq-cpp](https://github.com/lite-tx/pgmq-cpp) to the Community Client Libraries index.

pgmq-cpp is a community-maintained, independent C++20 SDK and reliable Worker Runtime for PGMQ. It is not an official PGMQ client. Compatibility and integration have been validated against PGMQ 1.12.0.

- [Project](https://github.com/lite-tx/pgmq-cpp)
- [v1.0.0 release](https://github.com/lite-tx/pgmq-cpp/releases/tag/v1.0.0)
- [main CI](https://github.com/lite-tx/pgmq-cpp/actions/runs/30201259362)
- [tag CI](https://github.com/lite-tx/pgmq-cpp/actions/runs/30201601299)

## Scope

This PR only adds the single C++ entry to the community index.
