### PR TITLE
docs: Add missing doc comments for `Queue` methods

### DIFF
--- a/pgmq-rs/Makefile
+++ b/pgmq-rs/Makefile
@@ -20,7 +20,11 @@ test:
 	psql ${DATABASE_URL} -c "CREATE DATABASE pgmq_ext_test;"
 	sqlx migrate run --database-url ${EXTENSION_DB}
 	cargo test --lib --all-features
+	cargo test --doc --all-features
 	cargo test
+
+test.doc:
+	cargo test --doc --all-features
 
 # Run the tests for `PGMQueueExt` with the embedded SQL-only installation approach. Assumes the DB is already running
 # and `pg_partman` is an available extension in the DB.

--- a/pgmq-rs/src/private/mod.rs
+++ b/pgmq-rs/src/private/mod.rs
@@ -1,4 +1,4 @@
 /// Private marker trait that can be used to mark another trait as "sealed", which prevents external
 /// consumers from implementing the trait. This allows adding new methods to the sealed trait
-/// in a semver compatible way. See: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
+/// in a semver compatible way. See: <https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed>
 pub(crate) trait Sealed {}

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -17,18 +17,61 @@ pub(crate) mod sql;
 pub mod sqlx;
 
 use crate::types::{QueueName, VisibilityTimeoutOffset};
-use crate::PgmqError;
+use crate::{Message, PgmqError};
 
-/// Sealed so we can add methods without breaking semver compatibility.
-/// See: <https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed>
+/// Interface that provides methods for invoking PGMQ SQL functions.
+///
+/// For variadic functions, only a single method with all available parameters is provided.
+/// For example, only `pgmq.send(queue_name, msg, headers, delay)` is supported instead of all
+/// the other variations of the `pgmq.send` function.
+// Sealed so we can add methods without breaking semver compatibility.
+// See: <https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed>
 #[async_trait::async_trait]
 #[allow(private_bounds)]
 pub trait Queue: crate::private::Sealed {
+    /// Create the SQL tables for the specified queue.
+    ///
+    /// Invokes the `pgmq.create` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// queue.create("my_queue").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn create<'q, Q, QE>(self, queue_name: Q) -> Result<(), PgmqError>
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: ToString;
 
+    /// Enqueue a message for the specified queue.
+    ///
+    /// Invokes the `pgmq.send` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// // Send an owned message with no headers and no delay
+    /// let msg = serde_json::json!({"a": 1234});
+    /// queue.send("my_queue", msg, (), 0).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// // Send a message reference with headers and a delay
+    /// let msg = serde_json::json!({"a": 1234});
+    /// queue.send("my_queue", &msg, serde_json::json!({"headerA": 5678}), 10).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn send<'q, T, H, Q, QE, D>(
         self,
         queue_name: Q,
@@ -43,6 +86,34 @@ pub trait Queue: crate::private::Sealed {
         QE: ToString,
         D: Send + Into<VisibilityTimeoutOffset>;
 
+    /// Enqueue several messages for the specified queue.
+    ///
+    /// Invokes the `pgmq.send_batch` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::types::EMPTY_HEADERS;
+    /// // Send owned messages with no headers and no delay
+    /// let msgs = [serde_json::json!({"a": 1}), serde_json::json!({"a": 2})];
+    /// queue.send_batch("my_queue", msgs, EMPTY_HEADERS, 0).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// // Send a slice of messages with headers and a delay
+    /// let msgs = [serde_json::json!({"a": 1}), serde_json::json!({"a": 2})];
+    /// let headers = [serde_json::json!({"headerA": 3}), serde_json::json!({"headerA": 4})];
+    /// queue.send_batch("my_queue", &msgs, Some(&headers), Duration::from_secs(10)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn send_batch<'q, T, H, TI, HI, Q, QE, D>(
         self,
         queue_name: Q,
@@ -59,12 +130,48 @@ pub trait Queue: crate::private::Sealed {
         QE: ToString,
         D: Send + Into<VisibilityTimeoutOffset>;
 
+    /// Read at most `quantity` messages from the queue with the provided `queue_name`. If no
+    /// messages are available, an empty [`Vec`] will be returned.
+    ///
+    /// Invokes the `pgmq.read` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// # use pgmq::types::EMPTY_HEADERS;
+    /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
+    /// // the visibility timeout (`vt`)
+    /// let msgs: Vec<Message> = queue.read("my_queue", 10, 1).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// # use pgmq::types::EMPTY_HEADERS;
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Read multiple messages, deserializing as a custom message struct, `MyMessage`, using
+    /// // a `Duration` to update the visibility timeout (`vt`)
+    /// let msgs: Vec<Message<MyMessage>> = queue.read("my_queue", Duration::from_secs(10), 2).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn read<'q, T, H, Q, QE, VT>(
         self,
         queue_name: Q,
         visibility_timeout: VT,
         quantity: i32,
-    ) -> Result<Vec<crate::Message<T, H>>, PgmqError>
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
     where
         T: 'static + Send + for<'de> serde::Deserialize<'de>,
         H: 'static + Send + for<'de> serde::Deserialize<'de>,
@@ -72,6 +179,24 @@ pub trait Queue: crate::private::Sealed {
         QE: ToString,
         VT: Send + Into<VisibilityTimeoutOffset>;
 
+    /// Mark the specified messages as archived. Moves the messages to the archive table for the
+    /// specified queue. Returns the IDs of the messages that were successfully archived. This may
+    /// differ from the IDs provided to this method, e.g., if a message was previously archived or
+    /// deleted, it won't be present in the returned list.
+    ///
+    /// Invokes the `pgmq.archive` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::types::EMPTY_HEADERS;
+    /// let msg_ids = [1234];
+    /// queue.archive("my_queue", &msg_ids).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn archive<'q, Q, QE>(
         self,
         queue_name: Q,
@@ -81,17 +206,70 @@ pub trait Queue: crate::private::Sealed {
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: ToString;
 
+    /// Delete the specified messages from the database. Returns the IDs of the messages that were
+    /// successfully deleted. This may differ from the IDs provided to this method, e.g., if a
+    /// message was previously archived or deleted, it won't be present in the returned list.
+    ///
+    /// Invokes the `pgmq.delete` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::types::EMPTY_HEADERS;
+    /// let msg_ids = [1234];
+    /// queue.delete("my_queue", &msg_ids).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn delete<'q, Q, QE>(self, queue_name: Q, msg_ids: &[i64]) -> Result<Vec<i64>, PgmqError>
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: ToString;
 
+    /// Update the visibility timeout (`vt`) of the specified messages. Returns the messages
+    /// that were successfully updated. This may differ from the IDs provided to this method,
+    /// e.g., if a message was previously archived or deleted, it won't be present in the returned
+    /// list.
+    ///
+    /// The provided `vt` value is a duration offset with a unit of seconds. The offset will be
+    /// added to the current timestamp when the command reaches the DB.
+    ///
+    /// Invokes the `pgmq.set_vt` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// # use pgmq::types::EMPTY_HEADERS;
+    /// let msg_ids = [1234];
+    /// // Update the visibility timeout (`vt`) using an integer offset
+    /// let _: Vec<Message> = queue.set_vt("my_queue", &msg_ids, 10).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use pgmq::{Message, PgmqError};
+    /// # use pgmq::types::EMPTY_HEADERS;
+    /// let msg_ids = [1234];
+    /// // Update the visibility timeout (`vt`) using a `Duration` offset
+    /// let _: Vec<Message> = queue.set_vt("my_queue", &msg_ids, Duration::from_secs(10)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn set_vt<'q, T, H, Q, QE, VT>(
         self,
         queue_name: Q,
         msg_ids: &[i64],
         visibility_timeout: VT,
-    ) -> Result<Vec<crate::Message<T, H>>, PgmqError>
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
     where
         T: 'static + Send + for<'de> serde::Deserialize<'de>,
         H: 'static + Send + for<'de> serde::Deserialize<'de>,

--- a/pgmq-rs/src/types/mod.rs
+++ b/pgmq-rs/src/types/mod.rs
@@ -1,12 +1,40 @@
 pub mod queue_name;
 pub mod visibility_timeout_offset;
 
-pub use queue_name::QueueName;
-pub use visibility_timeout_offset::VisibilityTimeoutOffset;
-
 use chrono::{DateTime, Utc};
 use serde_derive::Deserialize;
 use std::time::Duration;
+
+pub use queue_name::QueueName;
+pub use visibility_timeout_offset::VisibilityTimeoutOffset;
+
+/// Convenience value to provide for an optional `headers` parameter when no headers
+/// need to be sent. This is useful to avoid the somewhat cumbersome syntax required to specify
+/// the [`Option`] type when providing a [`None`] value.
+///
+/// # Examples
+///
+/// The following are equivalent:
+///
+/// ```rust,no_run
+/// # #[cfg(feature = "queue-experimental")]
+/// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+/// # let msgs: [(); 0] = [];
+/// let msg_ids = queue.send_batch("my_queue", &msgs, Option::<[(); 0]>::None, 0).await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ```rust,no_run
+/// # #[cfg(feature = "queue-experimental")]
+/// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+/// # use pgmq::types::EMPTY_HEADERS;
+/// # let msgs: [(); 0] = [];
+/// let msg_ids = queue.send_batch("my_queue", &msgs, EMPTY_HEADERS, 0).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub const EMPTY_HEADERS: Option<[(); 0]> = None;
 
 pub const VT_DEFAULT: i32 = 30;
 pub const READ_LIMIT_DEFAULT: i32 = 1;


### PR DESCRIPTION
Also:
- Add an `EMPTY_HEADERS` constant to simplify the syntax of `send_batch` when no headers need to be sent
- Ensure all doc tests are run in CI