### PR TITLE
feat!: Add `Queue#pop` method and implement for all sql drivers

### DIFF
--- a/pgmq-rs/Cargo.lock
+++ b/pgmq-rs/Cargo.lock
@@ -1630,7 +1630,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pgmq"
-version = "0.34.0-alpha.5"
+version = "0.34.0-alpha.6"
 dependencies = [
  "async-trait",
  "bb8",

--- a/pgmq-rs/Cargo.toml
+++ b/pgmq-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgmq"
-version = "0.34.0-alpha.5"
+version = "0.34.0-alpha.6"
 edition = "2021"
 authors = ["PGMQ Maintainers"]
 description = "A distributed message queue for Rust applications, on Postgres."

--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -2,7 +2,7 @@ use crate::errors::PgmqError;
 use crate::queue::sql::READ;
 use crate::queue::sqlx::util::handle_read_batch_result;
 use crate::queue::Queue;
-use crate::types::queue_name::{check_queue_name, QueueNameError};
+use crate::types::queue_name::check_queue_name;
 use crate::types::{
     ListNotifyInsertThrottlesRow, ListTopicBindingsRow, Message, PGMQueueMeta, QueueMetrics,
     SendBatchTopicRow, QUEUE_PREFIX,
@@ -227,7 +227,7 @@ impl PGMQueueExt {
     where
         E: sqlx::Acquire<'c, Database = Postgres>,
     {
-        let queue_name: QueueName = queue_name.try_into().map_err(QueueNameError::other)?;
+        let queue_name: QueueName = queue_name.try_into()?;
         let mut txn = self
             .acquire_queue_lock_with_cxn(*queue_name, executor)
             .await?;
@@ -433,7 +433,7 @@ impl PGMQueueExt {
         vt: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<Option<Message<T, H>>, PgmqError> {
-        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
+        let queue_name = queue_name.try_into()?;
         let vt: VisibilityTimeoutOffset = vt.into();
         crate::queue::sqlx::set_vt(executor, queue_name, &[msg_id], vt)
             .await
@@ -513,7 +513,7 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<i64, PgmqError> {
-        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
+        let queue_name = queue_name.try_into()?;
         let delay: VisibilityTimeoutOffset = delay.into();
         let message = serde_json::to_value(message)?;
         let headers = serde_json::to_value(headers)?;
@@ -598,7 +598,7 @@ impl PGMQueueExt {
         delay: impl Into<VisibilityTimeoutOffset>,
         executor: E,
     ) -> Result<Vec<i64>, PgmqError> {
-        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
+        let queue_name = queue_name.try_into()?;
         let delay: VisibilityTimeoutOffset = delay.into();
         let messages = serialize_list(messages)?;
         let headers = serialize_optional_list(headers)?;
@@ -1043,7 +1043,7 @@ impl PGMQueueExt {
         msg_ids: &[i64],
         executor: E,
     ) -> Result<Vec<i64>, PgmqError> {
-        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
+        let queue_name = queue_name.try_into()?;
         crate::queue::sqlx::archive(executor, queue_name, msg_ids).await
     }
 
@@ -1067,21 +1067,10 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<Option<Message<T, H>>, PgmqError> {
-        check_queue_name(queue_name)?;
-        let row = sqlx::query(r#"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.pop(queue_name=>$1::text)"#)
-            .bind(queue_name)
-            .fetch_optional(executor)
-            .await?;
-        match row {
-            Some(row) => {
-                // happy path - successfully read a message
-                Ok(Some(Message::<T, H>::from_row(&row)?))
-            }
-            None => {
-                // no message found
-                Ok(None)
-            }
-        }
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::pop(executor, queue_name, 1)
+            .await
+            .map(|result| result.into_iter().next())
     }
     // Read and message and immediately delete it.
     pub async fn pop<T: for<'de> Deserialize<'de>, H: for<'de> Deserialize<'de>>(
@@ -1114,7 +1103,7 @@ impl PGMQueueExt {
         msg_ids: &[i64],
         executor: E,
     ) -> Result<Vec<i64>, PgmqError> {
-        let queue_name = queue_name.try_into().map_err(QueueNameError::other)?;
+        let queue_name = queue_name.try_into()?;
         crate::queue::sqlx::delete(executor, queue_name, msg_ids).await
     }
 

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -88,6 +88,22 @@ macro_rules! diesel_functions {
             Ok(messages)
         }
 
+        async fn pop<C, T, H>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: 'static + Send + for<'de> serde::Deserialize<'de>,
+            H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        {
+            let messages =
+                crate::queue::diesel::query::pop_query(queue_name, quantity).get_results(executor);
+            let messages = $transform_result!(messages)?;
+            Ok(messages)
+        }
+
         async fn archive<C>(
             executor: &mut C,
             queue_name: crate::types::QueueName<'_>,

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -1,6 +1,7 @@
 //! Extracted Diesel SQL query functions. Can be used by both diesel and diesel-async.
 use crate::queue::diesel::sql::{
-    pgmq_archive, pgmq_create, pgmq_delete, pgmq_read, pgmq_send, pgmq_send_batch, pgmq_set_vt,
+    pgmq_archive, pgmq_create, pgmq_delete, pgmq_pop, pgmq_read, pgmq_send, pgmq_send_batch,
+    pgmq_set_vt,
 };
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
@@ -44,6 +45,12 @@ pub fn read_query(
     let queue_name: &str = *queue_name;
     let visibility_timeout: i32 = *visibility_timeout;
     select(pgmq_read(queue_name, visibility_timeout, quantity))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn pop_query(queue_name: QueueName<'_>, quantity: i32) -> _ {
+    let queue_name: &str = *queue_name;
+    select(pgmq_pop(queue_name, quantity))
 }
 
 #[diesel::dsl::auto_type(no_type_alias)]

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -78,6 +78,9 @@ extern "SQL" {
     #[sql_name = "pgmq.read"]
     fn pgmq_read(queue_name: Text, vt: Integer, qty: Integer) -> PgMessage;
 
+    #[sql_name = "pgmq.pop"]
+    fn pgmq_pop(queue_name: Text, qty: Integer) -> PgMessage;
+
     #[sql_name = "pgmq.archive"]
     fn pgmq_archive(queue_name: Text, msg_ids: Array<BigInt>) -> BigInt;
 

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -83,11 +83,9 @@ macro_rules! impl_queue {
             async fn create<'q, Q, QE>(self, queue_name: Q) -> Result<(), crate::PgmqError>
             where
                 Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
-                QE: ToString,
+                QE: Into<crate::types::queue_name::QueueNameError>,
             {
-                let queue_name = queue_name
-                    .try_into()
-                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 create($transform_self!(self), queue_name).await
             }
 
@@ -102,12 +100,11 @@ macro_rules! impl_queue {
                 T: Send + serde::Serialize,
                 H: Send + serde::Serialize,
                 Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
-                QE: ToString,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+
                 D: Send + Into<crate::types::VisibilityTimeoutOffset>,
             {
-                let queue_name = queue_name
-                    .try_into()
-                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 let delay: crate::types::VisibilityTimeoutOffset = delay.into();
                 let message = serde_json::to_value(message)?;
                 let headers = serde_json::to_value(headers)?;
@@ -127,12 +124,11 @@ macro_rules! impl_queue {
                 TI: Send + IntoIterator<Item = T>,
                 HI: Send + IntoIterator<Item = H>,
                 Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
-                QE: ToString,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+
                 D: Send + Into<crate::types::VisibilityTimeoutOffset>,
             {
-                let queue_name = queue_name
-                    .try_into()
-                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 let delay: crate::types::VisibilityTimeoutOffset = delay.into();
                 let messages = crate::util::serialize_list(messages)?;
                 let headers = crate::util::serialize_optional_list(headers)?;
@@ -149,12 +145,11 @@ macro_rules! impl_queue {
                 T: 'static + Send + for<'de> serde::Deserialize<'de>,
                 H: 'static + Send + for<'de> serde::Deserialize<'de>,
                 Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
-                QE: ToString,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+
                 VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
             {
-                let queue_name = queue_name
-                    .try_into()
-                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 let visibility_timeout: crate::types::VisibilityTimeoutOffset =
                     visibility_timeout.into();
                 read(
@@ -166,6 +161,21 @@ macro_rules! impl_queue {
                 .await
             }
 
+            async fn pop<'q, T, H, Q, QE>(
+                self,
+                queue_name: Q,
+                quantity: i32,
+            ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+            where
+                T: 'static + Send + for<'de> serde::Deserialize<'de>,
+                H: 'static + Send + for<'de> serde::Deserialize<'de>,
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                pop($transform_self!(self), queue_name, quantity).await
+            }
+
             async fn archive<'q, Q, QE>(
                 self,
                 queue_name: Q,
@@ -173,11 +183,9 @@ macro_rules! impl_queue {
             ) -> Result<Vec<i64>, crate::PgmqError>
             where
                 Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
-                QE: ToString,
+                QE: Into<crate::types::queue_name::QueueNameError>,
             {
-                let queue_name = queue_name
-                    .try_into()
-                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 archive($transform_self!(self), queue_name, msg_ids).await
             }
 
@@ -188,11 +196,9 @@ macro_rules! impl_queue {
             ) -> Result<Vec<i64>, crate::PgmqError>
             where
                 Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
-                QE: ToString,
+                QE: Into<crate::types::queue_name::QueueNameError>,
             {
-                let queue_name = queue_name
-                    .try_into()
-                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 delete($transform_self!(self), queue_name, msg_ids).await
             }
 
@@ -206,12 +212,11 @@ macro_rules! impl_queue {
                 T: 'static + Send + for<'de> serde::Deserialize<'de>,
                 H: 'static + Send + for<'de> serde::Deserialize<'de>,
                 Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
-                QE: ToString,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+
                 VT: Send + Into<crate::types::VisibilityTimeoutOffset>,
             {
-                let queue_name = queue_name
-                    .try_into()
-                    .map_err(crate::types::queue_name::QueueNameError::other)?;
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
                 let visibility_timeout: crate::types::VisibilityTimeoutOffset =
                     visibility_timeout.into();
                 set_vt(

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -45,7 +45,7 @@ pub trait Queue: crate::private::Sealed {
     async fn create<'q, Q, QE>(self, queue_name: Q) -> Result<(), PgmqError>
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
-        QE: ToString;
+        QE: Into<crate::types::queue_name::QueueNameError>;
 
     /// Enqueue a message for the specified queue.
     ///
@@ -83,7 +83,7 @@ pub trait Queue: crate::private::Sealed {
         T: Send + serde::Serialize,
         H: Send + serde::Serialize,
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
-        QE: ToString,
+        QE: Into<crate::types::queue_name::QueueNameError>,
         D: Send + Into<VisibilityTimeoutOffset>;
 
     /// Enqueue several messages for the specified queue.
@@ -127,7 +127,7 @@ pub trait Queue: crate::private::Sealed {
         TI: Send + IntoIterator<Item = T>,
         HI: Send + IntoIterator<Item = H>,
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
-        QE: ToString,
+        QE: Into<crate::types::queue_name::QueueNameError>,
         D: Send + Into<VisibilityTimeoutOffset>;
 
     /// Read at most `quantity` messages from the queue with the provided `queue_name`. If no
@@ -141,7 +141,6 @@ pub trait Queue: crate::private::Sealed {
     /// # #[cfg(feature = "queue-experimental")]
     /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
     /// # use pgmq::{Message, PgmqError};
-    /// # use pgmq::types::EMPTY_HEADERS;
     /// // Read a message, deserializing as a `serde_json::Value`, using an integer to update
     /// // the visibility timeout (`vt`)
     /// let msgs: Vec<Message> = queue.read("my_queue", 10, 1).await?;
@@ -155,7 +154,6 @@ pub trait Queue: crate::private::Sealed {
     /// # use std::time::Duration;
     /// # use serde_derive::Deserialize;
     /// # use pgmq::{Message, PgmqError};
-    /// # use pgmq::types::EMPTY_HEADERS;
     /// #[derive(Deserialize)]
     /// struct MyMessage {
     ///     a: String
@@ -176,8 +174,57 @@ pub trait Queue: crate::private::Sealed {
         T: 'static + Send + for<'de> serde::Deserialize<'de>,
         H: 'static + Send + for<'de> serde::Deserialize<'de>,
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
-        QE: ToString,
+        QE: Into<crate::types::queue_name::QueueNameError>,
         VT: Send + Into<VisibilityTimeoutOffset>;
+
+    /// Pop at most `quantity` messages from the queue with the provided `queue_name`. If no
+    /// messages are available, an empty [`Vec`] will be returned. The popped messages are deleted
+    /// from the queue -- this is the equivalent of [`Self::read`] + [`Self::delete`] within a
+    /// single command.
+    ///
+    /// Invokes the `pgmq.pop` SQL function.
+    ///
+    /// Take care when using this function -- if your application crashes while processing a
+    /// message and does not add the message back to the queue, the message may never be processed
+    /// because it was deleted.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use pgmq::{Message, PgmqError};
+    /// // Pop a message, deserializing as a `serde_json::Value`
+    /// let msgs: Vec<Message> = queue.pop("my_queue", 1).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// # use std::time::Duration;
+    /// # use serde_derive::Deserialize;
+    /// # use pgmq::{Message, PgmqError};
+    /// #[derive(Deserialize)]
+    /// struct MyMessage {
+    ///     a: String
+    /// }
+    /// // Pop multiple messages, deserializing as a custom message struct, `MyMessage`.
+    /// let msgs: Vec<Message<MyMessage>> = queue.pop("my_queue", 2).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn pop<'q, T, H, Q, QE>(
+        self,
+        queue_name: Q,
+        quantity: i32,
+    ) -> Result<Vec<Message<T, H>>, PgmqError>
+    where
+        T: 'static + Send + for<'de> serde::Deserialize<'de>,
+        H: 'static + Send + for<'de> serde::Deserialize<'de>,
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
 
     /// Mark the specified messages as archived. Moves the messages to the archive table for the
     /// specified queue. Returns the IDs of the messages that were successfully archived. This may
@@ -204,7 +251,7 @@ pub trait Queue: crate::private::Sealed {
     ) -> Result<Vec<i64>, PgmqError>
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
-        QE: ToString;
+        QE: Into<crate::types::queue_name::QueueNameError>;
 
     /// Delete the specified messages from the database. Returns the IDs of the messages that were
     /// successfully deleted. This may differ from the IDs provided to this method, e.g., if a
@@ -226,7 +273,7 @@ pub trait Queue: crate::private::Sealed {
     async fn delete<'q, Q, QE>(self, queue_name: Q, msg_ids: &[i64]) -> Result<Vec<i64>, PgmqError>
     where
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
-        QE: ToString;
+        QE: Into<crate::types::queue_name::QueueNameError>;
 
     /// Update the visibility timeout (`vt`) of the specified messages. Returns the messages
     /// that were successfully updated. This may differ from the IDs provided to this method,
@@ -274,6 +321,6 @@ pub trait Queue: crate::private::Sealed {
         T: 'static + Send + for<'de> serde::Deserialize<'de>,
         H: 'static + Send + for<'de> serde::Deserialize<'de>,
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
-        QE: ToString,
+        QE: Into<crate::types::queue_name::QueueNameError>,
         VT: Send + Into<VisibilityTimeoutOffset>;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -131,6 +131,27 @@ macro_rules! rust_postgres_functions {
                 .collect::<Result<Vec<crate::Message<T, H>>, crate::PgmqError>>()
         }
 
+        async fn pop<C, T, H>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+            quantity: i32,
+        ) -> Result<Vec<crate::Message<T, H>>, crate::PgmqError>
+        where
+            C: $executor_trait,
+            T: for<'de> serde::Deserialize<'de>,
+            H: for<'de> serde::Deserialize<'de>,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] = [
+                (&*queue_name, postgres_types::Type::TEXT),
+                (&quantity, postgres_types::Type::INT4),
+            ];
+            let rows = executor.query_typed(crate::queue::sql::POP, &params);
+            let rows = $transform_result!(rows)?;
+            rows.into_iter()
+                .map(|row| crate::Message::<T, H>::try_from(row))
+                .collect::<Result<Vec<crate::Message<T, H>>, crate::PgmqError>>()
+        }
+
         async fn archive<C>(
             executor: $ref_type!(C),
             queue_name: crate::types::QueueName<'_>,

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -16,6 +16,9 @@ pub const SEND_BATCH: &str = "SELECT * from pgmq.send_batch(queue_name=>$1::text
 pub const READ: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers FROM pgmq.read(queue_name=>$1::text, vt=>$2::integer, qty=>$3::integer)";
 
 // language=PostgreSQL
+pub const POP: &str = r"SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.pop(queue_name=>$1::text, qty=>$2::integer)";
+
+// language=PostgreSQL
 pub const ARCHIVE: &str = "SELECT * from pgmq.archive(queue_name=>$1::text, msg_ids=>$2::bigint[])";
 
 // language=PostgreSQL

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -1,5 +1,5 @@
 use crate::queue::macros::{identity_macro, impl_queue};
-use crate::queue::sql::{ARCHIVE, CREATE, DELETE, READ, SEND, SEND_BATCH, SET_VT};
+use crate::queue::sql::{ARCHIVE, CREATE, DELETE, POP, READ, SEND, SEND_BATCH, SET_VT};
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use crate::{Message, PgmqError};
 use sqlx::{Executor, Postgres};
@@ -89,6 +89,26 @@ where
     let rows = query
         .bind(*queue_name)
         .bind(visibility_timeout)
+        .bind(quantity)
+        .fetch_all(executor)
+        .await?;
+
+    handle_read_batch_result(rows)
+}
+
+pub(crate) async fn pop<'c, C, T, H>(
+    executor: C,
+    queue_name: QueueName<'_>,
+    quantity: i32,
+) -> Result<Vec<Message<T, H>>, PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+    T: for<'de> serde::Deserialize<'de>,
+    H: for<'de> serde::Deserialize<'de>,
+{
+    let query = sqlx::query(POP);
+    let rows = query
+        .bind(*queue_name)
         .bind(quantity)
         .fetch_all(executor)
         .await?;

--- a/pgmq-rs/src/types/queue_name.rs
+++ b/pgmq-rs/src/types/queue_name.rs
@@ -1,4 +1,4 @@
-use constants::MAX_PGMQ_QUEUE_LEN;
+use std::convert::Infallible;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use thiserror::Error;
@@ -19,8 +19,10 @@ mod constants {
 
     /// The max length of the name of a PGMQ queue, considering that the biggest postgres
     /// identifier created by PGMQ is the index on archived_at.
-    pub(super) const MAX_PGMQ_QUEUE_LEN: usize = MAX_IDENTIFIER_LEN - BIGGEST_CONCAT.len();
+    pub const MAX_PGMQ_QUEUE_LEN: usize = MAX_IDENTIFIER_LEN - BIGGEST_CONCAT.len();
 }
+
+pub use constants::MAX_PGMQ_QUEUE_LEN;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -39,6 +41,30 @@ impl QueueNameError {
     /// Construct [`QueueNameError::Other`] from the given error/message.
     pub fn other(err: impl ToString) -> Self {
         Self::Other(err.to_string())
+    }
+}
+
+impl From<String> for QueueNameError {
+    fn from(value: String) -> Self {
+        Self::other(value)
+    }
+}
+
+impl<'a> From<&'a str> for QueueNameError {
+    fn from(value: &'a str) -> Self {
+        Self::other(value)
+    }
+}
+
+impl From<()> for QueueNameError {
+    fn from(_: ()) -> Self {
+        Self::other("Unknown error")
+    }
+}
+
+impl From<Infallible> for QueueNameError {
+    fn from(_: Infallible) -> Self {
+        unreachable!("Experienced an Infallible error -- this should be impossible!")
     }
 }
 
@@ -109,7 +135,7 @@ pub fn check_queue_name(input: &str) -> Result<(), QueueNameError> {
 
 #[cfg(test)]
 mod tests {
-    use super::constants::MAX_PGMQ_QUEUE_LEN;
+    use super::MAX_PGMQ_QUEUE_LEN;
     use crate::types::QueueName;
     use rstest::rstest;
     use std::assert_matches;

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -11,10 +11,13 @@
 
 use initialization::ConnDetails;
 use pgmq::queue::Queue;
-use pgmq::Message;
+use pgmq::types::queue_name::QueueNameError;
+use pgmq::types::EMPTY_HEADERS;
+use pgmq::{Message, PgmqError};
 use rand::RngExt;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
+use std::assert_matches;
 use std::time::Duration;
 
 static QUEUE: &str = "queue";
@@ -211,6 +214,28 @@ impl TestMessage {
 }
 
 #[pgmq_test_macro::queue_test]
+async fn create_invalid_length(conn_details: ConnDetails, queue: impl Queue) {
+    let queue_name = std::iter::repeat_n("a", pgmq::types::queue_name::MAX_PGMQ_QUEUE_LEN + 1)
+        .collect::<String>();
+    let result = queue.create(&queue_name).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidLength(_)))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn create_invalid_character(conn_details: ConnDetails, queue: impl Queue) {
+    let result = queue.create("invalid-queue-name").await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
 async fn read(conn_details: ConnDetails, queue: impl Queue) {
     queue.create(QUEUE).await.unwrap();
     let msg = TestMessage::new();
@@ -251,6 +276,70 @@ async fn read_multiple(conn_details: ConnDetails, queue: impl Queue) {
 }
 
 #[pgmq_test_macro::queue_test]
+async fn read_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message>, _> = queue.read("invalid-queue-name", 10, 1).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn pop(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let msg = TestMessage::new();
+    let msg_id = queue.send(QUEUE, &msg, (), 0).await.unwrap();
+
+    // The first pop should return the message
+    let pop_msg: Message<TestMessage> = queue
+        .pop(QUEUE, 1)
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    assert_eq!(msg_id, pop_msg.msg_id);
+    assert_eq!(pop_msg.message, msg);
+
+    // A second pop should return no messages
+    let pop_msg: Vec<Message<TestMessage>> = queue.pop(QUEUE, 1).await.unwrap();
+    assert!(pop_msg.is_empty());
+}
+
+#[pgmq_test_macro::queue_test]
+async fn pop_multiple(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    let count = 2;
+    let msgs = (0..count)
+        .map(|_| TestMessage::new())
+        .collect::<Vec<TestMessage>>();
+    queue
+        .send_batch(QUEUE, msgs, EMPTY_HEADERS, 0)
+        .await
+        .unwrap();
+
+    let popped_msgs: Vec<Message<TestMessage>> = queue.pop(QUEUE, count).await.unwrap();
+    assert_eq!(
+        count as usize,
+        popped_msgs.len(),
+        "Pop should return multiple messages"
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn pop_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message>, _> = queue.pop("invalid-queue-name", 1).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
 async fn archive(conn_details: ConnDetails, queue: impl Queue) {
     queue.create(QUEUE).await.unwrap();
     let msg_id1 = queue.send(QUEUE, TestMessage::new(), (), 0).await.unwrap();
@@ -273,6 +362,17 @@ async fn archive(conn_details: ConnDetails, queue: impl Queue) {
 }
 
 #[pgmq_test_macro::queue_test]
+async fn archive_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result = queue.archive("invalid-queue-name", &[]).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
 async fn delete(conn_details: ConnDetails, queue: impl Queue) {
     queue.create(QUEUE).await.unwrap();
     let msg_id1 = queue.send(QUEUE, TestMessage::new(), (), 0).await.unwrap();
@@ -291,6 +391,17 @@ async fn delete(conn_details: ConnDetails, queue: impl Queue) {
     assert!(
         read_msg.is_empty(),
         "Attempting to read after deleting the message should return nothing"
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn delete_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result = queue.delete("invalid-queue-name", &[]).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
     );
 }
 
@@ -329,6 +440,17 @@ async fn set_vt(conn_details: ConnDetails, queue: impl Queue) {
 }
 
 #[pgmq_test_macro::queue_test]
+async fn set_vt_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result: Result<Vec<Message>, _> = queue.set_vt("invalid-queue-name", &[], 1).await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
 async fn send_batch(conn_details: ConnDetails, queue: impl Queue) {
     queue.create(QUEUE).await.unwrap();
     let count = 5;
@@ -337,7 +459,7 @@ async fn send_batch(conn_details: ConnDetails, queue: impl Queue) {
         .collect::<Vec<TestMessage>>();
 
     let msg_ids = queue
-        .send_batch(QUEUE, msgs, Option::<&[()]>::None, 0)
+        .send_batch(QUEUE, msgs, EMPTY_HEADERS, 0)
         .await
         .unwrap();
 
@@ -386,4 +508,17 @@ async fn send_batch_with_headers(conn_details: ConnDetails, queue: impl Queue) {
             "Read should properly deserialize headers sent with send_batch"
         )
     })
+}
+
+#[pgmq_test_macro::queue_test]
+async fn send_batch_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result = queue
+        .send_batch("invalid-queue-name", [()], EMPTY_HEADERS, 0)
+        .await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
 }


### PR DESCRIPTION
This PR adds the `pop` method to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres).

This PR also:

- Updates `PGMQueueExt#pop` to use the sqlx implementation of `Queue`.
- Changes the bounds of the `QE` type parameters to be `Into<QueueNameError>`. This is because the previous bounds and conversion method resulted in always returning `QueueNameError#Other`, even if the actual error was `QueueNameError#InvalidLength` or `QueueNameError#InvalidCharacter`. Tests were added to the `queue` integration tests to confirm that the correct error is returned.

Relates to https://github.com/pgmq/pgmq/issues/425