### PR TITLE
feat: Add fifo index methods to `Queue` and impl for all sql drivers

### DIFF
--- a/pgmq-rs/src/pg_ext/mod.rs
+++ b/pgmq-rs/src/pg_ext/mod.rs
@@ -1122,13 +1122,8 @@ impl PGMQueueExt {
         queue_name: &str,
         executor: E,
     ) -> Result<(), PgmqError> {
-        check_queue_name(queue_name)?;
-        sqlx::query("SELECT pgmq.create_fifo_index(queue_name=>$1::text);")
-            .bind(queue_name)
-            .execute(executor)
-            .await?;
-
-        Ok(())
+        let queue_name = queue_name.try_into()?;
+        crate::queue::sqlx::create_fifo_index(executor, queue_name).await
     }
 
     pub async fn create_fifo_index(&self, queue_name: &str) -> Result<(), PgmqError> {
@@ -1143,11 +1138,7 @@ impl PGMQueueExt {
         &self,
         executor: E,
     ) -> Result<(), PgmqError> {
-        sqlx::query("SELECT pgmq.create_fifo_indexes_all();")
-            .execute(executor)
-            .await?;
-
-        Ok(())
+        crate::queue::sqlx::create_fifo_indexes_all(executor).await
     }
 
     pub async fn create_fifo_indexes_all(&self) -> Result<(), PgmqError> {

--- a/pgmq-rs/src/queue/diesel/mod.rs
+++ b/pgmq-rs/src/queue/diesel/mod.rs
@@ -149,6 +149,29 @@ macro_rules! diesel_functions {
             let messages = $transform_result!(messages)?;
             Ok(messages)
         }
+
+        async fn create_fifo_index<C>(
+            executor: &mut C,
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let result =
+                crate::queue::diesel::query::create_fifo_index_query(queue_name).execute(executor);
+            $transform_result!(result)?;
+            Ok(())
+        }
+
+        async fn create_fifo_indexes_all<C>(executor: &mut C) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let result =
+                crate::queue::diesel::query::create_fifo_indexes_all_query().execute(executor);
+            $transform_result!(result)?;
+            Ok(())
+        }
     };
 }
 pub(crate) use diesel_functions;

--- a/pgmq-rs/src/queue/diesel/query.rs
+++ b/pgmq-rs/src/queue/diesel/query.rs
@@ -1,7 +1,7 @@
 //! Extracted Diesel SQL query functions. Can be used by both diesel and diesel-async.
 use crate::queue::diesel::sql::{
-    pgmq_archive, pgmq_create, pgmq_delete, pgmq_pop, pgmq_read, pgmq_send, pgmq_send_batch,
-    pgmq_set_vt,
+    pgmq_archive, pgmq_create, pgmq_create_fifo_index, pgmq_create_fifo_indexes_all, pgmq_delete,
+    pgmq_pop, pgmq_read, pgmq_send, pgmq_send_batch, pgmq_set_vt,
 };
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use diesel::dsl::select;
@@ -74,4 +74,15 @@ pub fn set_vt_query<'q, 'm>(
     let queue_name: &'q str = *queue_name;
     let visibility_timeout: i32 = *visibility_timeout;
     select(pgmq_set_vt(queue_name, msg_ids, visibility_timeout))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn create_fifo_index_query(queue_name: QueueName<'_>) -> _ {
+    let queue_name: &str = *queue_name;
+    select(pgmq_create_fifo_index(queue_name))
+}
+
+#[diesel::dsl::auto_type(no_type_alias)]
+pub fn create_fifo_indexes_all_query() -> _ {
+    select(pgmq_create_fifo_indexes_all())
 }

--- a/pgmq-rs/src/queue/diesel/sql.rs
+++ b/pgmq-rs/src/queue/diesel/sql.rs
@@ -89,4 +89,10 @@ extern "SQL" {
 
     #[sql_name = "pgmq.set_vt"]
     fn pgmq_set_vt(queue_name: Text, msg_ids: Array<BigInt>, vt: Integer) -> PgMessage;
+
+    #[sql_name = "pgmq.create_fifo_index"]
+    fn pgmq_create_fifo_index(queue_name: Text);
+
+    #[sql_name = "pgmq.create_fifo_indexes_all"]
+    fn pgmq_create_fifo_indexes_all();
 }

--- a/pgmq-rs/src/queue/macros.rs
+++ b/pgmq-rs/src/queue/macros.rs
@@ -227,6 +227,22 @@ macro_rules! impl_queue {
                 )
                 .await
             }
+
+            async fn create_fifo_index<'q, Q, QE>(
+                self,
+                queue_name: Q,
+            ) -> Result<(), crate::PgmqError>
+            where
+                Q: Send + TryInto<crate::types::QueueName<'q>, Error = QE>,
+                QE: Into<crate::types::queue_name::QueueNameError>,
+            {
+                let queue_name = queue_name.try_into().map_err(|err| err.into())?;
+                create_fifo_index($transform_self!(self), queue_name).await
+            }
+
+            async fn create_fifo_indexes_all(self) -> Result<(), crate::PgmqError> {
+                create_fifo_indexes_all($transform_self!(self)).await
+            }
         }
     };
 }

--- a/pgmq-rs/src/queue/mod.rs
+++ b/pgmq-rs/src/queue/mod.rs
@@ -323,4 +323,37 @@ pub trait Queue: crate::private::Sealed {
         Q: Send + TryInto<QueueName<'q>, Error = QE>,
         QE: Into<crate::types::queue_name::QueueNameError>,
         VT: Send + Into<VisibilityTimeoutOffset>;
+
+    /// Create an index on the `headers` column of the queue to improve FIFO read performance.
+    ///
+    /// Invokes the `pgmq.create_fifo_index` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// queue.create_fifo_index("my_queue").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn create_fifo_index<'q, Q, QE>(self, queue_name: Q) -> Result<(), PgmqError>
+    where
+        Q: Send + TryInto<QueueName<'q>, Error = QE>,
+        QE: Into<crate::types::queue_name::QueueNameError>;
+
+    /// Create an index on the `headers` column of all queues to improve FIFO read performance.
+    ///
+    /// Invokes the `pgmq.create_fifo_indexes_all` SQL function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # #[cfg(feature = "queue-experimental")]
+    /// # async fn example(queue: impl pgmq::queue::Queue) -> Result<(), pgmq::PgmqError> {
+    /// queue.create_fifo_indexes_all().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn create_fifo_indexes_all(self) -> Result<(), PgmqError>;
 }

--- a/pgmq-rs/src/queue/rust_postgres/mod.rs
+++ b/pgmq-rs/src/queue/rust_postgres/mod.rs
@@ -216,6 +216,29 @@ macro_rules! rust_postgres_functions {
                 .map(|row| crate::Message::<T, H>::try_from(row))
                 .collect::<Result<Vec<crate::Message<T, H>>, crate::PgmqError>>()
         }
+
+        async fn create_fifo_index<C>(
+            executor: $ref_type!(C),
+            queue_name: crate::types::QueueName<'_>,
+        ) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let params: [crate::queue::rust_postgres::SqlParam; _] =
+                [(&*queue_name, postgres_types::Type::TEXT)];
+            let result = executor.execute_typed(crate::queue::sql::CREATE_FIFO_INDEX, &params);
+            $transform_result!(result)?;
+            Ok(())
+        }
+
+        async fn create_fifo_indexes_all<C>(executor: $ref_type!(C)) -> Result<(), crate::PgmqError>
+        where
+            C: $executor_trait,
+        {
+            let result = executor.execute_typed(crate::queue::sql::CREATE_FIFO_INDEXES_ALL, &[]);
+            $transform_result!(result)?;
+            Ok(())
+        }
     };
 }
 pub(crate) use rust_postgres_functions;

--- a/pgmq-rs/src/queue/sql.rs
+++ b/pgmq-rs/src/queue/sql.rs
@@ -26,3 +26,9 @@ pub const DELETE: &str = "SELECT * from pgmq.delete(queue_name=>$1::text, msg_id
 
 // language=PostgreSQL
 pub const SET_VT: &str = "SELECT msg_id, read_ct, enqueued_at, last_read_at, vt, message, headers from pgmq.set_vt(queue_name=>$1::text, msg_ids=>$2::bigint[], vt=>$3::integer)";
+
+// language=PostgreSQL
+pub const CREATE_FIFO_INDEX: &str = "SELECT pgmq.create_fifo_index(queue_name=>$1::text)";
+
+// language=PostgreSQL
+pub const CREATE_FIFO_INDEXES_ALL: &str = "SELECT pgmq.create_fifo_indexes_all()";

--- a/pgmq-rs/src/queue/sqlx/mod.rs
+++ b/pgmq-rs/src/queue/sqlx/mod.rs
@@ -1,5 +1,8 @@
 use crate::queue::macros::{identity_macro, impl_queue};
-use crate::queue::sql::{ARCHIVE, CREATE, DELETE, POP, READ, SEND, SEND_BATCH, SET_VT};
+use crate::queue::sql::{
+    ARCHIVE, CREATE, CREATE_FIFO_INDEX, CREATE_FIFO_INDEXES_ALL, DELETE, POP, READ, SEND,
+    SEND_BATCH, SET_VT,
+};
 use crate::types::{QueueName, VisibilityTimeoutOffset};
 use crate::{Message, PgmqError};
 use sqlx::{Executor, Postgres};
@@ -167,4 +170,30 @@ where
         .await?;
 
     handle_read_batch_result(rows)
+}
+
+pub(crate) async fn create_fifo_index<'c, C>(
+    executor: C,
+    queue_name: QueueName<'_>,
+) -> Result<(), PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    sqlx::query(CREATE_FIFO_INDEX)
+        .bind(*queue_name)
+        .execute(executor)
+        .await?;
+
+    Ok(())
+}
+
+pub(crate) async fn create_fifo_indexes_all<'c, C>(executor: C) -> Result<(), PgmqError>
+where
+    C: Executor<'c, Database = Postgres>,
+{
+    sqlx::query(CREATE_FIFO_INDEXES_ALL)
+        .execute(executor)
+        .await?;
+
+    Ok(())
 }

--- a/pgmq-rs/tests/queue.rs
+++ b/pgmq-rs/tests/queue.rs
@@ -522,3 +522,26 @@ async fn send_batch_invalid_queue_name(conn_details: ConnDetails, queue: impl Qu
         )))
     );
 }
+
+#[pgmq_test_macro::queue_test]
+async fn create_fifo_index(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    queue.create_fifo_index(QUEUE).await.unwrap();
+}
+
+#[pgmq_test_macro::queue_test]
+async fn create_fifo_index_invalid_queue_name(conn_details: ConnDetails, queue: impl Queue) {
+    let result = queue.create_fifo_index("invalid-queue-name").await;
+    assert_matches!(
+        result,
+        Err(PgmqError::QueueNameError(QueueNameError::InvalidCharacter(
+            _
+        )))
+    );
+}
+
+#[pgmq_test_macro::queue_test]
+async fn create_fifo_indexes_all(conn_details: ConnDetails, queue: impl Queue) {
+    queue.create(QUEUE).await.unwrap();
+    queue.create_fifo_indexes_all().await.unwrap();
+}


### PR DESCRIPTION
This PR adds `create_fifo_index` and `create_fifo_indexes_all` methods to the `Queue` trait and adds implementations for all the sql drivers we support (sqlx, diesel, rust-postgres). This PR also updates `PGMQueueExt#create_fifo_index` and `PGMQueueExt#create_fifo_indexes_all` to use the sqlx implementation of `Queue`.

Relates to https://github.com/pgmq/pgmq/issues/425